### PR TITLE
fix: macOS compatibility and local HTTP mode fixes

### DIFF
--- a/bin/installAll.sh
+++ b/bin/installAll.sh
@@ -288,7 +288,11 @@ echo "Using domain: $IAM_DOMAIN"
 apply_domain() {
     local env_file="$1"
     local domain="$2"
-    sed -i "s|^MC_IAM_MANAGER_PUBLIC_DOMAIN=.*|MC_IAM_MANAGER_PUBLIC_DOMAIN=${domain}|" "$env_file"
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '' "s|^MC_IAM_MANAGER_PUBLIC_DOMAIN=.*|MC_IAM_MANAGER_PUBLIC_DOMAIN=${domain}|" "$env_file"
+    else
+        sed -i "s|^MC_IAM_MANAGER_PUBLIC_DOMAIN=.*|MC_IAM_MANAGER_PUBLIC_DOMAIN=${domain}|" "$env_file"
+    fi
     echo "✓ Set MC_IAM_MANAGER_PUBLIC_DOMAIN=${domain} in ${env_file##*/conf/docker/}"
 }
 

--- a/conf/docker/conf/mc-iam-manager/0_preset_local.sh
+++ b/conf/docker/conf/mc-iam-manager/0_preset_local.sh
@@ -93,6 +93,14 @@ echo "  MC_IAM_MANAGER_PORT: $MC_IAM_MANAGER_PORT"
 # 4. Rewrite PUBLIC_HOST variables from https:// to http:// in .env files
 # =============================================================================
 
+_sedi() {
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
+
 rewrite_https_to_http() {
     local env_file="$1"
     if [ ! -f "$env_file" ]; then
@@ -111,7 +119,7 @@ rewrite_https_to_http() {
 
     for var in "${vars[@]}"; do
         if grep -qE "^${var}=https://" "$env_file"; then
-            sed -i "s|^${var}=https://|${var}=http://|" "$env_file"
+            _sedi "s|^${var}=https://|${var}=http://|" "$env_file"
             echo "  ✓ ${var}: https:// → http://"
         fi
     done
@@ -136,7 +144,7 @@ else
         echo "✓ $DOMAIN already exists in $HOSTS_FILE. Skipping."
     else
         echo "Removing any existing entries for $DOMAIN..."
-        sed -i "/[[:space:]]*127\.0\.0\.1[[:space:]]\+${DOMAIN}[[:space:]]*$/d" "$HOSTS_FILE" 2>/dev/null || true
+        _sedi "/[[:space:]]*127\.0\.0\.1[[:space:]]\+${DOMAIN}[[:space:]]*$/d" "$HOSTS_FILE" 2>/dev/null || true
 
         echo "Adding 127.0.0.1 $DOMAIN to $HOSTS_FILE..."
         if sudo -n true 2>/dev/null; then

--- a/conf/docker/conf/mc-iam-manager/1_setup_auto.sh
+++ b/conf/docker/conf/mc-iam-manager/1_setup_auto.sh
@@ -468,7 +468,7 @@ update_public_service_urls() {
     # mc-cost-optimizer-fe: replace the internal container URL (http://mc-cost-optimizer-fe:7780)
     # with the nginx HTTPS proxy URL accessible directly from the browser.
     # /api/getapihosts returns this value as the iframe src in MCIAM_USE=true environments.
-    local cost_fe_public_url="https://${MC_IAM_MANAGER_PUBLIC_DOMAIN}:${MC_COST_OPTIMIZER_FE_PROXY_PORT}"
+    local cost_fe_public_url="${MC_COST_OPTIMIZER_FE_PUBLIC_HOST:-http://${MC_IAM_MANAGER_PUBLIC_DOMAIN}:${MC_COST_OPTIMIZER_FE_PROXY_PORT}}"
 
     # mc-cost-optimizer-fe is not in the upstream api.yaml, so attempt registration first (idempotent)
     local reg_body

--- a/conf/docker/conf/mc-iam-manager/nginx.template.local.conf
+++ b/conf/docker/conf/mc-iam-manager/nginx.template.local.conf
@@ -37,7 +37,9 @@ http {
         }
 
         location /health {
-            proxy_pass http://${MC_IAM_MANAGER_DOMAIN}:${MC_IAM_MANAGER_PORT}/readyz;
+            resolver 127.0.0.11 valid=10s;
+            set $upstream_iam ${MC_IAM_MANAGER_DOMAIN};
+            proxy_pass http://$upstream_iam:${MC_IAM_MANAGER_PORT}/readyz;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -51,7 +53,9 @@ http {
         }
 
         location /auth/ {
-            proxy_pass http://${MC_IAM_MANAGER_KEYCLOAK_DOMAIN}:${MC_IAM_MANAGER_KEYCLOAK_PORT}/auth/;
+            resolver 127.0.0.11 valid=10s;
+            set $upstream_kc ${MC_IAM_MANAGER_KEYCLOAK_DOMAIN};
+            proxy_pass http://$upstream_kc:${MC_IAM_MANAGER_KEYCLOAK_PORT}/auth/;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -68,7 +72,9 @@ http {
         }
 
         location / {
-            proxy_pass http://${MC_IAM_MANAGER_DOMAIN}:${MC_IAM_MANAGER_PORT};
+            resolver 127.0.0.11 valid=10s;
+            set $upstream_iam ${MC_IAM_MANAGER_DOMAIN};
+            proxy_pass http://$upstream_iam:${MC_IAM_MANAGER_PORT};
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
- `bin/installAll.sh`: macOS BSD sed 호환성 처리 (`apply_domain` 함수)
- `0_preset_local.sh`: macOS BSD sed 호환 `_sedi()` 헬퍼 함수 추가
- `1_setup_auto.sh`: `mc-cost-optimizer-fe` public URL 생성 시 `https://` 하드코딩 → `MC_COST_OPTIMIZER_FE_PUBLIC_HOST` 환경변수 사용 (local HTTP 모드 대응)
- `nginx.template.local.conf`: `resolver 127.0.0.11` + `set $upstream` 패턴으로 nginx 시작 시점 DNS 해석 지연 처리

## Test plan
- [ ] macOS (Apple Silicon)에서 `./bin/installAll.sh -m dev -d localhost -r log` 실행 확인
- [ ] local HTTP 모드에서 mc-cost-optimizer-fe iframe 정상 표시 확인
- [ ] nginx 시작 시 upstream DNS 오류 없이 기동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)