### PR TITLE
fix(setup): align api.yaml env var name with .env convention

### DIFF
--- a/conf/docker/conf/mc-iam-manager/1_setup_auto.sh
+++ b/conf/docker/conf/mc-iam-manager/1_setup_auto.sh
@@ -313,12 +313,12 @@ init_menu() {
 
 init_api_resources() {
     echo "Initializing API resources..."
-    if [ -n "$MCADMINCLI_APIYAML" ]; then
-        wget -q -O ./api.yaml "$MCADMINCLI_APIYAML" && echo "  Downloaded api.yaml from $MCADMINCLI_APIYAML" || {
-            echo "  WARNING: Failed to download api.yaml from $MCADMINCLI_APIYAML — using local copy"
+    if [ -n "$MC_ADMIN_CLI_APIYAML" ]; then
+        wget -q -O ./api.yaml "$MC_ADMIN_CLI_APIYAML" && echo "  Downloaded api.yaml from $MC_ADMIN_CLI_APIYAML" || {
+            echo "  WARNING: Failed to download api.yaml from $MC_ADMIN_CLI_APIYAML — using local copy"
         }
     else
-        echo "  MCADMINCLI_APIYAML not set — using local api.yaml"
+        echo "  MC_ADMIN_CLI_APIYAML not set — using local api.yaml"
     fi
     if [ ! -f ./api.yaml ]; then
         echo "ERROR: api.yaml not found"

--- a/conf/docker/conf/mc-iam-manager/1_setup_manual.sh
+++ b/conf/docker/conf/mc-iam-manager/1_setup_manual.sh
@@ -94,7 +94,7 @@ init_menu() {
 
 init_api_resources() {
     echo "Initializing API resources..."
-    wget -q -O ./api.yaml "$MCADMINCLI_APIYAML"
+    wget -q -O ./api.yaml "$MC_ADMIN_CLI_APIYAML"
     response=$(curl -s -X POST \
         --header "Authorization: Bearer $MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN" \
         --header 'Content-Type: application/json' \


### PR DESCRIPTION
## Summary

- `1_setup_auto.sh`, `1_setup_manual.sh`의 `$MCADMINCLI_APIYAML` → `$MC_ADMIN_CLI_APIYAML` 로 변경
- `.env`에 정의된 변수명(`MC_ADMIN_CLI_APIYAML`)과 불일치로 인해 `mc-iam-manager-post-initial` 컨테이너에서 `api.yaml not found` 에러 발생하던 문제 수정
- `menu.yaml`은 `.env` 변수명과 일치하는 `$MC_WEB_CONSOLE_MENUYAML`을 사용해 정상 동작하던 것과 비대칭이었음
