### PR TITLE
fix(web-console): remove optional service deps from mc-web-console-api

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -996,11 +996,6 @@ services:
       - mc-infra-connector
       - mc-infra-manager
       - mc-iam-manager
-      - mc-observability-manager
-      - mc-workflow-manager
-      - mc-data-manager
-      - mc-application-manager
-      - mc-cost-optimizer-be
     ports:
       - target: 3000
         published: ${MC_WEB_CONSOLE_API_PORT}
@@ -1023,8 +1018,6 @@ services:
       IFRAME_TARGET_IS_HOST: true
       MC_IAM_MANAGER_HOST: mc-iam-manager
       MC_IAM_MANAGER_PORT: ${MC_IAM_MANAGER_PORT}
-      MC_OBSERVABILITY_GRAFANA_PUBLIC_HOST: ${MC_OBSERVABILITY_GRAFANA_PUBLIC_HOST}
-      MC_COST_OPTIMIZER_FE_PUBLIC_HOST: ${MC_COST_OPTIMIZER_FE_PUBLIC_HOST}
     volumes:
       - ./tool/mcc:/app/tool/mcc
       - ./conf/mc-web-console/api/conf/:/conf/


### PR DESCRIPTION
## Summary

- `mc-web-console-api.depends_on`에서 선택적 서비스 5개 제거
  (`mc-observability-manager`, `mc-workflow-manager`, `mc-data-manager`, `mc-application-manager`, `mc-cost-optimizer-be`)
- `environment`에서 연동 전용 변수 2개 제거
  (`MC_OBSERVABILITY_GRAFANA_PUBLIC_HOST`, `MC_COST_OPTIMIZER_FE_PUBLIC_HOST`)

## 원인

`mcc infra run -s mc-web-console-front` 실행 시 아래 오류로 기동 실패:

```
dependency failed to start: container mc-observability-grafana is unhealthy
```

### 의존성 체인

```
mc-web-console-front → mc-web-console-api → mc-observability-manager
                                                      ↓ (condition: service_healthy)
                                             mc-observability-grafana (unhealthy)
```

`mc-observability-manager`는 grafana에 `service_healthy` 조건으로 묶여 있어,
grafana가 unhealthy이면 observability-manager가 `started` 상태에 도달하지 못함.
그 결과 `mc-web-console-api`의 묵시적 `service_started` 조건도 충족되지 않아 cascade 실패.

## 설계 의도

제거된 5개 서비스는 web-console에서 **iframe 또는 런타임 HTTP 호출**로 통합되는 선택적 기능이다.
이들이 부재해도 콘솔 자체는 기동되어야 하며, 해당 메뉴만 degraded 상태가 되는 것이 정상 동작이다.

## Test plan

- [ ] grafana unhealthy 상태에서 `mcc infra run -s mc-web-console-front` 성공 확인
- [ ] `docker ps --filter "name=mc-web-console"` → api/front 모두 Up (healthy)
- [ ] 전체 스택 healthy 환경에서 회귀 없음 확인