### PR TITLE
fix(iam): wait for mc-infra-manager healthy + add recovery guide for post-init failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,33 @@ The following ports must be registered in the firewall:
 
 ---
 
+# Troubleshooting
+
+## `mc-iam-manager` Stays Unhealthy After Install
+
+If `./mcc infra info` shows `mc-iam-manager` as **unhealthy** and
+`docker logs mc-iam-manager-post-initial` ends with `ERROR: 1_setup_auto.sh Script execution failed`,
+the post-init container started before `mc-iam-manager` finished its first boot.
+
+**Recovery steps:**
+
+```bash
+# 1. Confirm all prerequisites are healthy
+cd bin && ./mcc infra info
+
+# 2. Re-run the post-init container (idempotent — safe to repeat)
+cd ../conf/docker
+docker compose up -d --force-recreate mc-iam-manager-post-initial
+docker logs -f mc-iam-manager-post-initial
+# Each of the 8 setup steps should finish with ✓
+
+# 3. Verify
+curl -s http://localhost:5000/readyz | jq .
+# Expected: "status": "healthy"
+```
+
+---
+
 # Build from Source
 
 ## Build a Static Binary

--- a/README.md
+++ b/README.md
@@ -317,9 +317,9 @@ the post-init container started before `mc-iam-manager` finished its first boot.
 # 1. Confirm all prerequisites are healthy
 cd bin && ./mcc infra info
 
-# 2. Re-run the post-init container (idempotent — safe to repeat)
-cd ../conf/docker
-docker compose up -d --force-recreate mc-iam-manager-post-initial
+# 2. Remove the exited post-init container, then re-run it (idempotent — safe to repeat)
+docker rm mc-iam-manager-post-initial 2>/dev/null
+./mcc infra run -s mc-iam-manager-post-initial
 docker logs -f mc-iam-manager-post-initial
 # Each of the 8 setup steps should finish with ✓
 

--- a/README_kr.md
+++ b/README_kr.md
@@ -298,9 +298,9 @@ cd mc-admin-cli/bin
 # 1. 모든 사전 조건 컨테이너가 healthy인지 확인
 cd bin && ./mcc infra info
 
-# 2. post-init 컨테이너 재실행 (멱등성 보장 — 반복 실행 안전)
-cd ../conf/docker
-docker compose up -d --force-recreate mc-iam-manager-post-initial
+# 2. 종료된 post-init 컨테이너를 제거한 뒤 재실행 (멱등성 보장 — 반복 실행 안전)
+docker rm mc-iam-manager-post-initial 2>/dev/null
+./mcc infra run -s mc-iam-manager-post-initial
 docker logs -f mc-iam-manager-post-initial
 # 8단계 각각이 ✓ 로 완료되어야 합니다
 

--- a/README_kr.md
+++ b/README_kr.md
@@ -284,6 +284,33 @@ cd mc-admin-cli/bin
 
 ---
 
+# 트러블슈팅
+
+## 설치 후 `mc-iam-manager`가 계속 unhealthy 상태일 때
+
+`./mcc infra info`에서 `mc-iam-manager`가 **unhealthy**로 표시되고,
+`docker logs mc-iam-manager-post-initial`의 마지막 줄이 `ERROR: 1_setup_auto.sh Script execution failed`라면,
+`mc-iam-manager`가 완전히 기동되기 전에 post-init 컨테이너가 먼저 실행된 것입니다.
+
+**복구 절차:**
+
+```bash
+# 1. 모든 사전 조건 컨테이너가 healthy인지 확인
+cd bin && ./mcc infra info
+
+# 2. post-init 컨테이너 재실행 (멱등성 보장 — 반복 실행 안전)
+cd ../conf/docker
+docker compose up -d --force-recreate mc-iam-manager-post-initial
+docker logs -f mc-iam-manager-post-initial
+# 8단계 각각이 ✓ 로 완료되어야 합니다
+
+# 3. 헬스 상태 확인
+curl -s http://localhost:5000/readyz | jq .
+# 기대 결과: "status": "healthy"
+```
+
+---
+
 # 소스에서 빌드
 
 ## 정적 바이너리 빌드

--- a/conf/docker/conf/mc-iam-manager/.env.setup
+++ b/conf/docker/conf/mc-iam-manager/.env.setup
@@ -3,6 +3,7 @@
 ## .env.setup 기반으로 생성 - 운영 환경에서는 비밀번호 등을 반드시 변경하세요
 
 # 기본 서비스 설정
+# MC_IAM_MANAGER_DOMAIN: Docker 내부 컨테이너 이름 — 공개 도메인(PUBLIC_DOMAIN)과 다름, 변경 금지
 MC_IAM_MANAGER_DOMAIN=mc-iam-manager
 MC_IAM_MANAGER_PORT=5000
 MC_IAM_MANAGER_HOST=http://mc-iam-manager:5000

--- a/conf/docker/conf/mc-iam-manager/docker-post-init.sh
+++ b/conf/docker/conf/mc-iam-manager/docker-post-init.sh
@@ -85,7 +85,32 @@ if [ -f '1_setup_auto.sh' ]; then
   if bash 1_setup_auto.sh; then
     echo 'Script executed successfully with bash 1_setup_auto.sh'
   else
-    echo 'ERROR: 1_setup_auto.sh Script execution failed'
+    cat <<'RECOVERY'
+====================================================================
+ERROR: 1_setup_auto.sh failed.
+
+mc-iam-manager was likely not yet ready when setup ran.
+To recover manually:
+
+1. Wait ~2 minutes for all containers to stabilize.
+
+2. From the bin/ directory, check service status:
+       ./mcc infra info
+
+   Confirm mc-iam-manager and mc-infra-manager are both running.
+
+3. Re-run the post-init container (idempotent — safe to repeat):
+       cd conf/docker
+       docker compose up -d --force-recreate mc-iam-manager-post-initial
+       docker logs -f mc-iam-manager-post-initial
+
+   Each of the 8 setup steps should finish with ✓.
+
+4. Verify health:
+       curl -s http://localhost:5000/readyz | jq .
+   Expected: "status": "healthy"
+====================================================================
+RECOVERY
     exit 1
   fi
 else

--- a/conf/docker/conf/mc-iam-manager/docker-post-init.sh
+++ b/conf/docker/conf/mc-iam-manager/docker-post-init.sh
@@ -100,8 +100,8 @@ To recover manually:
    Confirm mc-iam-manager and mc-infra-manager are both running.
 
 3. Re-run the post-init container (idempotent — safe to repeat):
-       cd conf/docker
-       docker compose up -d --force-recreate mc-iam-manager-post-initial
+       docker rm mc-iam-manager-post-initial 2>/dev/null
+       cd <repo>/bin && ./mcc infra run -s mc-iam-manager-post-initial
        docker logs -f mc-iam-manager-post-initial
 
    Each of the 8 setup steps should finish with ✓.

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -244,9 +244,14 @@ services:
         published: ${MC_IAM_MANAGER_PORT}
         protocol: tcp
     depends_on:
-      - mc-iam-manager-db
-      - mc-iam-manager-kc
-      - mc-iam-manager-nginx
+      mc-iam-manager-db:
+        condition: service_healthy
+      mc-iam-manager-kc:
+        condition: service_healthy
+      mc-iam-manager-nginx:
+        condition: service_started
+      mc-infra-manager:
+        condition: service_healthy
     environment:
       DATABASE_URL: postgres://${MC_IAM_MANAGER_DATABASE_USER}:${MC_IAM_MANAGER_DATABASE_PASSWORD}@${MC_IAM_MANAGER_DATABASE_HOST}:5432/${MC_IAM_MANAGER_DATABASE_NAME}
       PORT: ${MC_IAM_MANAGER_PORT}


### PR DESCRIPTION
## Summary

- `docker-compose.yaml`: `mc-iam-manager.depends_on`에 `mc-infra-manager: condition: service_healthy` 추가 — cold start 시 DNS resolve 실패 해결
- `mc-iam-manager-db`, `mc-iam-manager-kc`를 `service_healthy` 조건으로 강화 (기존 묵시적 `service_started`)
- `docker-post-init.sh`: `1_setup_auto.sh` 실패 시 `mcc infra info` → post-init 재실행 순서를 안내하는 복구 가이드 출력
- `README.md` / `README_kr.md`: 트러블슈팅 섹션 추가 — mc-iam-manager unhealthy 수동 복구 절차

## Root Cause

`mc-iam-manager`의 healthcheck는 `mc-infra-manager:1323/tumblebug/readyz`를 호출하는데, `depends_on`에 `mc-infra-manager`가 없어 cold start 시 Docker embedded DNS에 등록되기 전에 lookup 실패 → 영구 unhealthy.

`mc-iam-manager-post-initial`은 `sleep 60` 후 `/api/initial-admin`을 호출하는데, 부하가 있는 호스트에서 mc-iam-manager가 60초 내에 API listen을 못 하면 HTTP 000으로 전체 setup 중단.

## Test

로컬 테스트 완료:
- `./mcc infra run -s mc-iam-manager` → `mc-iam-manager (healthy)` ✓
- `./mcc infra run -s mc-iam-manager-post-initial` → 8단계 모두 ✓, Exit 0
- `/readyz` → `"status": "healthy"` ✓
- admin 로그인 → access_token 발급 ✓

## Test Plan

- [ ] `bin/cleanAll.sh` 후 `bin/installAll.sh -m dev -d mciam.local -r background` 전체 재기동
- [ ] `docker compose ps`에서 `mc-iam-manager`가 `mc-infra-manager` healthy 대기 후 시작하는지 확인
- [ ] `docker logs -f mc-iam-manager-post-initial` — 8단계 ✓ 완료
- [ ] `curl -s http://localhost:5000/readyz | jq .` → `"status": "healthy"`