### PR TITLE
fix(setup): camelCase roleTypes in init_predefined_roles JSON payload

### DIFF
--- a/conf/docker/conf/mc-iam-manager/1_setup_auto.sh
+++ b/conf/docker/conf/mc-iam-manager/1_setup_auto.sh
@@ -254,7 +254,7 @@ init_predefined_roles() {
     for role in "${ROLES[@]}"; do
         echo "Creating role: $role"
         json_data=$(jq -n --arg name "$role" --arg description "$role Role" \
-            '{name: $name, description: $description, role_types: ["workspace", "platform"]}')
+            '{name: $name, description: $description, roleTypes: ["workspace", "platform"]}')
         response=$(curl -s -X POST \
             --header 'Content-Type: application/json' \
             --header "Authorization: Bearer $MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN" \


### PR DESCRIPTION
## Summary

- `conf/docker/conf/mc-iam-manager/1_setup_auto.sh`의 `init_predefined_roles` 함수에서 `role_types` (snake_case)를 `roleTypes` (camelCase)로 수정

## Root Cause

`CreateRoleRequest` 모델이 `json:"roleTypes"` (camelCase) 바인딩을 사용하는데 setup 스크립트에서 `role_types` (snake_case)로 전송해 Go JSON 역직렬화 시 무시됨.
결과: `viewer`, `billviewer`에 `platform` role_sub이 생성되지 않아 `assignPlatformRole` 500, `ListRoles` platform 필터에서 제외됨.

```bash
# Before
'{name: $name, description: $description, role_types: ["workspace", "platform"]}'

# After
'{name: $name, description: $description, roleTypes: ["workspace", "platform"]}'
```

ref: MZC-CSC/mc-iam-manager#111