### PR TITLE
feat/iframe-fe-services: iframe proxy ports, env var prefix 통일, 영문화, .env sync 자동화

### DIFF
--- a/bin/installAll.sh
+++ b/bin/installAll.sh
@@ -200,8 +200,42 @@ ensure_env_file() {
     fi
 }
 
+sync_missing_env_vars() {
+    local setup_file="$1"
+    local env_file="$2"
+
+    if [ ! -f "$setup_file" ] || [ ! -f "$env_file" ]; then
+        return 0
+    fi
+
+    local tmpfile
+    tmpfile=$(mktemp)
+
+    while IFS= read -r line; do
+        _key="${line%%=*}"
+        if ! grep -qE "^${_key}=" "$env_file"; then
+            printf '%s\n' "$line" >> "$tmpfile"
+        fi
+    done < <(grep -E '^[A-Z_][A-Z0-9_]*=' "$setup_file")
+
+    if [ -s "$tmpfile" ]; then
+        local rel="${env_file##*/conf/docker/}"
+        {
+            printf '\n'
+            printf '# === Synced from %s by installAll.sh on %s ===\n' \
+                "$(basename "$setup_file")" "$(date -Iseconds)"
+            cat "$tmpfile"
+        } >> "$env_file"
+        echo "✓ Synced $(wc -l < "$tmpfile") missing var(s) into ${rel}"
+    fi
+    rm -f "$tmpfile"
+}
+
 ensure_env_file "$PROJECT_ROOT_ABS/.env.setup"                            "$PROJECT_ROOT_ABS/.env"
 ensure_env_file "$PROJECT_ROOT_ABS/conf/mc-iam-manager/.env.setup"        "$PROJECT_ROOT_ABS/conf/mc-iam-manager/.env"
+
+sync_missing_env_vars "$PROJECT_ROOT_ABS/.env.setup"                      "$PROJECT_ROOT_ABS/.env"
+sync_missing_env_vars "$PROJECT_ROOT_ABS/conf/mc-iam-manager/.env.setup"  "$PROJECT_ROOT_ABS/conf/mc-iam-manager/.env"
 
 # =============================================================================
 # Domain Configuration


### PR DESCRIPTION
## Summary

- **env var prefix 통일** (`ADMINCLI-TECH-001`): `.env.setup` 및 관련 `.env` 파일의 변수명을 `MC_<FRAMEWORK>_*` prefix 규칙으로 통일
- **iframe FE service 항목 추가** (`ADMINCLI-TECH-002`): `api.yaml`에 mc-workflow-manager-fe, mc-data-manager-fe, mc-application-manager-fe, mc-cost-optimizer-fe 서비스 항목 추가. `.env.setup`에 `WORKFLOW/DATA/APPLICATION _PROXY_PORT` + `_PUBLIC_HOST` 변수 추가
- **사용자 노출 메시지 영문화**: 셸 스크립트 9개(`bin/`, `conf/docker/conf/mc-iam-manager/`) 및 설정 파일 5개의 한글 출력 메시지·가이드 주석을 영문으로 통일
- **`.env` 누락 변수 자동 sync** (`fix`): `installAll.sh`에 `sync_missing_env_vars()` 추가 — stale `.env`에 신규 변수가 없으면 `.env.setup`에서 append. 이로 인해 `MC_WORKFLOW_MANAGER_PROXY_PORT` 등 누락 시 발생하는 `no port specified: :<empty>` 오류 방지

## Changed Files

| Area | Files |
|------|-------|
| bin | `installAll.sh`, `cleanAll.sh`, `iam_manager_init.sh` |
| conf/docker | `.env.setup`, `api.yaml`, `docker-compose.cert.yaml` |
| conf/mc-iam-manager | `.env`, `.env.setup`, `0_preset_dev.sh`, `0_preset_prod.sh`, `1_setup_auto.sh`, `1_setup_manual.sh`, `docker-post-init.sh`, `init-db.sh`, `nginx.template.conf` |
| conf/mc-web-console | `.env` |
| conf/mc-data-manager | `.env` |
| src | `src/cmd/apicall/parse.go` |

## Test plan

- [ ] `./bin/installAll.sh` 신규 VM(`.env` 없음) — `.env.setup` 복사 후 누락 없이 `mcc infra run` 성공
- [ ] `./bin/installAll.sh` 기존 VM(stale `.env`) — 누락 변수 자동 append 후 `mcc infra run` 성공 (`✓ Synced N missing var(s)` 메시지 확인)
- [ ] 멱등성: `installAll.sh` 재실행 시 중복 추가 없음
- [ ] 영문화: 콘솔 출력이 영문으로 표시됨