### PR TITLE
fix(docker): mc-iam-manager 이미지를 cloudbaristaorg/mc-iam-manager:0.5.3으로 변경

### DIFF
--- a/conf/docker/docker-compose.mini.yaml
+++ b/conf/docker/docker-compose.mini.yaml
@@ -219,7 +219,7 @@ services:
 
   mc-iam-manager:
     container_name: mc-iam-manager
-    image: csescsta/mc-iam-manager:edge
+    image: cloudbaristaorg/mc-iam-manager:0.5.3
     restart: unless-stopped
     networks:
       - mc-iam-manager-network

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -242,7 +242,7 @@ services:
 
   mc-iam-manager:
     container_name: mc-iam-manager
-    image: csescsta/mc-iam-manager:edge
+    image: cloudbaristaorg/mc-iam-manager:0.5.3
     restart: unless-stopped
     networks:
       - mc-iam-manager-network


### PR DESCRIPTION
## Summary

- `cloudbaristaorg/mc-iam-manager:0.5.3` 변경
- 대상: `docker-compose.yaml`, `docker-compose.mini.yaml`
