### PR TITLE
fix(certbot): switch to webroot authenticator and add nginx reload hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,48 @@ cd mc-admin-cli/bin
 ```
 
 
+## TLS Certificate Auto-Renewal (Mode B)
+
+When running in Mode B (Let's Encrypt), certbot renews the certificate automatically via `systemd certbot.timer` (twice daily). The certificate is renewed 30 days before expiry.
+
+### Webroot setup (required once after installation)
+
+Mode B uses the **webroot** authenticator so nginx keeps running during renewal. If your installation used the `standalone` authenticator (older setup), switch it once:
+
+```shell
+sudo certbot certonly \
+  --webroot \
+  -w <mc-admin-cli-path>/conf/docker/container-volume/certbot/www \
+  -d <your-domain> \
+  --force-renewal
+```
+
+Verify the renewal config was updated:
+
+```shell
+sudo grep "authenticator" /etc/letsencrypt/renewal/<your-domain>.conf
+# Expected: authenticator = webroot
+```
+
+### Deploy hook — nginx reload after renewal
+
+After renewal, the new certificate must be loaded into the running nginx container. Install the deploy hook once:
+
+```shell
+sudo cp conf/docker/scripts/certbot-deploy-hook.sh \
+     /etc/letsencrypt/renewal-hooks/deploy/reload-nginx-docker.sh
+sudo chmod +x /etc/letsencrypt/renewal-hooks/deploy/reload-nginx-docker.sh
+```
+
+### Verify auto-renewal
+
+```shell
+sudo certbot renew --dry-run
+# Expected: "all simulated renewals succeeded"
+```
+
+---
+
 ## Firewall Port Information
 
 The following ports should be registered in the firewall if needed:

--- a/README_kr.md
+++ b/README_kr.md
@@ -185,6 +185,48 @@ cd mc-admin-cli/bin
 ```
 
 
+## TLS 인증서 자동갱신 (Mode B)
+
+Mode B(Let's Encrypt) 실행 시 certbot이 `systemd certbot.timer`를 통해 하루 2회 자동갱신을 시도합니다. 만료 30일 전부터 갱신이 시작됩니다.
+
+### Webroot 방식 전환 (최초 1회 필요)
+
+Mode B는 갱신 중에도 nginx가 계속 실행될 수 있도록 **webroot** 인증 방식을 사용합니다. 기존 `standalone` 방식으로 설치된 경우 아래 명령으로 한 번 전환해야 합니다:
+
+```shell
+sudo certbot certonly \
+  --webroot \
+  -w <mc-admin-cli 경로>/conf/docker/container-volume/certbot/www \
+  -d <your-domain> \
+  --force-renewal
+```
+
+전환 확인:
+
+```shell
+sudo grep "authenticator" /etc/letsencrypt/renewal/<your-domain>.conf
+# 기대값: authenticator = webroot
+```
+
+### Deploy Hook — 갱신 후 nginx 자동 reload
+
+인증서 갱신 후 nginx 컨테이너에 새 인증서를 즉시 적용하기 위한 deploy hook을 한 번 설치합니다:
+
+```shell
+sudo cp conf/docker/scripts/certbot-deploy-hook.sh \
+     /etc/letsencrypt/renewal-hooks/deploy/reload-nginx-docker.sh
+sudo chmod +x /etc/letsencrypt/renewal-hooks/deploy/reload-nginx-docker.sh
+```
+
+### 자동갱신 검증
+
+```shell
+sudo certbot renew --dry-run
+# 기대값: "all simulated renewals succeeded"
+```
+
+---
+
 ## 방화벽 포트 정보
 
 필요한 경우 다음 포트들을 방화벽에 등록해야 합니다:

--- a/conf/docker/scripts/certbot-deploy-hook.sh
+++ b/conf/docker/scripts/certbot-deploy-hook.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# certbot deploy hook — reload mc-iam-manager-nginx after certificate renewal.
+#
+# Install once:
+#   sudo cp conf/docker/scripts/certbot-deploy-hook.sh \
+#            /etc/letsencrypt/renewal-hooks/deploy/reload-nginx-docker.sh
+#   sudo chmod +x /etc/letsencrypt/renewal-hooks/deploy/reload-nginx-docker.sh
+docker exec mc-iam-manager-nginx nginx -s reload 2>/dev/null \
+  && echo "[certbot-deploy] mc-iam-manager-nginx reloaded successfully" \
+  || echo "[certbot-deploy] WARNING: failed to reload mc-iam-manager-nginx (container may not be running)"


### PR DESCRIPTION
## Summary

- **ADMIN-BUG-011** certbot 자동갱신 실패 수정 — `standalone` → `webroot` 인증 방식 전환

### 문제

`standalone` 방식은 갱신 시 port 80에 임시 서버를 바인딩해야 하지만, `mc-iam-manager-nginx`가 `:80`을 상시 점유 중이어서 `certbot renew`가 매번 실패했습니다.

```
Could not bind TCP port 80 because it is already in use
```

### 해결

nginx는 이미 `/.well-known/acme-challenge/` → `certbot/www` 볼륨을 서빙하고 있으므로, webroot 방식으로 전환하면 nginx를 멈추지 않고 갱신 가능합니다.

### Changes

- **conf/docker/scripts/certbot-deploy-hook.sh** (신규): 갱신 후 `docker exec mc-iam-manager-nginx nginx -s reload` 실행하는 deploy hook. `/etc/letsencrypt/renewal-hooks/deploy/`에 한 번 설치하면 이후 자동갱신마다 실행됨
- **README / README_kr**: "TLS Certificate Auto-Renewal (Mode B)" 섹션 추가
  - webroot 전환 명령 (최초 1회)
  - deploy hook 설치 방법
  - `certbot renew --dry-run` 검증 방법

## Test plan

- [x] `sudo certbot certonly --webroot ...` 실행 → `authenticator = webroot` 확인 (2026-05-17)
- [x] `/etc/letsencrypt/renewal-hooks/deploy/reload-nginx-docker.sh` 설치
- [x] `sudo certbot renew --dry-run` → `all simulated renewals succeeded` 확인 (2026-05-17)