### PR TITLE
docs: add Quick Start TL;DR section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,42 @@ docker ps
 ```
 
 
+## Quick Start (TL;DR)
+
+> For the full step-by-step guide, see the [Quick Guide](#quick-guide) section below.
+
+**1. Configure environment**
+```shell
+cd mc-admin-cli/conf/docker/conf/mc-iam-manager
+cp .env.setup .env
+# Edit .env — set required values such as platform admin ID and password
+```
+
+**2. Run installAll.sh**
+```shell
+cd mc-admin-cli/bin
+./installAll.sh
+```
+When prompted for a domain:
+- **Dev / Local PC** — press `Enter` (uses default `mciam.local`)
+- **Dev / Remote VM** — enter the VM's IP address or domain name
+- **Production** — enter your public FQDN (required; DNS A-record must point to this server)
+
+**3. Verify all containers are healthy**
+```shell
+./mcc infra info
+```
+Wait until all containers show `healthy`. `mc-iam-manager-post-initial` showing `Exited (0)` is normal.
+
+**4. Open the web console**
+
+Navigate to **`https://<server>:3001`** in your browser.
+> ⚠️ Use **https**, not http. When the browser shows a security warning, click **Continue** (or **Advanced → Proceed**).
+
+Default credentials: `mcmp` / `mcmp_password`
+
+---
+
 # Quick Guide
 This section describes the minimal process for those who want to set up quickly.   
 For more detailed installation guide, please refer to the [Running on Single Instance Guide](https://github.com/m-cmp/mc-admin-cli/blob/main/docs/running-on-instance.md) document.

--- a/README_kr.md
+++ b/README_kr.md
@@ -42,6 +42,42 @@ sudo apt-get update
 sudo apt-get install -y docker-ce docker-ce-cli docker-compose-plugin
 ```
 
+## 빠른 실행 요약 (TL;DR)
+
+> 단계별 상세 가이드는 아래 [빠른 가이드](#빠른-가이드) 섹션을 참고하세요.
+
+**1. 환경 파일 설정**
+```shell
+cd mc-admin-cli/conf/docker/conf/mc-iam-manager
+cp .env.setup .env
+# .env 파일 편집 — 플랫폼 관리자 ID / 비밀번호 등 필수 값 설정
+```
+
+**2. installAll.sh 실행**
+```shell
+cd mc-admin-cli/bin
+./installAll.sh
+```
+도메인 입력 안내:
+- **개발 / 로컬 PC** — `Enter` 입력 (기본값 `mciam.local` 사용)
+- **개발 / 원격 VM** — VM의 IP 주소 또는 도메인명 입력
+- **운영** — 공개 FQDN 입력 필수 (DNS A-레코드가 이 서버를 가리켜야 함)
+
+**3. 컨테이너 상태 확인**
+```shell
+./mcc infra info
+```
+모든 컨테이너가 `healthy` 상태가 될 때까지 대기. `mc-iam-manager-post-initial`이 `Exited (0)`으로 표시되는 것은 정상.
+
+**4. 웹 콘솔 접속**
+
+브라우저에서 **`https://<서버>:3001`** 로 접속합니다.
+> ⚠️ **http가 아닌 https**로 접속하세요. 보안 경고가 표시되면 **계속** (또는 **고급 → 계속 진행**) 을 선택합니다.
+
+기본 계정: `mcmp` / `mcmp_password`
+
+---
+
 # 빠른 가이드
 이 섹션은 빠르게 설정하고 싶은 분들을 위한 최소한의 과정을 설명합니다.   
 더 자세한 설치 가이드를 원하시면 [단일 인스턴스에서 실행하기 가이드](https://github.com/m-cmp/mc-admin-cli/blob/main/docs/running-on-instance.md) 문서를 참조하세요.


### PR DESCRIPTION
## Summary

- 처음 접하는 사용자가 핵심 실행 흐름을 한눈에 파악할 수 있도록 Quick Guide 앞에 TL;DR 요약 섹션 추가
- README.md (영문) / README_kr.md (한국어) 동일 적용

## 추가된 내용

1. `.env.setup` → `.env` 복사 후 필수 값(ID/PW) 설정 안내
2. `./installAll.sh` 실행 시 도메인 입력 방식 명시
   - 개발/로컬PC: `Enter` (기본값 사용)
   - 개발/원격VM: IP 주소 또는 도메인 입력
   - 운영: 공개 FQDN 필수
3. `./mcc infra info` 로 healthy 확인 안내
4. 브라우저 접속: `https://<서버>:3001` (http 아님), 보안 경고에서 계속 선택 안내

## Test plan

- [ ] GitHub에서 README.md 렌더링 확인 (코드 블록, 앵커 링크)
- [ ] README_kr.md 동일 확인