### PR TITLE
fix(docker): 매니저 서비스 restart 정책·depends_on 보강

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -872,6 +872,7 @@ services:
   mc-application-manager-sonatype-nexus:
     image: sonatype/nexus3:latest
     container_name: mc-application-manager-sonatype-nexus
+    restart: unless-stopped
     platform: linux/amd64
     networks:
       - mc-application-manager-network
@@ -896,8 +897,15 @@ services:
   mc-application-manager:
     image: cloudbaristaorg/mc-application-manager:0.5.2
     container_name: mc-application-manager
+    restart: unless-stopped
     depends_on:
       mc-application-manager-db:
+        condition: service_healthy
+      mc-application-manager-sonatype-nexus:
+        condition: service_started
+      mc-infra-manager:
+        condition: service_healthy
+      mc-observability-rabbitmq:
         condition: service_healthy
     networks:
       - mc-application-manager-network
@@ -959,6 +967,10 @@ services:
     image: cloudbaristaorg/mc-workflow-manager:0.5.3
     container_name: mc-workflow-manager
     platform: linux/amd64
+    restart: unless-stopped
+    depends_on:
+      mc-workflow-manager-jenkins:
+        condition: service_healthy
     networks:
       - mc-workflow-manager-network
       - mc-web-console-network
@@ -1026,6 +1038,7 @@ services:
   mc-data-manager-db:
     image: mariadb:latest
     container_name: mc-data-manager-db
+    restart: always
     command:
       - --skip-character-set-client-handshake
     volumes:


### PR DESCRIPTION
## 문제
`./mcc infra run` 초기 기동 시, 그리고 서버 중단 후 재가동 시 `mc-workflow-manager`, `mc-application-manager`, `mc-data-manager` 등 일부 서비스가 올라오지 않음.

## 원인
- 일부 매니저 서비스에 **restart 정책이 없어**, 무거운 의존 서비스(Jenkins/Nexus/RabbitMQ/infra-manager/MariaDB)보다 먼저 떠서 연결 실패로 크래시한 뒤 **자력 복구가 되지 않음**.
- 서버/도커 데몬 재시작 시 `depends_on` 순서는 적용되지 않고, restart 정책이 `always`/`unless-stopped`인 컨테이너만 자동 기동됨 → 정책 없는 매니저들이 안 올라옴.

## 변경
- **mc-workflow-manager**: `restart: unless-stopped` 추가 + `mc-workflow-manager-jenkins`(service_healthy) 의존 추가
- **mc-application-manager**: `restart: unless-stopped` 추가 + `sonatype-nexus`, `mc-infra-manager`(healthy), `mc-observability-rabbitmq`(healthy) 의존 추가
- **mc-application-manager-sonatype-nexus**: `restart: unless-stopped` 추가
- **mc-data-manager-db**: `restart: always` 추가 (재부팅 시 DB 미기동으로 data-manager가 재시작만 반복하던 문제 해결)

## 검증
- `docker compose config -q` 구문 검증 통과
- 변경 범위: `conf/docker/docker-compose.yaml` 1개 파일 (+13줄)

## 참고
- workflow-manager에 Jenkins healthy 의존이 추가되어 첫 기동은 Jenkins 부팅 완료까지 다소 지연될 수 있으나, 이전처럼 죽고 미복구되는 것보다 안정적입니다.

