### PR TITLE
fix: ADMIN-BUG-001/002/003 installAll.sh dev mode 설치 버그 수정

### DIFF
--- a/conf/docker/conf/mc-iam-manager/0_preset_dev.sh
+++ b/conf/docker/conf/mc-iam-manager/0_preset_dev.sh
@@ -13,7 +13,8 @@ ENV_FILE="${PROJECT_ROOT}/.env"
 
 
 # 인증서 파일 생성할 경로 (Let's Encrypt 구조와 동일)
-CERT_PARENT_DIR="${PROJECT_ROOT}/container-volume" # dockercontainer-volume 디렉토리
+# nginx 볼륨 마운트: ./container-volume/mc-iam-manager/certs:/etc/nginx/certs
+CERT_PARENT_DIR="${PROJECT_ROOT}/container-volume/mc-iam-manager"
 
 # --- 3. 필요한 디렉토리 생성 (Let's Encrypt 구조와 동일) ---
 echo "Creating necessary directories..."

--- a/conf/docker/conf/mc-iam-manager/1_setup_auto.sh
+++ b/conf/docker/conf/mc-iam-manager/1_setup_auto.sh
@@ -51,7 +51,16 @@ auto_setup() {
         return 1
     fi
     echo "✓ API resources initialized successfully"
-    
+
+    # 5-1. 프레임워크 서비스 URL 등록 (sync-projects 전 서비스 레지스트리 선행 등록)
+    echo "Step 5-1: Registering framework service URLs..."
+    register_framework_services
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Framework service registration failed"
+        return 1
+    fi
+    echo "✓ Framework services registered successfully"
+
     # 6. 프로젝트 동기화
     echo "Step 6: Syncing projects..."
     sync_projects
@@ -314,6 +323,65 @@ init_api_resources() {
     fi
     
     echo "API resources initialized"
+    return 0
+}
+
+register_framework_services() {
+    echo "Registering framework service URLs to mcmp_api_services..."
+
+    # api.yaml의 services 섹션에 정의된 서비스들을 POST /api/mcmp-apis 로 등록
+    # sync-mcmp-apis는 serviceActions(권한)만 등록하고 service URL 레지스트리는 미처리하므로 별도 등록 필요
+
+    register_service() {
+        local name="$1"
+        local version="$2"
+        local base_url="$3"
+        local auth_type="${4:-none}"
+        local auth_user="${5:-}"
+        local auth_pass="${6:-}"
+
+        json_data=$(jq -n \
+            --arg name "$name" \
+            --arg version "$version" \
+            --arg baseUrl "$base_url" \
+            --arg authType "$auth_type" \
+            --arg authUser "$auth_user" \
+            --arg authPass "$auth_pass" \
+            --argjson isActive true \
+            '{name: $name, version: $version, baseUrl: $baseUrl, authType: $authType, authUser: $authUser, authPass: $authPass, isActive: $isActive}')
+
+        response=$(curl -s -w "HTTPSTATUS:%{http_code}" -X POST \
+            --header "Authorization: Bearer $MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN" \
+            --header 'Content-Type: application/json' \
+            --data "$json_data" \
+            "$MC_IAM_MANAGER_HOST/api/mcmp-apis")
+
+        http_code=$(echo $response | tr -d '\n' | sed -e 's/.*HTTPSTATUS://')
+        response_body=$(echo $response | sed -e 's/HTTPSTATUS\:.*//g')
+
+        if [ "$http_code" = "201" ]; then
+            echo "  ✓ Registered: $name ($base_url)"
+        elif [ "$http_code" = "409" ]; then
+            echo "  ✓ Already registered: $name (skipped)"
+        else
+            echo "  ✗ Failed to register $name (HTTP $http_code): $response_body"
+            return 1
+        fi
+        return 0
+    }
+
+    # services 섹션 기반으로 서비스 URL 등록 (api.yaml 버전과 동기화 필요 시 업데이트)
+    INFRA_MANAGER_VERSION=$(grep -A1 "^  mc-infra-manager:" ./api.yaml 2>/dev/null | grep "version:" | awk '{print $2}' | tr -d '"')
+    INFRA_MANAGER_VERSION="${INFRA_MANAGER_VERSION:-0.12.6}"
+
+    register_service "mc-infra-manager" "$INFRA_MANAGER_VERSION" \
+        "http://mc-infra-manager:${MC_INFRA_MANAGER_PORT:-1323}/tumblebug" \
+        "basic" "$MC_INFRA_MANAGER_API_USERNAME" "$MC_INFRA_MANAGER_API_PASSWORD"
+    if [ $? -ne 0 ]; then
+        return 1
+    fi
+
+    echo "Framework service registration completed"
     return 0
 }
 

--- a/conf/docker/conf/mc-web-console/init.sql
+++ b/conf/docker/conf/mc-web-console/init.sql
@@ -1,0 +1,1 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -930,6 +930,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./container-volume/mc-web-console/postgres/postgres_data:/var/lib/postgresql/data
+      - ./conf/mc-web-console/init.sql:/docker-entrypoint-initdb.d/init.sql:ro
     environment:
       POSTGRES_DB: ${CONSOLE_POSTGRES_DB}
       POSTGRES_USER: ${CONSOLE_POSTGRES_USER}


### PR DESCRIPTION
## Summary

- **ADMIN-BUG-001** `0_preset_dev.sh` 인증서 경로 불일치 수정 — `CERT_PARENT_DIR`을 `container-volume/mc-iam-manager`로 변경하여 nginx 볼륨 마운트(`./container-volume/mc-iam-manager/certs:/etc/nginx/certs`) 경로와 일치
- **ADMIN-BUG-002** `mc-web-console-db` uuid-ossp 익스텐션 자동 설치 — `conf/mc-web-console/init.sql` 생성 후 `docker-compose.yaml`에 init 스크립트 마운트 추가, `uuid_generate_v4()` 미존재로 web-console-api 기동 실패하던 문제 해소
- **ADMIN-BUG-003** `1_setup_auto.sh` Step 5-1 `register_framework_services` 추가 — `sync-mcmp-apis`가 service URL 레지스트리(`mcmp_api_services`)를 미처리하므로 `sync-projects` 호출 전 `POST /api/mcmp-apis`로 mc-infra-manager URL 선행 등록

## Root Cause

| ID | 파일 | 원인 |
|----|------|------|
| ADMIN-BUG-001 | `0_preset_dev.sh:16` | `CERT_PARENT_DIR=container-volume` → nginx가 `container-volume/mc-iam-manager/certs`를 마운트하므로 경로 1단계 불일치 |
| ADMIN-BUG-002 | `docker-compose.yaml` mc-web-console-db | PostgreSQL 컨테이너 초기화 시 `uuid-ossp` 익스텐션 미설치 |
| ADMIN-BUG-003 | `1_setup_auto.sh` sync_projects | `SyncMcmpAPIsFromYAML()`은 `serviceActions` 권한만 처리, `mcmp_api_services` 테이블 미등록 → sync-projects의 `McmpApiCall("mc-infra-manager")` 호출 시 record not found |

## Test plan

- [ ] `./installAll.sh --mode dev` 실행 후 `mc-iam-manager-nginx` 컨테이너 정상 기동 확인
- [ ] `mc-web-console-api` 컨테이너 DB 마이그레이션 정상 완료 확인
- [ ] `mc-iam-manager-post-initial` 컨테이너 Exit(0)으로 정상 종료 확인 (sync-projects 성공)
