### PR TITLE
fix(keycloak): set realm frontendUrl in configure_keycloak_client_uris

### DIFF
--- a/conf/docker/conf/mc-iam-manager/1_setup_auto.sh
+++ b/conf/docker/conf/mc-iam-manager/1_setup_auto.sh
@@ -644,6 +644,18 @@ configure_keycloak_client_uris() {
 
     KC_ADMIN_URL="${MC_IAM_MANAGER_KEYCLOAK_HOST}/admin/realms/${MC_IAM_MANAGER_KEYCLOAK_REALM}"
 
+    # Keycloak realm Frontend URL 설정 (토큰 iss 클레임 base URL)
+    REALM_HTTP=$(curl -s -o /dev/null -w "%{http_code}" -X PUT \
+        "${MC_IAM_MANAGER_KEYCLOAK_HOST}/admin/realms/${MC_IAM_MANAGER_KEYCLOAK_REALM}" \
+        -H "Authorization: Bearer ${KC_ADMIN_TOKEN}" \
+        -H "Content-Type: application/json" \
+        -d "{\"attributes\": {\"frontendUrl\": \"${MC_IAM_MANAGER_PUBLIC_HOST}\"}}")
+    if [ "$REALM_HTTP" = "204" ]; then
+        echo "  ✓ Keycloak realm frontendUrl set to ${MC_IAM_MANAGER_PUBLIC_HOST}"
+    else
+        echo "  ⚠️  Failed to set realm frontendUrl (HTTP $REALM_HTTP) — tokens may use internal iss"
+    fi
+
     # mciamClient, mciam-oidc-Client 두 클라이언트 설정
     for CLIENT_NAME in "$MC_IAM_MANAGER_KEYCLOAK_CLIENT_NAME" "$MC_IAM_MANAGER_KEYCLOAK_OIDC_CLIENT_NAME"; do
         [ -z "$CLIENT_NAME" ] && continue


### PR DESCRIPTION
## Summary

- `1_setup_auto.sh`의 `configure_keycloak_client_uris` 함수에 Keycloak realm Frontend URL 갱신 추가
- Keycloak Admin API `PUT /admin/realms/{realm}`으로 `frontendUrl = MC_IAM_MANAGER_PUBLIC_HOST` 설정

## 문제

Keycloak realm Frontend URL이 설정되지 않으면:
- 토큰의 `iss` 클레임이 내부 호스트명(`http://mc-iam-manager-kc:8080/auth/realms/mciam`)으로 발급됨
- 초기화 후 재기동 시 또는 도메인 변경 시 Keycloak `sub`(kc_id)가 DB와 불일치할 수 있음
- mc-iam-manager가 외부 토큰으로 사용자 조회 실패 → `workspace/projects` 빈 배열 반환

## Test plan

- [ ] `installAll.sh` 실행 후 post-initial 로그에서 `✓ Keycloak realm frontendUrl set to https://...` 확인
- [ ] 로그인 후 토큰 `iss` 클레임이 `MC_IAM_MANAGER_PUBLIC_HOST` 와 일치하는지 확인
- [ ] `getProjectsByWorkspaceId` API가 projects를 정상 반환하는지 확인