### PR TITLE
fix(web-console): sync mc-iam-manager entries in runtime api.yaml

### DIFF
--- a/conf/docker/conf/mc-web-console/api/conf/api.yaml
+++ b/conf/docker/conf/mc-web-console/api/conf/api.yaml
@@ -669,6 +669,10 @@ serviceActions:
       method: post
       resourcePath: /api/mcmp-apis/list
       description: "전체 프레임워크 서비스 목록 및 BaseURL 조회."
+    CreateFrameworkService:
+      method: post
+      resourcePath: /api/mcmp-apis
+      description: "프레임워크 서비스 신규 등록. body: {name, version, baseUrl, authType, isActive}"
     UpdateFrameworkService:
       method: put
       resourcePath: /api/mcmp-apis/name/{serviceName}
@@ -978,7 +982,7 @@ serviceActions:
       description: "특정 사용자의 워크스페이스 목록조회"
     Createuser:
       method: post
-      resourcePath: /api/user
+      resourcePath: /api/users
       description: "유저를 등록합니다."
     Deactiveuser:
       method: post
@@ -992,6 +996,186 @@ serviceActions:
       method: post
       resourcePath: /api/roles/assign/platform-role
       description: "Platform Role 할당"
+    Signup:
+      method: post
+      resourcePath: /api/auth/signup
+      description: "신규 사용자 회원가입 (관리자 승인 후 로그인 가능)"
+    GetCspRoleById:
+      method: get
+      resourcePath: /api/roles/csp/id/{roleId}
+      description: "CSP Role 단건 조회"
+    CreateCspRole:
+      method: post
+      resourcePath: /api/roles/csp
+      description: "CSP Role 생성"
+    DeleteCspRole:
+      method: delete
+      resourcePath: /api/roles/csp/id/{roleId}
+      description: "CSP Role 삭제"
+    listCspPolicies:
+      method: post
+      resourcePath: /api/csp-policies/list
+      description: "CSP Policy 목록 조회"
+    GetCspPolicyById:
+      method: get
+      resourcePath: /api/csp-policies/id/{policyId}
+      description: "CSP Policy 단건 조회"
+    CreateCspPolicy:
+      method: post
+      resourcePath: /api/csp-policies
+      description: "CSP Policy 생성"
+    UpdateCspPolicy:
+      method: put
+      resourcePath: /api/csp-policies/id/{policyId}
+      description: "CSP Policy 수정"
+    DeleteCspPolicy:
+      method: delete
+      resourcePath: /api/csp-policies/id/{policyId}
+      description: "CSP Policy 삭제"
+    GetPoliciesByRoleId:
+      method: get
+      resourcePath: /api/csp-policies/role/{roleId}
+      description: "CSP Role에 연결된 Policy 목록 조회"
+    AttachPolicyToRole:
+      method: post
+      resourcePath: /api/csp-policies/attach
+      description: "CSP Policy를 Role에 연결"
+    DetachPolicyFromRole:
+      method: post
+      resourcePath: /api/csp-policies/detach
+      description: "CSP Policy를 Role에서 해제"
+    SyncCspPolicies:
+      method: post
+      resourcePath: /api/csp-policies/sync
+      description: "CSP Policy 동기화"
+    Listmenustree:
+      method: post
+      resourcePath: /api/menus/menus-tree/list
+      description: "List all menus as tree structure (Admin only)"
+    Createmenu:
+      method: post
+      resourcePath: /api/menus
+      description: "Create a new menu"
+    Getmenubyid:
+      method: get
+      resourcePath: /api/menus/id/{menuId}
+      description: "Get menu details by ID"
+    Updatemenu:
+      method: put
+      resourcePath: /api/menus/id/{menuId}
+      description: "Update menu details"
+    Deletemenu:
+      method: delete
+      resourcePath: /api/menus/id/{menuId}
+      description: "Delete a menu"
+    UpdateUserStatus:
+      method: post
+      resourcePath: /api/users/id/{userId}/status
+      description: "사용자 승인/비활성화 (enabled true/false)"
+    ResetUserPassword:
+      method: put
+      resourcePath: /api/users/id/{userId}/password
+      description: "관리자가 사용자 비밀번호 재설정"
+    ChangeMyPassword:
+      method: put
+      resourcePath: /api/users/me/password
+      description: "사용자 본인 비밀번호 변경"
+    Createorganization:
+      method: post
+      resourcePath: /api/organizations
+      description: "그룹 생성"
+    Getorganizations:
+      method: get
+      resourcePath: /api/organizations
+      description: "그룹 목록/트리 조회 (query: tree=true면 중첩 구조)"
+    Getorganizationbyid:
+      method: get
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 단건 조회 by ID"
+    Getorganizationbycode:
+      method: get
+      resourcePath: /api/organizations/code/{code}
+      description: "그룹 단건 조회 by code"
+    Updateorganization:
+      method: put
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 수정 (부모 변경 시 하위 코드 자동 재생성)"
+    Deleteorganization:
+      method: delete
+      resourcePath: /api/organizations/id/{organizationId}
+      description: "그룹 삭제 (하위 그룹·소속 사용자 있으면 400)"
+    Getorganizationusers:
+      method: get
+      resourcePath: /api/organizations/id/{organizationId}/users
+      description: "그룹 소속 사용자 목록"
+    Assignuserorganizations:
+      method: post
+      resourcePath: /api/users/id/{userId}/organizations
+      description: "사용자 그룹 할당 (다중)"
+    Getuserorganizations:
+      method: get
+      resourcePath: /api/users/id/{userId}/organizations
+      description: "사용자 소속 그룹 목록"
+    Removeuserorganization:
+      method: delete
+      resourcePath: /api/users/id/{userId}/organizations/{organizationId}
+      description: "사용자 그룹 제거"
+    listCspAccounts:
+      method: post
+      resourcePath: /api/csp-accounts/list
+      description: "CSP 계정 목록 조회 (필터: csp_type)"
+    createCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts
+      description: "CSP 계정 등록"
+    getCspAccountByID:
+      method: get
+      resourcePath: /api/csp-accounts/id/{accountId}
+      description: "CSP 계정 단건 조회 by ID"
+    updateCspAccount:
+      method: put
+      resourcePath: /api/csp-accounts/id/{accountId}
+      description: "CSP 계정 수정"
+    deleteCspAccount:
+      method: delete
+      resourcePath: /api/csp-accounts/id/{accountId}
+      description: "CSP 계정 삭제"
+    validateCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts/id/{accountId}/validate
+      description: "CSP 계정 자격증명 유효성 검증"
+    activateCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts/id/{accountId}/activate
+      description: "CSP 계정 활성화"
+    deactivateCspAccount:
+      method: post
+      resourcePath: /api/csp-accounts/id/{accountId}/deactivate
+      description: "CSP 계정 비활성화"
+    GetProjectSyncDiff:
+      method: get
+      resourcePath: /api/setup/projects/sync-diff
+      description: "Infra NS ↔ IAM Project 동기화 차이 조회"
+    ApplyProjectSync:
+      method: post
+      resourcePath: /api/setup/projects/sync
+      description: "nsIds + workspaceId를 받아 Project 생성 + Workspace 할당"
+    listMenus:
+      method: post
+      resourcePath: /api/menus/list
+      description: "메뉴 목록 조회 (전체)"
+    InitialMenus:
+      method: post
+      resourcePath: /api/setup/initial-menus
+      description: "menu.yaml 기반 메뉴 일괄 재등록 (1_setup_auto.sh init_menu와 동일)"
+    SyncMcmpApis:
+      method: post
+      resourcePath: /api/setup/sync-mcmp-apis
+      description: "api.yaml 기반 mcmpApi 카탈로그 재동기화 (1_setup_auto.sh init_api_resources와 동일)"
+    syncProjects:
+      method: post
+      resourcePath: /api/setup/sync-projects
+      description: "mc-infra-manager의 namespace 목록을 가져와 project 테이블과 동기화"
 
   mc-infra-manager:
     GetCredentialHolderList:


### PR DESCRIPTION
## Summary

- 런타임 `conf/docker/conf/mc-web-console/api/conf/api.yaml`에 누락된 mc-iam-manager operationId 46개 추가
- `Createuser.resourcePath` 경로 오류 수정: `/api/user` → `/api/users`

## 누락 항목 분류

| 분류 | operationId |
|------|-------------|
| 인증 | `Signup` |
| CSP Role | `GetCspRoleById`, `CreateCspRole`, `DeleteCspRole` |
| CSP Policy | `listCspPolicies`, `GetCspPolicyById`, `CreateCspPolicy`, `UpdateCspPolicy`, `DeleteCspPolicy`, `GetPoliciesByRoleId`, `AttachPolicyToRole`, `DetachPolicyFromRole`, `SyncCspPolicies` |
| 메뉴 CRUD | `Listmenustree`, `Createmenu`, `Getmenubyid`, `Updatemenu`, `Deletemenu` |
| 사용자 관리 | `UpdateUserStatus`, `ResetUserPassword`, `ChangeMyPassword` |
| Organization | `Createorganization`, `Getorganizations`, `Getorganizationbyid`, `Getorganizationbycode`, `Updateorganization`, `Deleteorganization`, `Getorganizationusers`, `Assignuserorganizations`, `Getuserorganizations`, `Removeuserorganization` |
| CSP 계정 | `listCspAccounts`, `createCspAccount`, `getCspAccountByID`, `updateCspAccount`, `deleteCspAccount`, `validateCspAccount`, `activateCspAccount`, `deactivateCspAccount` |
| Setup/Sync | `GetProjectSyncDiff`, `ApplyProjectSync`, `listMenus`, `InitialMenus`, `SyncMcmpApis`, `syncProjects` |

## 참고

`mc-web-console/conf/api.yaml`을 기준으로 런타임 api.yaml과 diff하여 누락 항목을 식별.
누락된 operationId는 proxy가 찾지 못해 404를 반환하는 원인이 됨.
