### PR TITLE
fix(preset-dev): remove sudo from directory setup; guide user to cleanAll.sh on failure

### DIFF
--- a/conf/docker/conf/mc-iam-manager/0_preset_dev.sh
+++ b/conf/docker/conf/mc-iam-manager/0_preset_dev.sh
@@ -28,9 +28,24 @@ CURRENT_GROUP=$(id -gn)
 
 echo "Current user: ${CURRENT_USER}:${CURRENT_GROUP}"
 
-mkdir -p "${CERT_PARENT_DIR}" || { echo "Error: Failed to create ${CERT_PARENT_DIR}"; exit 1; }
-chown -R "${CURRENT_USER}:${CURRENT_GROUP}" "${CERT_PARENT_DIR}" || { echo "Error: Failed to change ownership of ${CERT_PARENT_DIR}"; exit 1; }
-echo "✓ Container volume directory created and permissions set"
+# This script only needs write access to certs/ and nginx/ subdirectories.
+# Other subdirs (postgres/, keycloak/) are Docker-managed and may be root-owned
+# from a previous run — chown-ing the entire tree would fail. Only target what we need.
+for _dir in "${CERT_PARENT_DIR}/certs" "${CERT_PARENT_DIR}/nginx"; do
+    if ! mkdir -p "$_dir" 2>/dev/null; then
+        echo "⚠️  Cannot create $_dir (root-owned parent). Requesting sudo..."
+        sudo mkdir -p "$_dir" || { echo "Error: Failed to create $_dir"; exit 1; }
+    fi
+    if ! chown -R "${CURRENT_USER}:${CURRENT_GROUP}" "$_dir" 2>/dev/null; then
+        echo "⚠️  Root-owned files in $_dir (from previous Docker run). Requesting sudo..."
+        sudo chown -R "${CURRENT_USER}:${CURRENT_GROUP}" "$_dir" || {
+            echo "Error: Failed to set permissions on $_dir"
+            echo "  Please run: sudo chown -R ${CURRENT_USER}:${CURRENT_GROUP} $_dir"
+            exit 1
+        }
+    fi
+done
+echo "✓ Certificate and nginx directories created and permissions set"
 
 
 # 템플릿 파일 경로

--- a/conf/docker/conf/mc-iam-manager/0_preset_dev.sh
+++ b/conf/docker/conf/mc-iam-manager/0_preset_dev.sh
@@ -28,24 +28,27 @@ CURRENT_GROUP=$(id -gn)
 
 echo "Current user: ${CURRENT_USER}:${CURRENT_GROUP}"
 
-# This script only needs write access to certs/ and nginx/ subdirectories.
-# Other subdirs (postgres/, keycloak/) are Docker-managed and may be root-owned
-# from a previous run — chown-ing the entire tree would fail. Only target what we need.
+# Only the certs/ and nginx/ subdirs need to be writable by this script.
+# postgres/ and keycloak/ are Docker-managed and may be root-owned from a
+# previous run — do not touch them. Newly mkdir'd dirs are user-owned automatically,
+# so chown is unnecessary. If mkdir or the writable check fails, the root-owned
+# state must be cleared first via cleanAll.sh (which handles sudo interactively).
 for _dir in "${CERT_PARENT_DIR}/certs" "${CERT_PARENT_DIR}/nginx"; do
     if ! mkdir -p "$_dir" 2>/dev/null; then
-        echo "⚠️  Cannot create $_dir (root-owned parent). Requesting sudo..."
-        sudo mkdir -p "$_dir" || { echo "Error: Failed to create $_dir"; exit 1; }
+        echo "❌ Error: Cannot create $_dir"
+        echo "   A previous Docker run likely left root-owned files in the parent directory."
+        echo "   Please run the cleanup script first, then re-run installAll.sh:"
+        echo "       cd ${SCRIPT_DIR}/../../bin && ./cleanAll.sh"
+        exit 1
     fi
-    if ! chown -R "${CURRENT_USER}:${CURRENT_GROUP}" "$_dir" 2>/dev/null; then
-        echo "⚠️  Root-owned files in $_dir (from previous Docker run). Requesting sudo..."
-        sudo chown -R "${CURRENT_USER}:${CURRENT_GROUP}" "$_dir" || {
-            echo "Error: Failed to set permissions on $_dir"
-            echo "  Please run: sudo chown -R ${CURRENT_USER}:${CURRENT_GROUP} $_dir"
-            exit 1
-        }
+    if [ ! -w "$_dir" ]; then
+        echo "❌ Error: $_dir exists but is not writable by ${CURRENT_USER}."
+        echo "   Please run the cleanup script first, then re-run installAll.sh:"
+        echo "       cd ${SCRIPT_DIR}/../../bin && ./cleanAll.sh"
+        exit 1
     fi
 done
-echo "✓ Certificate and nginx directories created and permissions set"
+echo "✓ Certificate and nginx directories ready"
 
 
 # 템플릿 파일 경로


### PR DESCRIPTION
## Summary

- `0_preset_dev.sh`의 디렉토리 초기화 로직에서 `sudo` 의존 제거
- `chown -R`을 전체 `mc-iam-manager/` 트리에 적용하다 Docker가 만든 root 소유 서브디렉토리(`postgres/`, `keycloak/`)에서 실패하던 오류 수정
- 스크립트가 실제로 쓰기 필요한 `certs/`와 `nginx/` 두 개만 타겟으로 좁힘
- `mkdir` 또는 writable 체크 실패 시 `cleanAll.sh` 실행을 안내하는 명확한 오류 메시지 출력

## Root Cause

```
chown: cannot read directory .../postgres/postgres_data: Permission denied
Error: Failed to change ownership of .../container-volume/mc-iam-manager
```

이전 `docker compose up` 실행 후 `postgres_data`, `keycloak/data` 등이 root 소유로 남아있을 때 발생. 직전 시도(sudo fallback)는 비대화형 환경에서 동작하지 않으므로 제거.

## Fix

새로 `mkdir`로 생성된 디렉토리는 자동으로 현재 사용자 소유 — `chown` 자체가 불필요. root 소유 잔재가 있는 경우 `cleanAll.sh`(프로젝트의 표준 sudo 기반 정리 경로)를 실행하도록 안내.

## Test Plan

- [ ] `cleanAll.sh` 후 `installAll.sh -m dev -d mciam.local -r skip` — sudo 비번 없이 정상 통과
- [ ] 재실행 (certs/, nginx/ 이미 존재, user 소유) — 재진입 안전
- [ ] `postgres/` root 소유로 둔 채 `certs/`, `nginx/` 제거 후 재실행 — postgres/ 건드리지 않고 통과