### PR TITLE
fix(docker): influx 헬스체크 start_period 및 interval 조정

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -1359,7 +1359,10 @@ services:
       - ./container-volume/mc-observability/influxdb/influxdb_data:/var/lib/influxdb
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8086/health"]
-      <<: *default-health-check
+      interval: 10s
+      timeout: 10s
+      retries: 30
+      start_period: 120s
 
   mc-observability-influx-2-init-volumes:
     image: busybox:stable
@@ -1396,7 +1399,10 @@ services:
       - ./container-volume/mc-observability/influxdb/influxdb2_data:/var/lib/influxdb
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8086/health"]
-      <<: *default-health-check
+      interval: 10s
+      timeout: 10s
+      retries: 30
+      start_period: 120s
 
 ##### Remove annotations if data inquiry is required with chronograf during development phase #####
 #  mc-observability-chronograf:


### PR DESCRIPTION
## Summary

- `mc-observability-influx`, `mc-observability-influx-2` 헬스체크 타이밍 수정

기존 `*default-health-check` 설정:
- `start_period: 60s` + `interval: 1m` × `retries: 3` = **최대 4분** 허용

## 수정

다른 observability 서비스(grafana, rabbitmq, loki 등)와 동일한 기준으로 변경:
