### PR TITLE
chore: update cb-spider version 0.12.14 → 0.12.18

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
 ##### MC-INFRA-CONNECTOR #########################################################################################################################
 
   mc-infra-connector:
-    image: cloudbaristaorg/cb-spider:0.12.14
+    image: cloudbaristaorg/cb-spider:0.12.18
     pull_policy: missing
     container_name: mc-infra-connector
     platform: linux/amd64


### PR DESCRIPTION
## Summary

- `mc-infra-connector` 이미지를 `cloudbaristaorg/cb-spider:0.12.18`로 업그레이드
- 테스트 환경에서 기동 및 healthy 상태 확인 완료