### PR TITLE
feat: add e2e test spec suite

### DIFF
--- a/e2e/.env.external-domain.example
+++ b/e2e/.env.external-domain.example
@@ -1,0 +1,17 @@
+# 도메인 접속 설정
+# 복사 후 실제 값으로 교체: cp .env.external-domain.example .env.external-domain
+EXTERNAL_DOMAIN=<도메인>
+EXTERNAL_PORT=3001
+
+# 사용자 자격증명
+ADMIN_ID=<admin_아이디>
+ADMIN_PASSWORD=<admin_비밀번호>
+
+# mc-data-manager 직접 접근 (인증 불필요)
+DATA_MANAGER_BASE_URL=https://<도메인>:3300
+
+# mc-application-manager 직접 접근
+APP_MANAGER_BASE_URL=https://<도메인>:18084
+
+# mc-workflow-manager 직접 접근
+MC_WORKFLOW_MANAGER_BASE_URL=https://<도메인>:18183

--- a/e2e/.env.external-ip.example
+++ b/e2e/.env.external-ip.example
@@ -1,0 +1,16 @@
+# 외부 IP 접속 설정
+# 복사 후 실제 값으로 교체: cp .env.external-ip.example .env.external-ip
+EXTERNAL_IP=<서버_IP>
+EXTERNAL_PORT=3001
+EXTERNAL_HTTPS=false
+
+# 사용자 자격증명
+ADMIN_ID=<admin_아이디>
+ADMIN_PASSWORD=<admin_비밀번호>
+
+# 워크스페이스/프로젝트
+WORKSPACE_NAME=ws01
+PROJECT_NAME=default
+
+# 선택: 설정 시 MCI 목록 자동 발견 없이 이 MCI만 사용
+# MCI_ID=<mci_id>

--- a/e2e/.gitignore
+++ b/e2e/.gitignore
@@ -1,0 +1,10 @@
+# 환경별 설정 — 자격증명 포함, 절대 커밋 금지
+.env.*
+!.env.*.example
+
+# 테스트 결과 및 런타임 아티팩트
+test-results/
+node_modules/
+
+*.xlsx
+.DS_Store

--- a/e2e/MANUAL.md
+++ b/e2e/MANUAL.md
@@ -1,0 +1,615 @@
+# deploy/ 테스트 관리 매뉴얼
+
+> 관련 문서: [README.md](../README.md) · [definitions/GUIDE.md](../definitions/GUIDE.md) · [integration/SCENARIOS.md](../integration/SCENARIOS.md)
+
+이 문서는 `deploy/` 폴더의 TC·시나리오·파라미터 관리 방법을 처음 접하는 사람도 따라할 수 있도록 작성한 실무 안내서다.
+
+---
+
+## 전체 구조 한눈에 보기
+
+```
+deploy/
+├── MANUAL.md                        ← 이 문서
+│
+├── registry/                        ← TC·시나리오 전체 목록 (권위 있는 원천)
+│   ├── types.ts                     ← 공통 타입 정의
+│   ├── index.ts                     ← 전체 목록 통합 + 조회 유틸
+│   ├── tc/
+│   │   ├── iam.registry.ts          ← IAM 도메인 TC 76개
+│   │   ├── csp.registry.ts          ← CSP 도메인 TC 44개
+│   │   ├── infra.registry.ts        ← INFRA 도메인 TC 11개
+│   │   ├── sw.registry.ts           ← SW 도메인 TC 25개
+│   │   ├── data.registry.ts         ← DATA 도메인 TC 18개
+│   │   ├── obs.registry.ts          ← OBS 도메인 TC 6개
+│   │   ├── cost.registry.ts         ← COST 도메인 TC 5개
+│   │   ├── workflow.registry.ts     ← WORKFLOW 도메인 TC 5개
+│   │   └── workload.registry.ts     ← WORKLOAD 도메인 TC 3개
+│   └── scenario/
+│       └── scenarios.registry.ts    ← 시나리오 전체 목록
+│
+├── tc/                              ← TC spec 파일 (도메인 폴더 아래 배치)
+│   ├── iam/
+│   ├── infra/
+│   ├── sw/
+│   ├── data/
+│   ├── obs/
+│   ├── csp/
+│   ├── cost/
+│   ├── workflow/
+│   └── workload/
+│
+├── scenarios/                       ← 시나리오 spec 파일
+│
+└── params/                          ← 파라미터 관리
+    ├── types.ts
+    ├── loader.ts                    ← 4-layer merge 로더
+    ├── runtime/
+    │   ├── store.ts                 ← 런타임 IN/OUT 저장소
+    │   └── context.ts               ← 시나리오 실행 컨텍스트
+    ├── base/
+    │   ├── tc/{domain}/             ← TC별 기본 파라미터 (repo 커밋)
+    │   └── scenarios/               ← 시나리오별 파라미터 (repo 커밋)
+    └── env/                         ← 환경별 파라미터 (.gitignore 대상)
+        ├── local.params.ts          ← .gitignore (절대 커밋 금지)
+        └── local.params.ts_sample   ← 커밋됨 (구조 참조용, 실제 값 없음)
+```
+
+---
+
+## § 1. TC 등록 방법
+
+> TC 이름 형식: `TC-{DOMAIN}-{FEATURE}-{NN}[-{DESCRIPTION}]`
+> 예: `TC-IAM-AUTH-01`, `TC-INFRA-MCI-03`, `TC-APP-REP-02`
+
+### 1-1. TC spec 파일을 도메인 폴더에 배치한다
+
+TC 이름에 포함된 도메인이 배치 폴더를 결정한다.
+
+| TC 이름의 DOMAIN | 배치 폴더 |
+|---|---|
+| `TC-IAM-*` | `deploy/tc/iam/` |
+| `TC-INFRA-*` | `deploy/tc/infra/` |
+| `TC-APP-*` · `TC-SW-*` | `deploy/tc/sw/` |
+| `TC-DATA-*` | `deploy/tc/data/` |
+| `TC-OBS-*` | `deploy/tc/obs/` |
+| `TC-CSP-*` | `deploy/tc/csp/` |
+| `TC-COST-*` | `deploy/tc/cost/` |
+| `TC-WORKFLOW-*` · `TC-WF-*` | `deploy/tc/workflow/` |
+| `TC-WORKLOAD-*` · `TC-INFRA-K8S-*` | `deploy/tc/workload/` |
+
+**같은 기능이라도 variant(CSP·포맷·역할·아키텍처)가 다를 때**는 단일 spec 파일에서 파라미터로 분기하거나, 파일을 나눈다.
+
+- **파라미터로 분기** (권장): 파일은 하나, `TC_VARIANT` 환경변수로 실행 시 분기
+- **파일 분리**: variant당 spec 파일이 따로 있고 레지스트리에 `variants[]`로 등록
+
+### 1-2. TC params 파일을 만든다
+
+`deploy/params/base/tc/{domain}/` 아래에 `{TC-ID}.params.ts` 파일을 만든다.
+
+```typescript
+// deploy/params/base/tc/infra/TC-INFRA-SSH-KEY-02.params.ts
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:        'default',
+    sshKeyName:  'tc-sshkey-temp',
+    description: 'E2E temp SSH key',
+  },
+  // variant 없으면 variants 생략 가능
+} satisfies TCParams;
+```
+
+variant가 있는 경우 (CSP별, 포맷별 등):
+
+```typescript
+// deploy/params/base/tc/infra/TC-INFRA-MCI-03.params.ts
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:           'default',
+    mciName:        'tc-mci-temp',
+    connectionName: 'aws-ap-northeast-2',   // 기본값 (aws variant)
+    commonSpec:     'aws+ap-northeast-2+t2.small',
+  },
+  variants: {
+    aws:   { connectionName: 'aws-ap-northeast-2',  commonSpec: 'aws+ap-northeast-2+t2.small' },
+    azure: { connectionName: 'azure-koreacentral',   commonSpec: 'azure+koreacentral+Standard_B1s' },
+    gcp:   { connectionName: 'gcp-asia-northeast3',  commonSpec: 'gcp+asia-northeast3+n1-standard-1' },
+  },
+} satisfies TCParams;
+```
+
+### 1-3. 레지스트리에 TC를 등록한다
+
+해당 도메인의 `deploy/registry/tc/{domain}.registry.ts` 파일을 열고 배열에 항목을 추가한다.
+
+**단일 파일 TC** (variant 없음):
+```typescript
+{
+  id:       'TC-INFRA-SSH-KEY-02',
+  domain:   'infra',
+  feature:  'SSH-KEY',
+  title:    'SSH 키 생성',
+  status:   'ready',
+  channel:  'api+ui',
+  specFile: 'deploy/tc/infra/TC-INFRA-SSH-KEY-02.spec.ts',
+},
+```
+
+**variant 파일이 여럿인 TC** (TC-APP-REP-02 패턴):
+```typescript
+{
+  id:      'TC-APP-REP-02',
+  domain:  'sw',
+  feature: 'APP-REP',
+  title:   'Repository 신규 생성',
+  status:  'ready',
+  channel: 'api+ui',
+  variants: [
+    { key: 'api',       channel: 'api', specFile: 'deploy/tc/sw/TC-APP-REP-02-api.spec.ts' },
+    { key: 'ui:helm',   channel: 'ui',  specFile: 'deploy/tc/sw/TC-APP-REP-02-ui-helm.spec.ts' },
+    { key: 'ui:docker', channel: 'ui',  specFile: 'deploy/tc/sw/TC-APP-REP-02-ui-docker.spec.ts' },
+  ],
+},
+```
+
+**미구현·bypass TC**:
+```typescript
+{
+  id:      'TC-IAM-WORKSPACE-ASSIGN-01',
+  domain:  'iam',
+  feature: 'WORKSPACE',
+  title:   'Workspace Role 할당 (신규 API)',
+  status:  'bypass',
+  channel: 'api',
+  specFile: 'deploy/tc/iam/TC-IAM-WORKSPACE-ASSIGN-01.spec.ts',
+  bypass:  { reason: 'assignWorkspaceRole API 미구현', issue: 'ISSUE-009' },
+},
+```
+
+### 1-4. status 값 규칙
+
+| status | 의미 | spec 파일 있음? | 실행 가능? |
+|---|---|---|---|
+| `ready` | 구현 완료, 정상 실행 | ✓ | ✓ |
+| `wip` | 구현 중 | ✓ (부분) | △ 일부 |
+| `todo` | 구현 예정 | ✗ | ✗ |
+| `deprecated` | 사용 중단 | ✓ (구버전) | ✗ |
+
+---
+
+## § 2. 시나리오 등록 방법
+
+### 2-1. 시나리오 ID 규칙
+
+```
+{CODE}-{slug}
+예: C4-service-create-infra, WF-TC1-infra-create
+```
+
+| CODE | 범위 |
+|---|---|
+| C2 | IAM·사용자 관리 |
+| C3 | Workflow 기반 서비스 생성 |
+| C4 | 직접 서비스 생성 (no workflow) |
+| C5 | 서비스 운영·관리 |
+| C6 | 모니터링·로깅·트레이싱 |
+| C7 | K8s 클러스터 관리 |
+| C8 | 데이터 백업·복구·마이그레이션 |
+| C9 | 클라우드 비용 분석 |
+| WF | 워크플로우 기반 시나리오 |
+
+### 2-2. 시나리오를 레지스트리에 등록한다
+
+`deploy/registry/scenario/scenarios.registry.ts` 배열에 항목을 추가한다.
+
+```typescript
+{
+  id:          'C4-service-create-infra',
+  code:        'C4',
+  title:       '글로벌 멀티클라우드 MCI 직접 구성·배포',
+  description: '워크플로우 없이 MCI를 직접 생성하고 SW를 배포한다.',
+  status:      'ready',
+  actor:       'SRE 엔지니어',
+  specFile:    'deploy/scenarios/C4-service-create-infra.spec.ts',
+  steps: [
+    { order: 1, tcId: 'TC-CSP-CREDENTIAL-03', status: 'ready',  description: 'CSP 자격증명 등록' },
+    { order: 2, tcId: 'TC-CSP-CONNECTION-02', status: 'ready',  description: 'CSP 연결 생성' },
+    { order: 3, tcId: 'TC-INFRA-MCI-03',      status: 'ready',  description: 'MCI 생성', variant: 'aws' },
+    { order: 4, tcId: 'TC-APP-CAT-05',         status: 'bypass', description: 'App Catalog 등록',
+      bypass: { reason: 'Catalog API 불안정', issue: 'ISSUE-012' } },
+    { order: 5, tcId: 'TC-INFRA-MCI-05',      status: 'ready',  description: 'MCI 삭제 (정리)' },
+  ],
+},
+```
+
+### 2-3. 시나리오 status 규칙
+
+| status | 의미 |
+|---|---|
+| `ready` | 전체 스텝 실행 가능 |
+| `partial` | 일부 스텝 wip/todo 포함, 나머지 실행 가능 |
+| `wip` | 작업 중 |
+| `todo` | 구현 예정 |
+| `deprecated` | 더 이상 사용하지 않음 |
+
+---
+
+## § 3. 파라미터 관리
+
+파라미터는 4개 계층에서 병합된다. 낮은 계층이 기본값, 높은 계층이 덮어쓴다.
+
+```
+Layer 1: base TC params        ← deploy/params/base/tc/{domain}/{TC-ID}.params.ts
+    ↓
+Layer 2: env params            ← deploy/params/env/{TEST_ENV}.params.ts  (.gitignore)
+    ↓
+Layer 3: scenario override     ← deploy/params/base/scenarios/{scenario-id}.params.ts
+    ↓
+Layer 4: process.env           ← CI/CD 주입 (최우선)
+```
+
+### 3-1. 환경별 파라미터 파일 만들기 (로컬 전용)
+
+예시 파일을 복사하여 실제 값으로 편집한다:
+
+```bash
+cp deploy/params/env/local.params.ts_sample deploy/params/env/local.params.ts
+# local.params.ts 를 실제 값으로 편집 (절대 커밋 금지)
+```
+
+외부 IP 접근이 필요한 환경에서는 `.env.external-ip.example` 을 복사한 뒤 편집한다:
+
+```bash
+cp .env.external-ip.example .env.external-ip
+# 이후 .env.external-ip 파일을 편집 (실제 IP 값 입력)
+```
+
+> **NOTE**: `.env.external-ip` 는 `.gitignore` 에 등록되어 있으므로 git에 커밋되지 않는다.
+> repo에는 `.env.external-ip.example` (빈 구조 파일) 만 커밋된다.
+
+```typescript
+// deploy/params/env/local.params.ts   ← .gitignore 대상, 절대 커밋 금지
+import type { EnvParams } from '../types';
+
+export default {
+  env: 'local',
+  global: {
+    adminId:       'mcmp',
+    adminPassword: 'your_password_here',   // ← 여기에 실제 비밀번호
+    baseUrl:       'http://localhost:3000',
+  },
+  tc: {
+    'TC-CSP-CREDENTIAL-03': {
+      credentialKeyId:    'AKIA...',        // ← 실제 AWS Access Key ID
+      credentialKeyValue: '...',            // ← 실제 Secret Access Key
+    },
+    'TC-DATA-RDB-01': {
+      dbPassword: 'RealDb!Pass',
+    },
+  },
+  scenario: {},
+} satisfies EnvParams;
+```
+
+### 3-2. variant 지정 방법
+
+**TC 단독 실행 시** — `StandaloneContext` 에 variant 전달:
+```typescript
+// deploy/tc/infra/TC-INFRA-MCI-03.spec.ts
+import { StandaloneContext } from '../../params/runtime/context';
+
+const ctx = new StandaloneContext('TC-INFRA-MCI-03', process.env.TC_VARIANT);
+const p   = ctx.params;   // base + variant 병합 결과
+```
+
+```bash
+TC_VARIANT=azure npx playwright test deploy/tc/infra/TC-INFRA-MCI-03.spec.ts
+TC_VARIANT=ui:helm npx playwright test deploy/tc/sw/TC-APP-REP-02.spec.ts
+```
+
+**시나리오 params에서** — `ScenarioContext` 에 variant 전달 + `steps` 로 per-TC override:
+```typescript
+// deploy/tc/infra/TC-INFRA-MCI-03.spec.ts (시나리오에서 호출될 때)
+import { ScenarioContext } from '../../params/runtime/context';
+
+// SCENARIO_ID 는 시나리오 spec 파일이 process.env 로 전달
+const ctx = new ScenarioContext(process.env.SCENARIO_ID!, 'TC-INFRA-MCI-03', 'aws');
+const p   = ctx.params;   // base + variant + scenario steps 병합
+```
+
+```typescript
+// deploy/params/base/scenarios/C4-001.params.ts
+import type { ScenarioStaticParams } from '../../types';
+
+export default {
+  global: { nsId: 'default' },
+  steps: {
+    'TC-INFRA-MCI-03': {
+      mciName:        'C4-001-mci',
+      connectionName: 'aws-ap-northeast-2',   // variant 없이 직접 override
+    },
+    'TC-APP-DEP-01': {
+      appName: 'C4-001-nginx',
+    },
+  },
+} satisfies ScenarioStaticParams;
+```
+
+---
+
+## § 4. 런타임 파라미터 (IN/OUT)
+
+시나리오 내에서 **앞 TC가 만든 ID나 이름을 뒤 TC가 사용**해야 할 때 런타임 파라미터를 사용한다.
+
+> **Static params** (§ 3)과의 차이:
+> - Static → 실행 **전** 결정된 값 (파일에서 읽음)
+> - Runtime → 실행 **중** 생성된 값 (이전 TC가 저장, 다음 TC가 읽음)
+
+### 4-1. TC 종료 시 OUT param 저장하기
+
+```typescript
+// deploy/tc/infra/TC-INFRA-MCI-03.spec.ts
+import { ScenarioContext } from '../../params/runtime/context';
+
+// 시나리오에서 호출될 때만 store 활성화
+const ctx = process.env.SCENARIO_ID
+  ? new ScenarioContext(process.env.SCENARIO_ID, 'TC-INFRA-MCI-03', process.env.TC_VARIANT)
+  : null;
+
+let createdMciId: string;
+let createdMciName: string;
+
+test('MCI 생성', async ({ request }) => {
+  // ... MCI 생성 로직 ...
+  createdMciId   = body.responseData.id;
+  createdMciName = ctx?.params.mciName as string ?? 'tc-mci-temp';
+});
+
+// ── TC 종료 시 OUT param 저장 ──────────────────────────────────
+test.afterAll(() => {
+  if (!ctx) return;
+  ctx.store.set('mciId',   createdMciId);
+  ctx.store.set('mciName', createdMciName);
+  ctx.store.set('nsId',    ctx.params.nsId ?? 'default');
+});
+```
+
+### 4-2. 다음 TC에서 IN param 읽기
+
+```typescript
+// deploy/tc/workload/TC-WORKLOAD-MCI-01.spec.ts
+import { ScenarioContext } from '../../params/runtime/context';
+
+const ctx = process.env.SCENARIO_ID
+  ? new ScenarioContext(process.env.SCENARIO_ID, 'TC-WORKLOAD-MCI-01')
+  : null;
+
+let mciId: string;
+let mciName: string;
+
+test.beforeAll(() => {
+  if (!ctx) {
+    // 단독 실행 시: env fallback
+    mciId   = process.env.MCI_ID   ?? 'fallback-mci';
+    mciName = process.env.MCI_NAME ?? 'fallback-mci';
+    return;
+  }
+  // 시나리오 실행 시: 이전 TC(TC-INFRA-MCI-03)가 저장한 값을 읽음
+  mciId   = ctx.store.require<string>('mciId');
+  mciName = ctx.store.require<string>('mciName');
+});
+
+test('터미널 접속', async ({ request }) => {
+  // mciId, mciName 사용 ...
+});
+```
+
+> **NOTE**: 선행 TC가 실패하면 `store.set()`이 호출되지 않으므로,
+> 후속 TC의 `store.require()` 가 자동으로 에러를 throw한다.
+> bypass 또는 cascade 별도 처리 불필요.
+
+### 4-3. 콘솔에서 흐름 확인하기
+
+시나리오 마지막에 `ctx.store.dump()`를 호출하면 스토어 내용이 출력된다:
+
+```
+── ScenarioRuntimeStore ──────────────────────
+  params  : {
+    "mciId": "mci-abc123",
+    "mciName": "C4-001-mci",
+    "nsId": "default"
+  }
+────────────────────────────────────────
+```
+
+---
+
+## § 5. 실행 방법
+
+### 5-1. TC 단독 실행
+
+```bash
+# 기본 (base params)
+npx playwright test deploy/tc/infra/TC-INFRA-MCI-03.spec.ts
+
+# CSP variant 지정
+TC_VARIANT=azure npx playwright test deploy/tc/infra/TC-INFRA-MCI-03.spec.ts
+
+# 민감값 주입 (PW_* 접두사 → loader가 접두사 제거 후 params에 주입)
+PW_adminPassword=mypassword TC_VARIANT=aws npx playwright test deploy/tc/infra/TC-INFRA-MCI-03.spec.ts
+
+# 여러 PW_* 조합
+PW_adminId=mcmp PW_adminPassword=secret TC_VARIANT=gcp \
+  npx playwright test deploy/tc/infra/TC-INFRA-MCI-03.spec.ts
+```
+
+### 5-2. 시나리오 실행
+
+```bash
+# 시나리오 전체 실행 (SCENARIO_ID 필수 — 런타임 store 활성화)
+SCENARIO_ID=C4-001 \
+npx playwright test deploy/scenarios/C4-service-create-infra.spec.ts
+
+# 런타임 store 를 초기화하고 재실행 (이전 상태 제거)
+rm -f /tmp/scenario-runtime-C4-001.json
+SCENARIO_ID=C4-001 npx playwright test deploy/scenarios/C4-service-create-infra.spec.ts
+```
+
+### 5-3. 채널별 실행 (API만 또는 UI만)
+
+```bash
+# API 테스트만
+npx playwright test deploy/tc/ --grep "API:"
+
+# UI 테스트만 (브라우저 실행)
+npx playwright test deploy/tc/ --grep "UI:"
+```
+
+### 5-4. 레지스트리 조회 스크립트
+
+```bash
+# 전체 TC 통계 출력
+npx ts-node -e "
+  import { summary } from './deploy/registry';
+  console.log(JSON.stringify(summary(), null, 2));
+"
+
+# 특정 도메인 TC 목록 출력
+npx ts-node -e "
+  import { listByDomain } from './deploy/registry';
+  listByDomain('infra').forEach(tc => console.log(tc.id, tc.status, tc.title));
+"
+
+# bypass 상태인 TC 목록 확인
+npx ts-node -e "
+  import { listByStatus } from './deploy/registry';
+  listByStatus('bypass').forEach(tc =>
+    console.log(tc.id, tc.bypass?.reason)
+  );
+"
+```
+
+---
+
+## § 6. 자주 묻는 질문 (FAQ)
+
+**Q. 새 TC를 추가할 때 어디서부터 시작해야 하나?**
+
+1. `deploy/tc/{domain}/` 에 spec 파일 생성
+2. `deploy/params/base/tc/{domain}/{TC-ID}.params.ts` 생성
+3. `deploy/registry/tc/{domain}.registry.ts` 에 항목 추가 (status: `wip`)
+4. 구현 완료 후 status를 `ready`로 변경
+
+---
+
+**Q. 미구현·미지원 TC는 어떻게 처리하나?**
+
+- 레지스트리에 status를 `'wip'` 또는 `'todo'`로 설정
+- 시나리오에서 해당 스텝도 동일 status로 표기
+- 실행 시 스텝이 `throw new Error()`를 발생시키면 FAIL 처리됨
+- 선행 TC 실패 시 후속 TC의 `store.require()`가 자동으로 에러를 throw함
+
+---
+
+**Q. 같은 TC를 시나리오마다 다른 파라미터로 실행하려면?**
+
+`deploy/params/base/scenarios/{scenario-id}.params.ts` 의 `steps` 에 해당 TC 항목을 추가한다.
+
+```typescript
+// deploy/params/base/scenarios/C4-002.params.ts
+export default {
+  global: { nsId: 'default' },
+  steps: {
+    'TC-INFRA-MCI-03': {
+      mciName:        'C4-002-mci-azure',
+      connectionName: 'azure-koreacentral',
+      commonSpec:     'azure+koreacentral+Standard_B1s',
+    },
+  },
+} satisfies ScenarioStaticParams;
+```
+
+TC spec 파일에서는 `ScenarioContext` 에 variant 를 직접 전달하거나, `steps` override 값을 사용한다.
+
+---
+
+**Q. TC-APP-REP-02처럼 variant별 파일이 나뉜 경우 레지스트리에 어떻게 등록하나?**
+
+`specFile` 대신 `variants[]`를 사용한다.
+
+```typescript
+{
+  id: 'TC-APP-REP-02',
+  ...
+  variants: [
+    { key: 'api',       specFile: 'deploy/tc/sw/TC-APP-REP-02-api.spec.ts' },
+    { key: 'ui:helm',   specFile: 'deploy/tc/sw/TC-APP-REP-02-ui-helm.spec.ts' },
+    { key: 'ui:docker', specFile: 'deploy/tc/sw/TC-APP-REP-02-ui-docker.spec.ts' },
+  ],
+}
+```
+
+실행 시: `TC_VARIANT=api npx playwright test deploy/tc/sw/TC-APP-REP-02-api.spec.ts`
+
+---
+
+**Q. 환경별 민감한 파라미터(비밀번호·IP)는 어디에 두나?**
+
+`deploy/params/env/local.params.ts` 에 두고, 이 파일은 `.gitignore`에 포함되어 있다. repo에는 `deploy/params/env/local.params.ts_sample` 만 커밋된다. CI/CD 환경에서는 `PW_*` 환경변수로 직접 주입한다.
+
+---
+
+**Q. TC 파일 이름에 DOMAIN이 APP-*인데 폴더는 sw/인 이유는?**
+
+기존 코드베이스에서 Application Manager 서비스의 TC는 `TC-APP-*` 으로 명명되었지만 폴더는 `sw/`로 통일되어 있다. 로더(`params/loader.ts`)의 `DOMAIN_MAP`에서 `app → sw`로 매핑하여 처리한다.
+
+---
+
+## 빠른 참조
+
+### TC status 한눈에 보기
+
+| status | 레지스트리 | spec 파일 | 시나리오 처리 |
+|---|---|---|---|
+| `ready` | 등록 완료 | 완전 구현 | 정상 실행 |
+| `wip` | 등록 완료 | 부분 구현 | 실행 시 일부 실패 가능 |
+| `todo` | 등록 완료 | 없음 | 실행 시 FAIL |
+| `deprecated` | 등록 유지 (하위 호환) | 구버전 | 사용 금지 |
+
+### 환경변수 한눈에 보기
+
+| 변수 | 기본값 | 설명 |
+|---|---|---|
+| `TC_VARIANT` | *(없음)* | variant 선택 (`aws` · `azure` · `ui:helm` · `ui:docker` …) |
+| `SCENARIO_ID` | *(없음)* | 런타임 store 활성화 + 시나리오 파라미터 로드 |
+| `PW_adminId` | (base params) | 관리자 계정 ID (PW_ 접두사 → params 에 주입) |
+| `PW_adminPassword` | (base params) | 관리자 비밀번호 |
+| `PW_credentialKeyId` | (base params) | CSP Credential Key ID |
+| `PW_credentialKeyValue` | (base params) | CSP Credential Key Value |
+| `PW_{ANY_KEY}` | (base params) | PW_ 접두사 키는 모두 params 에 주입 (접두사 제거됨) |
+
+> `PW_*` 환경변수는 4-레이어 중 최고 우선순위. `env/local.params.ts` 보다도 우선한다.
+> CI/CD 파이프라인에서는 시크릿을 `PW_adminPassword=***` 형태로 주입한다.
+
+### 도메인 → 레지스트리 파일 매핑
+
+| 도메인 | 레지스트리 파일 | TC 수 |
+|---|---|---|
+| iam | `registry/tc/iam.registry.ts` | 76 |
+| csp | `registry/tc/csp.registry.ts` | 44 |
+| infra | `registry/tc/infra.registry.ts` | 11 |
+| sw | `registry/tc/sw.registry.ts` | 25 |
+| data | `registry/tc/data.registry.ts` | 18 |
+| obs | `registry/tc/obs.registry.ts` | 6 |
+| cost | `registry/tc/cost.registry.ts` | 5 |
+| workflow | `registry/tc/workflow.registry.ts` | 5 |
+| workload | `registry/tc/workload.registry.ts` | 3 |
+| **합계** | | **193** |
+
+---
+
+> 최초 작성: 2026-06-19 · 관리: QA 팀

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,145 @@
+# MCMP E2E 테스트 스펙
+
+MCMP(Multi-Cloud Management Platform) 기능 검증용 E2E 테스트 스펙 모음입니다.
+
+이 폴더는 **테스트 스펙만** 포함합니다.  
+실행 환경(Playwright, Node.js 패키지)은 이 폴더 밖에 별도로 설치합니다.
+
+---
+
+## Prerequisites
+
+- Node.js 18 이상
+- npm
+
+---
+
+## Installation
+
+이 폴더 밖의 임의 위치에서 Playwright를 설치합니다.
+
+```bash
+mkdir playwright-runner && cd playwright-runner
+npm init -y
+npm install @playwright/test ts-node typescript dotenv
+npx playwright install --with-deps chromium
+```
+
+---
+
+## Configuration
+
+이 폴더(`e2e/`) 안에서 접속 환경에 맞는 `.env` 파일을 생성합니다.
+
+### external-ip (IP 직접 접속)
+
+```bash
+cp .env.external-ip.example .env.external-ip
+```
+
+| 변수 | 설명 | 예시 |
+|------|------|------|
+| `EXTERNAL_IP` | 서버 IP 주소 | `192.168.1.100` |
+| `EXTERNAL_PORT` | 포트 번호 | `3001` |
+| `EXTERNAL_HTTPS` | HTTPS 사용 여부 | `false` |
+| `ADMIN_ID` | 관리자 계정 ID | `admin` |
+| `ADMIN_PASSWORD` | 관리자 계정 비밀번호 | `password` |
+| `WORKSPACE_NAME` | 기본 워크스페이스 이름 | `ws01` |
+| `PROJECT_NAME` | 기본 프로젝트 이름 | `default` |
+| `MCI_ID` | (선택) 고정 MCI ID | `mci-abc123` |
+
+### external-domain (도메인 접속)
+
+```bash
+cp .env.external-domain.example .env.external-domain
+# 값 수정
+```
+
+---
+
+## Run
+
+Playwright가 설치된 위치(playwright-runner/)에서 실행합니다.  
+`--config` 로 이 폴더의 설정 파일을, 마지막 인자로 실행할 스펙 경로를 지정합니다.
+
+```bash
+E2E=/path/to/mc-admin-cli/e2e
+```
+
+### TC 실행
+
+```bash
+# 특정 TC
+ACCESS_MODE=external-ip npx playwright test \
+  --config=$E2E/playwright.config.ts \
+  $E2E/tc/infra/TC-INFRA-DEPLOY-06.spec.ts
+
+# TC 도메인 디렉토리 전체
+ACCESS_MODE=external-ip npx playwright test \
+  --config=$E2E/playwright.config.ts \
+  $E2E/tc/sw/
+
+# CSP 변형(variant) 지정
+ACCESS_MODE=external-ip TC_VARIANT=aws npx playwright test \
+  --config=$E2E/playwright.config.ts \
+  $E2E/tc/infra/TC-INFRA-DEPLOY-05.spec.ts
+```
+
+### 시나리오 실행
+
+```bash
+# 특정 시나리오 디렉토리 전체
+ACCESS_MODE=external-ip npx playwright test \
+  --config=$E2E/playwright.config.ts \
+  $E2E/scenarios/C4-svc-direct/
+
+# 특정 시나리오 단계 파일만
+ACCESS_MODE=external-ip npx playwright test \
+  --config=$E2E/playwright.config.ts \
+  $E2E/scenarios/C2-admin-setup/C2-01-onboarding-mc-iam-manager-user-create.spec.ts
+
+# external-domain 기준 실행
+ACCESS_MODE=external-domain npx playwright test \
+  --config=$E2E/playwright.config.ts \
+  $E2E/scenarios/C3-svc-wf/
+```
+
+---
+
+## Folder Structure
+
+```
+e2e/
+├── tc/                    # 도메인별 개별 TC 스펙 파일
+│   ├── csp/
+│   ├── infra/
+│   ├── sw/
+│   ├── data/
+│   └── workflow/
+│
+├── scenarios/             # 통합 흐름 시나리오 스펙 파일
+│   ├── C2-admin-setup/    # IAM 온보딩
+│   ├── C3-svc-wf/         # 워크플로우 기반 서비스 생성
+│   ├── C4-svc-direct/     # 직접 서비스 생성
+│   ├── C5-svc-mgmt1/      # 서비스 운영 관리
+│   ├── C6-monitoring/     # 모니터링/옵저버빌리티
+│   ├── C7-svc-mgmt2/      # 인프라 라이프사이클
+│   ├── C8-data/           # 데이터 백업/복원/마이그레이션
+│   ├── C9-cost/           # 클라우드 비용 분석
+│   └── C10-cleanup/       # 인프라 정리
+│
+├── registry/              # TC·시나리오 카탈로그 (단일 진실 공급원)
+├── params/                # 파라미터 시스템 (4-layer merge)
+├── shared/                # 공통 유틸리티 (API routes, page URLs)
+│
+├── playwright.config.ts   # Playwright 설정 + .env 로딩
+├── tsconfig.json
+├── .env.external-ip.example
+└── .env.external-domain.example
+```
+
+---
+
+## Reference
+
+TC 등록 방법, 파라미터 시스템, 레지스트리 쿼리 등 상세 내용은 [MANUAL.md](MANUAL.md)를 참고하세요.

--- a/e2e/params/base/scenarios/C10-02-wf-k8s-delete.params.ts
+++ b/e2e/params/base/scenarios/C10-02-wf-k8s-delete.params.ts
@@ -1,0 +1,30 @@
+/**
+ * deploy/params/base/scenarios/C10-02-wf-k8s-delete.params.ts
+ *
+ * [C10] 워크플로우로 K8s 삭제
+ *
+ * 워크플로우 쌍:
+ *   생성: k8s-mariadb-backup-import-data-init  (C3-06-wf-run-k8s-create 계획)
+ *   삭제: k8s-mariadb-data-init-cleanup        ← 기본값 (단일 CSP 클러스터 삭제)
+ *
+ *   생성: multi-csp-k8s-cluster-deploy         (C3-07-wf-run-k8s-create-sw 계획)
+ *   삭제: multi-csp-k8s-cluster-cleanup        ← PW_workflowName 으로 오버라이드
+ *
+ * 실행 (단일 CSP 삭제 — 기본):
+ *   npx playwright test deploy/scenarios/C10-cleanup/C10-02-wf-k8s-delete.spec.ts \
+ *     --config deploy/playwright.config.ts --project=session-e-cleanup
+ *
+ * 실행 (다중 CSP 삭제 — override):
+ *   PW_workflowName=multi-csp-k8s-cluster-cleanup \
+ *   npx playwright test deploy/scenarios/C10-cleanup/C10-02-wf-k8s-delete.spec.ts \
+ *     --config deploy/playwright.config.ts --project=session-e-cleanup
+ */
+import type { ScenarioStaticParams } from '../../types';
+
+export default {
+  global: {
+    // 기본: k8s-mariadb-backup-import-data-init 의 삭제 워크플로우
+    workflowName:        'k8s-mariadb-data-init-cleanup',
+    workflowDescription: '단일 CSP K8s 클러스터 삭제',
+  },
+} satisfies ScenarioStaticParams;

--- a/e2e/params/base/scenarios/C2-001.params.ts
+++ b/e2e/params/base/scenarios/C2-001.params.ts
@@ -1,0 +1,33 @@
+/**
+ * deploy/params/base/scenarios/C2-001.params.ts
+ * C2-001: IAM 기본 시나리오 — 사용자 생성 ~ 워크스페이스 설정
+ *
+ * 런타임 IN/OUT 흐름:
+ *   TC-IAM-USER-LIFECYCLE-01 → store.set('newUserId', ...)
+ *   TC-IAM-WS-02      → store.set('workspaceId', ...)
+ *   TC-IAM-UG-02      → store.require('workspaceId'), store.require('newUserId')
+ */
+import type { ScenarioStaticParams } from '../../types';
+
+export default {
+  global: {
+    // C2-001 전체에서 사용하는 공통 접두사
+    resourcePrefix: 'c2-001',
+  },
+  steps: {
+    'TC-IAM-USER-LIFECYCLE-01': {
+      newUserId:       'c2-001-user',
+      newUserPassword: 'C2Test!2024',
+      newUserName:     'C2-001 테스트 사용자',
+      newUserEmail:    'c2-001-user@example.com',
+    },
+    'TC-IAM-WS-02': {
+      workspaceName:        'c2-001-workspace',
+      workspaceDescription: 'C2-001 시나리오 테스트 워크스페이스',
+    },
+    'TC-IAM-UG-02': {
+      groupName:        'c2-001-group',
+      groupDescription: 'C2-001 시나리오 테스트 그룹',
+    },
+  },
+} satisfies ScenarioStaticParams;

--- a/e2e/params/base/scenarios/C3-mci-multi-csp.params.ts
+++ b/e2e/params/base/scenarios/C3-mci-multi-csp.params.ts
@@ -1,0 +1,14 @@
+/**
+ * deploy/params/base/scenarios/C3-mci-multi-csp.params.ts
+ *
+ * [C3] Multi-CSP MCI — 여러 CSP VM을 단일 MCI로 통합 생성
+ * 대응 삭제 시나리오: C3-mci-multi-csp-delete
+ */
+import type { ScenarioStaticParams } from '../../types';
+
+export default {
+  global: {
+    mciName: 'mci-multi',
+    vmName:  'ing-multi',
+  },
+} satisfies ScenarioStaticParams;

--- a/e2e/params/base/scenarios/C3-service-create-infra.params.ts
+++ b/e2e/params/base/scenarios/C3-service-create-infra.params.ts
@@ -1,0 +1,50 @@
+/**
+ * deploy/params/base/scenarios/C3-service-create-infra.params.ts
+ * C3-service-create-infra: MCI 직접 생성 → SW 배포 → 정리
+ *
+ * Spec 검색:
+ *   - Priority option: seoul
+ *   - vCPU max: 4, Cost max: 1
+ *
+ * MCI 중복:
+ *   - mciDuplicateMode: rename|duplicate (기본 rename)
+ */
+import type { ScenarioStaticParams } from '../../types';
+
+export default {
+  global: {
+    nsId: 'default',
+    mciName:        'e2e-mci-c3',
+    specSearch: {
+      priorityRegion: 'seoul',
+      maxCpu:         4,
+      maxCost:        1,
+      notFoundMode:   'fail',
+      specKeywords:   ['t3a.small', 'c4.large', 'small'],
+    },
+    mciDuplicateMode: 'rename',
+  },
+  steps: {
+    'TC-INFRA-DEPLOY-05': {
+      mciName:        'c3-mci-temp',
+      connectionName: 'aws-ap-northeast-2',
+      commonSpec:     'aws+ap-northeast-2+t2.small',
+      specSearch: {
+        priorityRegion: 'seoul',
+        maxCpu:         4,
+        maxCost:        1,
+        notFoundMode:   'fail',
+      },
+    },
+    'TC-APP-DEP-01': {
+      appName:     'c3-nginx',
+      catalogName: 'nginx',
+      version:     'latest',
+      deployType:  'standalone',
+    },
+    'TC-OBS-METRIC-01': {
+      metricType: 'cpu',
+      periodSec:  60,
+    },
+  },
+} satisfies ScenarioStaticParams;

--- a/e2e/params/base/scenarios/C3-wf-infra-create-sw.params.ts
+++ b/e2e/params/base/scenarios/C3-wf-infra-create-sw.params.ts
@@ -1,0 +1,23 @@
+/**
+ * deploy/params/base/scenarios/C3-wf-infra-create-sw.params.ts
+ *
+ * [C3] 워크플로우로 인프라 생성 + SW 설치
+ * 실행 워크플로우: vm-mariadb-backup-import-data-init  (단일 CSP 인프라 배포 + mariadb 설치)
+ *
+ * 대응 삭제 시나리오: C3-wf-infra-delete (single) → vm-mariadb-data-init-cleanup
+ *   npx playwright test deploy/scenarios/C3-wf-infra-delete.spec.ts \
+ *     --config deploy/playwright.config.ts
+ *   (C3-wf-infra-delete.params.ts 의 workflowName 이 vm-mariadb-data-init-cleanup 으로 설정됨)
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C3-wf-infra-create-sw.spec.ts \
+ *     --config deploy/playwright.config.ts
+ */
+import type { ScenarioStaticParams } from '../../types';
+
+export default {
+  global: {
+    workflowName:        'vm-mariadb-backup-import-data-init',
+    workflowDescription: '단일 CSP 인프라 배포 + mariadb 설치',
+  },
+} satisfies ScenarioStaticParams;

--- a/e2e/params/base/scenarios/C3-wf-infra-create.params.ts
+++ b/e2e/params/base/scenarios/C3-wf-infra-create.params.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/params/base/scenarios/C3-wf-infra-create.params.ts
+ *
+ * [C3] 워크플로우로 인프라 생성
+ * 실행 워크플로우: multi-csp-vm-deploy  (다중 CSP 인프라 배포)
+ *
+ * 대응 삭제 시나리오: C3-wf-infra-delete → multi-csp-vm-cleanup
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C3-wf-infra-create.spec.ts \
+ *     --config deploy/playwright.config.ts
+ */
+import type { ScenarioStaticParams } from '../../types';
+
+export default {
+  global: {
+    workflowName:        'multi-csp-vm-deploy',
+    workflowDescription: '다중 CSP 인프라 배포 (8종)',
+  },
+} satisfies ScenarioStaticParams;

--- a/e2e/params/base/scenarios/C3-wf-infra-delete.params.ts
+++ b/e2e/params/base/scenarios/C3-wf-infra-delete.params.ts
@@ -1,0 +1,30 @@
+/**
+ * deploy/params/base/scenarios/C3-wf-infra-delete.params.ts
+ *
+ * [C3] 워크플로우로 인프라 삭제
+ *
+ * 워크플로우 쌍:
+ *   생성: vm-mariadb-backup-import-data-init  (C3-wf-infra-create-sw)
+ *   삭제: vm-mariadb-data-init-cleanup        ← 기본값 (단일 CSP 삭제)
+ *
+ *   생성: multi-csp-vm-deploy                (C3-wf-infra-create)
+ *   삭제: multi-csp-vm-cleanup               ← PW_workflowName 으로 오버라이드
+ *
+ * 실행 (단일 CSP 삭제 — 기본):
+ *   npx playwright test deploy/scenarios/C3-wf-infra-delete.spec.ts \
+ *     --config deploy/playwright.config.ts
+ *
+ * 실행 (다중 CSP 삭제 — override):
+ *   PW_workflowName=multi-csp-vm-cleanup \
+ *   npx playwright test deploy/scenarios/C3-wf-infra-delete.spec.ts \
+ *     --config deploy/playwright.config.ts
+ */
+import type { ScenarioStaticParams } from '../../types';
+
+export default {
+  global: {
+    // 기본: C3-wf-infra-create-sw (vm-mariadb-backup-import-data-init) 의 삭제 워크플로우
+    workflowName:        'vm-mariadb-data-init-cleanup',
+    workflowDescription: '단일 CSP 인프라 삭제',
+  },
+} satisfies ScenarioStaticParams;

--- a/e2e/params/base/scenarios/C3-wf-k8s-create-sw.params.ts
+++ b/e2e/params/base/scenarios/C3-wf-k8s-create-sw.params.ts
@@ -1,0 +1,23 @@
+/**
+ * deploy/params/base/scenarios/C3-wf-k8s-create-sw.params.ts
+ *
+ * [C3] 워크플로우로 K8s 생성 + SW 설치
+ * 실행 워크플로우: k8s-mariadb-backup-import-data-init  (단일 CSP 클러스터 배포 + mariadb Helm 설치)
+ *
+ * 대응 삭제 시나리오: C3-wf-k8s-delete (single) → k8s-mariadb-data-init-cleanup
+ *   npx playwright test deploy/scenarios/C3-wf-k8s-delete.spec.ts \
+ *     --config deploy/playwright.config.ts
+ *   (C3-wf-k8s-delete.params.ts 의 workflowName 이 k8s-mariadb-data-init-cleanup 으로 설정됨)
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C3-wf-k8s-create-sw.spec.ts \
+ *     --config deploy/playwright.config.ts
+ */
+import type { ScenarioStaticParams } from '../../types';
+
+export default {
+  global: {
+    workflowName:        'k8s-mariadb-backup-import-data-init',
+    workflowDescription: '단일 CSP 클러스터 배포 + mariadb Helm 설치',
+  },
+} satisfies ScenarioStaticParams;

--- a/e2e/params/base/scenarios/C3-wf-k8s-create.params.ts
+++ b/e2e/params/base/scenarios/C3-wf-k8s-create.params.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/params/base/scenarios/C3-wf-k8s-create.params.ts
+ *
+ * [C3] 워크플로우로 K8s 생성
+ * 실행 워크플로우: multi-csp-k8s-cluster-deploy  (다중 CSP 클러스터 배포)
+ *
+ * 대응 삭제 시나리오: C3-wf-k8s-delete → multi-csp-k8s-cluster-cleanup
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C3-wf-k8s-create.spec.ts \
+ *     --config deploy/playwright.config.ts
+ */
+import type { ScenarioStaticParams } from '../../types';
+
+export default {
+  global: {
+    workflowName:        'multi-csp-k8s-cluster-deploy',
+    workflowDescription: '다중 CSP 클러스터 배포',
+  },
+} satisfies ScenarioStaticParams;

--- a/e2e/params/base/scenarios/C3-wf-k8s-delete.params.ts
+++ b/e2e/params/base/scenarios/C3-wf-k8s-delete.params.ts
@@ -1,0 +1,30 @@
+/**
+ * deploy/params/base/scenarios/C3-wf-k8s-delete.params.ts
+ *
+ * [C3] 워크플로우로 K8s 삭제
+ *
+ * 워크플로우 쌍:
+ *   생성: k8s-mariadb-backup-import-data-init  (C3-wf-k8s-create-sw)
+ *   삭제: k8s-mariadb-data-init-cleanup        ← 기본값 (단일 CSP 삭제)
+ *
+ *   생성: multi-csp-k8s-cluster-deploy         (C3-wf-k8s-create)
+ *   삭제: multi-csp-k8s-cluster-cleanup        ← PW_workflowName 으로 오버라이드
+ *
+ * 실행 (단일 CSP 삭제 — 기본):
+ *   npx playwright test deploy/scenarios/C3-wf-k8s-delete.spec.ts \
+ *     --config deploy/playwright.config.ts
+ *
+ * 실행 (다중 CSP 삭제 — override):
+ *   PW_workflowName=multi-csp-k8s-cluster-cleanup \
+ *   npx playwright test deploy/scenarios/C3-wf-k8s-delete.spec.ts \
+ *     --config deploy/playwright.config.ts
+ */
+import type { ScenarioStaticParams } from '../../types';
+
+export default {
+  global: {
+    // 기본: C3-wf-k8s-create-sw (k8s-mariadb-backup-import-data-init) 의 삭제 워크플로우
+    workflowName:        'k8s-mariadb-data-init-cleanup',
+    workflowDescription: '단일 CSP 클러스터 삭제',
+  },
+} satisfies ScenarioStaticParams;

--- a/e2e/params/base/scenarios/C3-wf-run-predefined.params.ts
+++ b/e2e/params/base/scenarios/C3-wf-run-predefined.params.ts
@@ -1,0 +1,32 @@
+/**
+ * deploy/params/base/scenarios/C3-wf-run-predefined.params.ts
+ *
+ * [C3] 사전 정의 워크플로우 실행
+ * 이미 등록된 워크플로우를 이름으로 조회·실행한다.
+ *
+ * 8개 사전 정의 워크플로우 (PW_workflowName 으로 선택):
+ *   vm-mariadb-backup-import-data-init   — 단일 CSP VM + SW 생성 (기본값)
+ *   vm-mariadb-data-init-cleanup         — 단일 CSP VM + SW 삭제
+ *   multi-csp-vm-deploy                  — 다중 CSP VM 생성
+ *   multi-csp-vm-cleanup                 — 다중 CSP VM 삭제
+ *   k8s-mariadb-backup-import-data-init  — 단일 CSP K8s + SW 생성
+ *   k8s-mariadb-data-init-cleanup        — 단일 CSP K8s + SW 삭제
+ *   multi-csp-k8s-cluster-deploy         — 다중 CSP K8s 생성
+ *   multi-csp-k8s-cluster-cleanup        — 다중 CSP K8s 삭제
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C3-wf-run-predefined.spec.ts \
+ *     --config deploy/playwright.config.ts
+ *
+ *   PW_workflowName=multi-csp-vm-deploy \
+ *   npx playwright test deploy/scenarios/C3-wf-run-predefined.spec.ts \
+ *     --config deploy/playwright.config.ts
+ */
+import type { ScenarioStaticParams } from '../../types';
+
+export default {
+  global: {
+    workflowName:        'vm-mariadb-backup-import-data-init',
+    workflowDescription: '단일 CSP VM + SW 생성',
+  },
+} satisfies ScenarioStaticParams;

--- a/e2e/params/base/scenarios/C8-001.params.ts
+++ b/e2e/params/base/scenarios/C8-001.params.ts
@@ -1,0 +1,37 @@
+/**
+ * deploy/params/base/scenarios/C8-001.params.ts
+ * C8-001: 데이터 백업·복구·마이그레이션 시나리오 (mc-data-manager)
+ */
+import type { ScenarioStaticParams } from '../../types';
+import { AWS_RDB, ALIBABA_RDB, ALIBABA_NRDB, DATA_MANAGER_DEFAULTS } from '../tc/data/connections';
+
+export default {
+  global: {
+    dataManagerBaseUrl: DATA_MANAGER_DEFAULTS.dataManagerBaseUrl,
+  },
+  steps: {
+    'TC-DATA-OBJ-MIG-01': {
+      dataManagerBaseUrl: DATA_MANAGER_DEFAULTS.dataManagerBaseUrl,
+    },
+    'TC-DATA-OBJ-BAK-01': {
+      dataManagerBaseUrl: DATA_MANAGER_DEFAULTS.dataManagerBaseUrl,
+    },
+    'TC-DATA-RDB-MIG-01': {
+      sourcePoint: AWS_RDB,
+      targetPoint: ALIBABA_RDB,
+    },
+    'TC-DATA-RDB-BAK-01': {
+      sourcePoint: AWS_RDB,
+    },
+    'TC-DATA-NORDB-MIG-01': {
+      ...ALIBABA_NRDB,
+      mongoHost:     ALIBABA_NRDB.host,
+      mongoPort:     ALIBABA_NRDB.port,
+      mongoUser:     ALIBABA_NRDB.username,
+      mongoPassword: ALIBABA_NRDB.password,
+    },
+    'TC-DATA-NORDB-BAK-01': {
+      ...ALIBABA_NRDB,
+    },
+  },
+} satisfies ScenarioStaticParams;

--- a/e2e/params/base/tc/cost/TC-COST-BILL-01.params.ts
+++ b/e2e/params/base/tc/cost/TC-COST-BILL-01.params.ts
@@ -1,0 +1,17 @@
+/**
+ * deploy/params/base/tc/cost/TC-COST-BILL-01.params.ts
+ * TC-COST-BILL-01 ~ 04 공통 파라미터
+ * TC-COST-IFRAME-01: Cost Analysis iframe
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    // Cost API는 admin token 으로 호출 (adminId/adminPassword 는 전역 env 에서 주입)
+    currency:       'USD',
+    // 조회 기간 (getCurMonthBill 등에서 사용)
+    billingYear:    new Date().getFullYear(),
+    billingMonth:   new Date().getMonth() + 1,
+    top5Limit:      5,
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/cost/TC-COSTOPT-BILL-01.params.ts
+++ b/e2e/params/base/tc/cost/TC-COSTOPT-BILL-01.params.ts
@@ -1,0 +1,17 @@
+/**
+ * deploy/params/base/tc/cost/TC-COSTOPT-BILL-01.params.ts
+ * TC-COSTOPT-BILL-01 ~ 04 공통 파라미터
+ * TC-COSTOPT-IFRAME-01: Cost Analysis iframe
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    // Cost API는 admin token 으로 호출 (adminId/adminPassword 는 전역 env 에서 주입)
+    currency:       'USD',
+    // 조회 기간 (getCurMonthBill 등에서 사용)
+    billingYear:    new Date().getFullYear(),
+    billingMonth:   new Date().getMonth() + 1,
+    top5Limit:      5,
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/cost/TC-COSTOPT-INIT.params.ts
+++ b/e2e/params/base/tc/cost/TC-COSTOPT-INIT.params.ts
@@ -1,0 +1,49 @@
+/**
+ * deploy/params/base/tc/cost/TC-COSTOPT-INIT.params.ts
+ * TC-COSTOPT-INIT-01~06 공통 파라미터
+ *
+ * INIT-01~04: CSP별 CUR 데이터 수집 설정 (AWS, NCP, Azure, GCP)
+ * INIT-05: 알림 채널 설정 (Gmail / Slack)
+ * INIT-06: LLM 채널 설정
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    // CUR 설정 공통
+    currency: 'USD',
+  },
+  variants: {
+    aws: {
+      csp:         'aws',
+      region:      'ap-northeast-2',
+      displayName: 'AWS CUR',
+    },
+    ncp: {
+      csp:         'ncp',
+      region:      'kr',
+      displayName: 'NCP CUR',
+    },
+    azure: {
+      csp:         'azure',
+      region:      'koreacentral',
+      displayName: 'Azure CUR',
+    },
+    gcp: {
+      csp:         'gcp',
+      region:      'asia-northeast3',
+      displayName: 'GCP CUR',
+    },
+    // 알림 채널 (INIT-05)
+    'notification-gmail': {
+      channelType: 'gmail',
+    },
+    'notification-slack': {
+      channelType: 'slack',
+    },
+    // LLM 채널 (INIT-06)
+    llm: {
+      channelType: 'llm',
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/cost/TC-COSTOPT-OPER.params.ts
+++ b/e2e/params/base/tc/cost/TC-COSTOPT-OPER.params.ts
@@ -1,0 +1,23 @@
+/**
+ * deploy/params/base/tc/cost/TC-COSTOPT-OPER.params.ts
+ * TC-COSTOPT-OPER-01~03 공통 파라미터
+ *
+ * OPER-01: 비용 수집 및 최적화 알람 수신
+ * OPER-02: 덤프데이터를 통한 비용 수집 및 최적화 알람 수신
+ * OPER-03: ML/LLM 자원 추천 (Resource Recommendation)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    currency:     'USD',
+    billingYear:  new Date().getFullYear(),
+    billingMonth: new Date().getMonth() + 1,
+  },
+  variants: {
+    // OPER-02: 덤프 데이터 기반 테스트용
+    dump: {
+      useDumpData: true,
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/csp/TC-CSP-CONNECTION-02.params.ts
+++ b/e2e/params/base/tc/csp/TC-CSP-CONNECTION-02.params.ts
@@ -1,0 +1,49 @@
+/**
+ * deploy/params/base/tc/csp/TC-CSP-CONNECTION-02.params.ts
+ * TC-CSP-CONNECTION-02: CSP Connection 생성
+ *
+ * variant: CSP 제공자별 (aws / azure / gcp / ali / ibm / nhn / tencent)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    // 기본값: aws ap-northeast-2
+    connectionName:   'aws-ap-northeast-2',
+    providerName:     'aws',
+    regionName:       'ap-northeast-2',
+    credentialHolder: 'e2e-credential',
+  },
+  variants: {
+    aws: {
+      connectionName:   'aws-ap-northeast-2',
+      providerName:     'aws',
+      regionName:       'ap-northeast-2',
+      credentialHolder: 'e2e-aws-credential',
+    },
+    azure: {
+      connectionName:   'azure-koreacentral',
+      providerName:     'azure',
+      regionName:       'koreacentral',
+      credentialHolder: 'e2e-azure-credential',
+    },
+    gcp: {
+      connectionName:   'gcp-asia-northeast3',
+      providerName:     'gcp',
+      regionName:       'asia-northeast3',
+      credentialHolder: 'e2e-gcp-credential',
+    },
+    ali: {
+      connectionName:   'alibaba-ap-northeast-1',
+      providerName:     'alibaba',
+      regionName:       'ap-northeast-1',
+      credentialHolder: 'e2e-ali-credential',
+    },
+    nhn: {
+      connectionName:   'nhncloud-kr1',
+      providerName:     'nhncloud',
+      regionName:       'kr1',
+      credentialHolder: 'e2e-nhn-credential',
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/csp/TC-CSP-CREDENTIAL-03.params.ts
+++ b/e2e/params/base/tc/csp/TC-CSP-CREDENTIAL-03.params.ts
@@ -1,0 +1,129 @@
+/**
+ * deploy/params/base/tc/csp/TC-CSP-CREDENTIAL-03.params.ts
+ * TC-CSP-CREDENTIAL-03: CSP 자격증명 등록
+ *
+ * variant 'api'      → mc-web-console/specs/csp/ 의 API 테스트 (credentialKeyId/Value 사용)
+ * variant 'aws'~     → deploy/tc/csp/TC-CSP-CREDENTIAL-03-ui.spec.ts 의 UI 테스트
+ *
+ * 민감값(비밀번호·키)은 env/local.params.ts 또는 PW_* 환경변수로 주입한다.
+ * 이 파일에는 구조(키 목록)만 정의하고 값은 빈 문자열로 유지한다.
+ *
+ * Provider별 KV 필드명은 cb-spider PROVIDER_KEYS 기준:
+ *   aws:       ClientId, ClientSecret
+ *   gcp:       ClientEmail, PrivateKey, ProjectID
+ *   azure:     ClientId, ClientSecret, TenantId, SubscriptionId
+ *   alibaba:   ClientId, ClientSecret
+ *   ibm:       ApiKey, S3AccessKey, S3SecretKey
+ *   ncp:       ClientId, ClientSecret
+ *   nhn:       IdentityEndpoint, Username, Password, DomainName, TenantId
+ *   kt:        IdentityEndpoint, Username, Password, DomainName, ProjectID
+ *   openstack: IdentityEndpoint, Username, Password, DomainName, ProjectID
+ *   tencent:   SecretId, SecretKey
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    credentialHolder:   'e2e-credential',
+    providerName:       'aws',
+    credentialKeyId:    '',
+    credentialKeyValue: '',
+  },
+
+  variants: {
+
+    // ── API 테스트 (기존 방식) ─────────────────────────────────────────────
+    api: {
+      credentialHolder:   'e2e-credential',
+      providerName:       'aws',
+      credentialKeyId:    '',    // PW_credentialKeyId
+      credentialKeyValue: '',    // PW_credentialKeyValue
+    },
+
+    // ── UI 테스트 — CSP별 ──────────────────────────────────────────────────
+
+    aws: {
+      credentialHolder: 'e2e-aws-credential',
+      providerName:     'aws',
+      ClientId:         '',    // PW_ClientId  (AWS Access Key ID)
+      ClientSecret:     '',    // PW_ClientSecret  (AWS Secret Access Key)
+    },
+
+    gcp: {
+      credentialHolder: 'e2e-gcp-credential',
+      providerName:     'gcp',
+      ClientEmail:      '',    // PW_ClientEmail  (서비스 계정 이메일)
+      PrivateKey:       '',    // PW_PrivateKey   (서비스 계정 Private Key JSON)
+      ProjectID:        '',    // PW_ProjectID
+    },
+
+    azure: {
+      credentialHolder: 'e2e-azure-credential',
+      providerName:     'azure',
+      ClientId:         '',    // PW_ClientId      (Application/Client ID)
+      ClientSecret:     '',    // PW_ClientSecret  (Client Secret Value)
+      TenantId:         '',    // PW_TenantId
+      SubscriptionId:   '',    // PW_SubscriptionId
+    },
+
+    alibaba: {
+      credentialHolder: 'e2e-alibaba-credential',
+      providerName:     'alibaba',
+      ClientId:         '',    // PW_ClientId      (AccessKey ID)
+      ClientSecret:     '',    // PW_ClientSecret  (AccessKey Secret)
+    },
+
+    ibm: {
+      credentialHolder: 'e2e-ibm-credential',
+      providerName:     'ibm',
+      ApiKey:           '',    // PW_ApiKey
+      S3AccessKey:      '',    // PW_S3AccessKey
+      S3SecretKey:      '',    // PW_S3SecretKey
+    },
+
+    ncp: {
+      credentialHolder: 'e2e-ncp-credential',
+      providerName:     'ncp',
+      ClientId:         '',    // PW_ClientId      (NCP Access Key)
+      ClientSecret:     '',    // PW_ClientSecret  (NCP Secret Key)
+    },
+
+    nhn: {
+      credentialHolder:  'e2e-nhn-credential',
+      providerName:      'nhn',
+      IdentityEndpoint:  '',    // PW_IdentityEndpoint  (Keystone v3 endpoint)
+      Username:          '',    // PW_Username
+      Password:          '',    // PW_Password
+      DomainName:        '',    // PW_DomainName
+      TenantId:          '',    // PW_TenantId  (Project ID)
+    },
+
+    kt: {
+      credentialHolder:  'e2e-kt-credential',
+      providerName:      'kt',
+      IdentityEndpoint:  '',    // PW_IdentityEndpoint
+      Username:          '',    // PW_Username
+      Password:          '',    // PW_Password
+      DomainName:        '',    // PW_DomainName
+      ProjectID:         '',    // PW_ProjectID
+    },
+
+    openstack: {
+      credentialHolder:  'e2e-openstack-credential',
+      providerName:      'openstack',
+      IdentityEndpoint:  '',    // PW_IdentityEndpoint
+      Username:          '',    // PW_Username
+      Password:          '',    // PW_Password
+      DomainName:        '',    // PW_DomainName
+      ProjectID:         '',    // PW_ProjectID
+    },
+
+    tencent: {
+      credentialHolder: 'e2e-tencent-credential',
+      providerName:     'tencent',
+      SecretId:         '',    // PW_SecretId
+      SecretKey:        '',    // PW_SecretKey
+    },
+
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/csp/TC-CSP-VPC-03.params.ts
+++ b/e2e/params/base/tc/csp/TC-CSP-VPC-03.params.ts
@@ -1,0 +1,36 @@
+/**
+ * deploy/params/base/tc/csp/TC-CSP-VPC-03.params.ts
+ * TC-CSP-VPC-03: VPC 생성 (서브넷 포함)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    connectionName: 'aws-ap-northeast-2',
+    vpcName:        'e2e-vpc',
+    cidrBlock:      '10.0.0.0/16',
+    subnetName:     'e2e-subnet-01',
+    subnetCidr:     '10.0.1.0/24',
+    zone:           'ap-northeast-2a',
+  },
+  variants: {
+    aws: {
+      connectionName: 'aws-ap-northeast-2',
+      cidrBlock:      '10.10.0.0/16',
+      subnetCidr:     '10.10.1.0/24',
+      zone:           'ap-northeast-2a',
+    },
+    azure: {
+      connectionName: 'azure-koreacentral',
+      cidrBlock:      '10.20.0.0/16',
+      subnetCidr:     '10.20.1.0/24',
+      zone:           'koreacentral-1',
+    },
+    gcp: {
+      connectionName: 'gcp-asia-northeast3',
+      cidrBlock:      '10.30.0.0/16',
+      subnetCidr:     '10.30.1.0/24',
+      zone:           'asia-northeast3-a',
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/data/TC-DATA-NORDB-BAK-01.params.ts
+++ b/e2e/params/base/tc/data/TC-DATA-NORDB-BAK-01.params.ts
@@ -1,0 +1,9 @@
+import type { TCParams } from '../../../types';
+import { ALIBABA_NRDB, DATA_MANAGER_DEFAULTS } from './connections';
+
+export default {
+  base: {
+    ...DATA_MANAGER_DEFAULTS,
+    ...ALIBABA_NRDB,
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/data/TC-DATA-NORDB-MIG-01.params.ts
+++ b/e2e/params/base/tc/data/TC-DATA-NORDB-MIG-01.params.ts
@@ -1,0 +1,13 @@
+import type { TCParams } from '../../../types';
+import { ALIBABA_NRDB, DATA_MANAGER_DEFAULTS } from './connections';
+
+export default {
+  base: {
+    ...DATA_MANAGER_DEFAULTS,
+    ...ALIBABA_NRDB,
+    mongoHost:     ALIBABA_NRDB.host,
+    mongoPort:     ALIBABA_NRDB.port,
+    mongoUser:     ALIBABA_NRDB.username,
+    mongoPassword: ALIBABA_NRDB.password,
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/data/TC-DATA-NRDB-01.params.ts
+++ b/e2e/params/base/tc/data/TC-DATA-NRDB-01.params.ts
@@ -1,0 +1,22 @@
+/**
+ * deploy/params/base/tc/data/TC-DATA-NRDB-01.params.ts
+ * TC-DATA-NRDB-01 ~ 04: NoRDBMS Generate / Migrate / Backup / Restore
+ */
+import type { TCParams } from '../../../types';
+import { AWS_NRDB, ALIBABA_NRDB, DATA_MANAGER_DEFAULTS } from './connections';
+
+export default {
+  base: {
+    ...DATA_MANAGER_DEFAULTS,
+    awsNrdb:     AWS_NRDB,
+    alibabaNrdb: ALIBABA_NRDB,
+  },
+  variants: {
+    aws: {
+      nrdb: AWS_NRDB,
+    },
+    alibaba: {
+      nrdb: ALIBABA_NRDB,
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/data/TC-DATA-OBJ-BAK-01.params.ts
+++ b/e2e/params/base/tc/data/TC-DATA-OBJ-BAK-01.params.ts
@@ -1,0 +1,8 @@
+import type { TCParams } from '../../../types';
+import { DATA_MANAGER_DEFAULTS } from './connections';
+
+export default {
+  base: {
+    ...DATA_MANAGER_DEFAULTS,
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/data/TC-DATA-OBJ-MIG-01.params.ts
+++ b/e2e/params/base/tc/data/TC-DATA-OBJ-MIG-01.params.ts
@@ -1,0 +1,8 @@
+import type { TCParams } from '../../../types';
+import { DATA_MANAGER_DEFAULTS } from './connections';
+
+export default {
+  base: {
+    ...DATA_MANAGER_DEFAULTS,
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/data/TC-DATA-OS-01.params.ts
+++ b/e2e/params/base/tc/data/TC-DATA-OS-01.params.ts
@@ -1,0 +1,28 @@
+/**
+ * deploy/params/base/tc/data/TC-DATA-OS-01.params.ts
+ * TC-DATA-OS-01 ~ 04: Object Storage CRUD
+ *
+ * 런타임 OUT params (TC-DATA-OS-01):
+ *   store.set('bucketName', bucketName)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:           'default',
+    connectionName: 'aws-ap-northeast-2',
+    bucketName:     'tc-bucket-e2e',
+    objectKey:      'tc-test-object.txt',
+    objectContent:  'E2E 테스트 오브젝트 내용',
+  },
+  variants: {
+    aws: {
+      connectionName: 'aws-ap-northeast-2',
+      bucketName:     'tc-bucket-e2e-aws',
+    },
+    gcp: {
+      connectionName: 'gcp-asia-northeast3',
+      bucketName:     'tc-bucket-e2e-gcp',
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/data/TC-DATA-RDB-01.params.ts
+++ b/e2e/params/base/tc/data/TC-DATA-RDB-01.params.ts
@@ -1,0 +1,25 @@
+/**
+ * deploy/params/base/tc/data/TC-DATA-RDB-01.params.ts
+ * TC-DATA-RDB-01 ~ 04: RDBMS Generate / Migrate / Backup / Restore
+ */
+import type { TCParams } from '../../../types';
+import { AWS_RDB, ALIBABA_RDB, DATA_MANAGER_DEFAULTS } from './connections';
+
+export default {
+  base: {
+    ...DATA_MANAGER_DEFAULTS,
+    sourcePoint: AWS_RDB,
+    targetPoint: ALIBABA_RDB,
+    rdbName:     'tc-rdb-e2e',
+    dbType:      'mysql',
+    dbVersion:   '8.0',
+  },
+  variants: {
+    aws: {
+      sourcePoint: AWS_RDB,
+    },
+    alibaba: {
+      targetPoint: ALIBABA_RDB,
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/data/TC-DATA-RDB-BAK-01.params.ts
+++ b/e2e/params/base/tc/data/TC-DATA-RDB-BAK-01.params.ts
@@ -1,0 +1,9 @@
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    dataManagerBaseUrl: 'https://15.164.139.37:3300',
+    workspaceName:      'ws01',
+    projectName:        'default',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/data/TC-DATA-RDB-MIG-01.params.ts
+++ b/e2e/params/base/tc/data/TC-DATA-RDB-MIG-01.params.ts
@@ -1,0 +1,10 @@
+import type { TCParams } from '../../../types';
+import { AWS_RDB, ALIBABA_RDB, DATA_MANAGER_DEFAULTS } from './connections';
+
+export default {
+  base: {
+    ...DATA_MANAGER_DEFAULTS,
+    sourcePoint: AWS_RDB,
+    targetPoint: ALIBABA_RDB,
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/data/TC-DATA-UI-01.params.ts
+++ b/e2e/params/base/tc/data/TC-DATA-UI-01.params.ts
@@ -1,0 +1,9 @@
+import type { TCParams } from '../../../types';
+import { DATA_MANAGER_DEFAULTS } from './connections';
+
+export default {
+  base: {
+    ...DATA_MANAGER_DEFAULTS,
+    pageUrl: '/webconsole/operations/manage/datamigrations',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/data/connections.ts
+++ b/e2e/params/base/tc/data/connections.ts
@@ -1,0 +1,52 @@
+/**
+ * deploy/params/base/tc/data/connections.ts
+ * mc-data-manager E2E — AWS / Alibaba 접속 프로필 (Tumblebug credential.temp 기준)
+ *
+ * NRDB:
+ *   AWS     — Tumblebug 등록 credential 선택 후 Generate
+ *   Alibaba — 등록 credential 선택 (host: dds-mj7e... / root / mcmp_test123)
+ */
+export const AWS_RDB = {
+  provider:     'aws',
+  host:         'mcmp-test.cteomeg827o8.ap-northeast-2.rds.amazonaws.com',
+  port:         '3306',
+  username:     'admin',
+  password:     'mcmp_test',
+  databaseName: 'LibraryManagement_0',
+} as const;
+
+export const ALIBABA_RDB = {
+  provider:     'alibaba',
+  host:         'rm-mj747t00m6294g84pvo.mysql.ap-northeast-2.rds.aliyuncs.com',
+  port:         '3306',
+  username:     'root',
+  password:     'mcmp_test123',
+  databaseName: 'MZ_LibraryManagement',
+} as const;
+
+/** AWS NoRDB — DynamoDB/Firestore: credential 드롭다운에서 Tumblebug 등록 credential 선택 */
+export const AWS_NRDB = {
+  mode:             'credential' as const,
+  provider:         'aws',
+  credentialFilter: ['dynamo', 'firestore', 'aws'],
+  databaseName:     'e2e-nrdb-aws',
+} as const;
+
+/** Alibaba NoRDB — MongoDB: 등록 credential 선택 (직접 입력 fallback 값 포함) */
+export const ALIBABA_NRDB = {
+  mode:             'credential' as const,
+  provider:         'alibaba',
+  host:             'dds-mj7e851cdba37bb42822-pub.mongodb.ap-northeast-2.rds.aliyuncs.com',
+  port:             '3717',
+  username:         'root',
+  password:         'mcmp_test123',
+  credentialFilter: ['alibaba', 'mongo', 'dds-mj7', 'aliyun'],
+  sourceDatabase:   'mcmp_test',
+  targetDatabase:   'MZ_mcmp_test',
+} as const;
+
+export const DATA_MANAGER_DEFAULTS = {
+  dataManagerBaseUrl: process.env.DATA_MANAGER_BASE_URL ?? 'https://15.164.139.37:3300',
+  workspaceName:      'ws01',
+  projectName:        'default',
+};

--- a/e2e/params/base/tc/iam/TC-IAM-AUTH-01.params.ts
+++ b/e2e/params/base/tc/iam/TC-IAM-AUTH-01.params.ts
@@ -1,0 +1,12 @@
+/**
+ * deploy/params/base/tc/iam/TC-IAM-AUTH-01.params.ts
+ * TC-IAM-AUTH-01: login
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    adminId:       'mcmp',
+    adminPassword: 'mcmp_password',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/iam/TC-IAM-RBAC-01.params.ts
+++ b/e2e/params/base/tc/iam/TC-IAM-RBAC-01.params.ts
@@ -1,0 +1,26 @@
+/**
+ * deploy/params/base/tc/iam/TC-IAM-RBAC-01.params.ts
+ * TC-IAM-RBAC-01 ~ 08 공통 파라미터
+ *
+ * variant 'admin' / 'viewer' 로 권한 수준별 케이스 분리
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    roleName:        'e2e-custom-role',
+    roleDescription: 'E2E 테스트용 커스텀 역할',
+    // 기본 권한 집합 (조회만)
+    permissions: ['workspace:read', 'project:read'],
+  },
+  variants: {
+    admin: {
+      roleName:    'e2e-admin-role',
+      permissions: ['workspace:read', 'workspace:write', 'project:read', 'project:write'],
+    },
+    viewer: {
+      roleName:    'e2e-viewer-role',
+      permissions: ['workspace:read', 'project:read'],
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/iam/TC-IAM-ROLE-01.params.ts
+++ b/e2e/params/base/tc/iam/TC-IAM-ROLE-01.params.ts
@@ -1,0 +1,26 @@
+/**
+ * deploy/params/base/tc/iam/TC-IAM-ROLE-01.params.ts
+ * TC-IAM-ROLE-01 ~ 08 공통 파라미터
+ *
+ * variant 'admin' / 'viewer' 로 권한 수준별 케이스 분리
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    roleName:        'e2e-custom-role',
+    roleDescription: 'E2E 테스트용 커스텀 역할',
+    // 기본 권한 집합 (조회만)
+    permissions: ['workspace:read', 'project:read'],
+  },
+  variants: {
+    admin: {
+      roleName:    'e2e-admin-role',
+      permissions: ['workspace:read', 'workspace:write', 'project:read', 'project:write'],
+    },
+    viewer: {
+      roleName:    'e2e-viewer-role',
+      permissions: ['workspace:read', 'project:read'],
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/iam/TC-IAM-UG-01.params.ts
+++ b/e2e/params/base/tc/iam/TC-IAM-UG-01.params.ts
@@ -1,0 +1,13 @@
+/**
+ * deploy/params/base/tc/iam/TC-IAM-UG-01.params.ts
+ * TC-IAM-UG-01 ~ 17 공통 파라미터
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    groupName:        'e2e-usergroup',
+    groupDescription: 'E2E 테스트용 사용자 그룹',
+    targetUserId:     'e2e-user-01',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/iam/TC-IAM-USER-LIFECYCLE-01.params.ts
+++ b/e2e/params/base/tc/iam/TC-IAM-USER-LIFECYCLE-01.params.ts
@@ -1,0 +1,14 @@
+/**
+ * deploy/params/base/tc/iam/TC-IAM-USER-LIFECYCLE-01.params.ts
+ * TC-IAM-USER-LIFECYCLE-01: 사용자 회원가입
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    newUserId:       'e2e-user-01',
+    newUserPassword: 'E2eUser!2024',
+    newUserName:     'E2E 테스트 사용자',
+    newUserEmail:    'e2e-user-01@example.com',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/iam/TC-IAM-USERGROUP-01.params.ts
+++ b/e2e/params/base/tc/iam/TC-IAM-USERGROUP-01.params.ts
@@ -1,0 +1,13 @@
+/**
+ * deploy/params/base/tc/iam/TC-IAM-USERGROUP-01.params.ts
+ * TC-IAM-USERGROUP-01 ~ 17 공통 파라미터
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    groupName:        'e2e-usergroup',
+    groupDescription: 'E2E 테스트용 사용자 그룹',
+    targetUserId:     'e2e-user-01',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/iam/TC-IAM-WORKSPACE-01.params.ts
+++ b/e2e/params/base/tc/iam/TC-IAM-WORKSPACE-01.params.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/params/base/tc/iam/TC-IAM-WORKSPACE-01.params.ts
+ * TC-IAM-WORKSPACE-01: 워크스페이스 목록 조회
+ * TC-IAM-WORKSPACE-02: 워크스페이스 생성  (같은 params 파일 공유)
+ * TC-IAM-WORKSPACE-03: 워크스페이스 상세
+ * ...
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    workspaceName:        'e2e-workspace',
+    workspaceDescription: 'E2E 테스트용 워크스페이스',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/iam/TC-IAM-WS-01.params.ts
+++ b/e2e/params/base/tc/iam/TC-IAM-WS-01.params.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/params/base/tc/iam/TC-IAM-WS-01.params.ts
+ * TC-IAM-WS-01: 워크스페이스 목록 조회
+ * TC-IAM-WS-02: 워크스페이스 생성  (같은 params 파일 공유)
+ * TC-IAM-WS-03: 워크스페이스 상세
+ * ...
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    workspaceName:        'e2e-workspace',
+    workspaceDescription: 'E2E 테스트용 워크스페이스',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/infra/TC-INFRA-CSP-03.params.ts
+++ b/e2e/params/base/tc/infra/TC-INFRA-CSP-03.params.ts
@@ -1,0 +1,129 @@
+/**
+ * deploy/params/base/tc/infra/TC-INFRA-CSP-03.params.ts
+ * TC-INFRA-CSP-03: CSP 자격증명 등록
+ *
+ * variant 'api'      → mc-web-console/specs/csp/ 의 API 테스트 (credentialKeyId/Value 사용)
+ * variant 'aws'~     → deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts 의 UI 테스트
+ *
+ * 민감값(비밀번호·키)은 env/local.params.ts 또는 PW_* 환경변수로 주입한다.
+ * 이 파일에는 구조(키 목록)만 정의하고 값은 빈 문자열로 유지한다.
+ *
+ * Provider별 KV 필드명은 cb-spider PROVIDER_KEYS 기준:
+ *   aws:       ClientId, ClientSecret
+ *   gcp:       ClientEmail, PrivateKey, ProjectID
+ *   azure:     ClientId, ClientSecret, TenantId, SubscriptionId
+ *   alibaba:   ClientId, ClientSecret
+ *   ibm:       ApiKey, S3AccessKey, S3SecretKey
+ *   ncp:       ClientId, ClientSecret
+ *   nhn:       IdentityEndpoint, Username, Password, DomainName, TenantId
+ *   kt:        IdentityEndpoint, Username, Password, DomainName, ProjectID
+ *   openstack: IdentityEndpoint, Username, Password, DomainName, ProjectID
+ *   tencent:   SecretId, SecretKey
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    credentialHolder:   'e2e-credential',
+    providerName:       'aws',
+    credentialKeyId:    '',
+    credentialKeyValue: '',
+  },
+
+  variants: {
+
+    // ── API 테스트 (기존 방식) ─────────────────────────────────────────────
+    api: {
+      credentialHolder:   'e2e-credential',
+      providerName:       'aws',
+      credentialKeyId:    '',    // PW_credentialKeyId
+      credentialKeyValue: '',    // PW_credentialKeyValue
+    },
+
+    // ── UI 테스트 — CSP별 ──────────────────────────────────────────────────
+
+    aws: {
+      credentialHolder: 'e2e-aws-credential',
+      providerName:     'aws',
+      ClientId:         '',    // PW_ClientId  (AWS Access Key ID)
+      ClientSecret:     '',    // PW_ClientSecret  (AWS Secret Access Key)
+    },
+
+    gcp: {
+      credentialHolder: 'e2e-gcp-credential',
+      providerName:     'gcp',
+      ClientEmail:      '',    // PW_ClientEmail  (서비스 계정 이메일)
+      PrivateKey:       '',    // PW_PrivateKey   (서비스 계정 Private Key JSON)
+      ProjectID:        '',    // PW_ProjectID
+    },
+
+    azure: {
+      credentialHolder: 'e2e-azure-credential',
+      providerName:     'azure',
+      ClientId:         '',    // PW_ClientId      (Application/Client ID)
+      ClientSecret:     '',    // PW_ClientSecret  (Client Secret Value)
+      TenantId:         '',    // PW_TenantId
+      SubscriptionId:   '',    // PW_SubscriptionId
+    },
+
+    alibaba: {
+      credentialHolder: 'e2e-alibaba-credential',
+      providerName:     'alibaba',
+      ClientId:         '',    // PW_ClientId      (AccessKey ID)
+      ClientSecret:     '',    // PW_ClientSecret  (AccessKey Secret)
+    },
+
+    ibm: {
+      credentialHolder: 'e2e-ibm-credential',
+      providerName:     'ibm',
+      ApiKey:           '',    // PW_ApiKey
+      S3AccessKey:      '',    // PW_S3AccessKey
+      S3SecretKey:      '',    // PW_S3SecretKey
+    },
+
+    ncp: {
+      credentialHolder: 'e2e-ncp-credential',
+      providerName:     'ncp',
+      ClientId:         '',    // PW_ClientId      (NCP Access Key)
+      ClientSecret:     '',    // PW_ClientSecret  (NCP Secret Key)
+    },
+
+    nhn: {
+      credentialHolder:  'e2e-nhn-credential',
+      providerName:      'nhn',
+      IdentityEndpoint:  '',    // PW_IdentityEndpoint  (Keystone v3 endpoint)
+      Username:          '',    // PW_Username
+      Password:          '',    // PW_Password
+      DomainName:        '',    // PW_DomainName
+      TenantId:          '',    // PW_TenantId  (Project ID)
+    },
+
+    kt: {
+      credentialHolder:  'e2e-kt-credential',
+      providerName:      'kt',
+      IdentityEndpoint:  '',    // PW_IdentityEndpoint
+      Username:          '',    // PW_Username
+      Password:          '',    // PW_Password
+      DomainName:        '',    // PW_DomainName
+      ProjectID:         '',    // PW_ProjectID
+    },
+
+    openstack: {
+      credentialHolder:  'e2e-openstack-credential',
+      providerName:      'openstack',
+      IdentityEndpoint:  '',    // PW_IdentityEndpoint
+      Username:          '',    // PW_Username
+      Password:          '',    // PW_Password
+      DomainName:        '',    // PW_DomainName
+      ProjectID:         '',    // PW_ProjectID
+    },
+
+    tencent: {
+      credentialHolder: 'e2e-tencent-credential',
+      providerName:     'tencent',
+      SecretId:         '',    // PW_SecretId
+      SecretKey:        '',    // PW_SecretKey
+    },
+
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/infra/TC-INFRA-DEPLOY-01.params.ts
+++ b/e2e/params/base/tc/infra/TC-INFRA-DEPLOY-01.params.ts
@@ -1,0 +1,12 @@
+/**
+ * deploy/params/base/tc/infra/TC-INFRA-DEPLOY-01.params.ts
+ * TC-INFRA-DEPLOY-01: MCI 목록 조회
+ * TC-INFRA-DEPLOY-02: MCI 상세 조회  (같은 파일 공유 — nsId 필요)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId: 'default',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/infra/TC-INFRA-DEPLOY-05.params.ts
+++ b/e2e/params/base/tc/infra/TC-INFRA-DEPLOY-05.params.ts
@@ -1,0 +1,124 @@
+/**
+ * deploy/params/base/tc/infra/TC-INFRA-DEPLOY-05.params.ts
+ * TC-INFRA-DEPLOY-05: MCI 생성
+ *
+ * CSP별 variant 를 통해 동일 TC를 여러 클라우드에서 실행할 수 있다.
+ *
+ * 런타임 OUT params:
+ *   store.set('mciId',   생성된 MCI ID)
+ *   store.set('mciName', mciName)
+ *   store.set('nsId',    nsId)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:    'default',
+    mciName: 'tc-mci-temp',
+    // 기본값: aws ap-northeast-2
+    connectionName: 'aws-ap-northeast-2',
+    commonSpec:     'aws+ap-northeast-2+c4.large',
+    rootDiskType:   'default',
+    rootDiskSize:   '0',
+    subGroupSize:   '1',
+  },
+  variants: {
+    // ── VM(MCI) 생성 variants — 2라운드: mci11~17
+    // imageId 미지정 시 Ubuntu 22.04 OS 필터 자동 적용 (non-pro 우선)
+    aws: {
+      mciName:        'mci11',
+      vmName:         'ing11',
+      connectionName: 'aws-ap-northeast-2',
+      commonSpec:     'aws+ap-northeast-2+c4.large',
+    },
+    // Azure koreacentral — 생성 성공 확인 (2026-06-27)
+    // Standard_B2ts_v2, Standard_F2ams_v6 모두 성공
+    azure: {
+      mciName:        'mci12',
+      vmName:         'ing12',
+      connectionName: 'azure-koreacentral',
+      commonSpec:     'azure+koreacentral+Standard_B2ts_v2',
+      imageId:        'Canonical:ubuntu-22_04-lts:server:22.04.202603110',
+    },
+    // azure-f2ams: Standard_F2ams_v6 — 성공 확인 (2026-06-27), 대체 spec
+    'azure-f2ams': {
+      mciName:        'mci12',
+      vmName:         'ing12',
+      connectionName: 'azure-koreacentral',
+      commonSpec:     'azure+koreacentral+Standard_F2ams_v6',
+      imageId:        'Canonical:ubuntu-22_04-lts:server:22.04.202603110',
+    },
+    gcp: {
+      mciName:        'mci13',
+      vmName:         'ing13',
+      connectionName: 'gcp-asia-northeast3',
+      commonSpec:     'gcp+asia-northeast3+n1-standard-4',
+    },
+    // Alibaba: ap-northeast-2 (서울, 1차) — 2026-06-26 확인: ecs.t6-c4m1.large
+    ali: {
+      mciName:        'mci14',
+      vmName:         'ing14',
+      connectionName: 'alibaba-ap-northeast-2',
+      commonSpec:     'alibaba+ap-northeast-2+ecs.t6-c4m1.large',
+    },
+    ibm: {
+      mciName:        'mci15',
+      vmName:         'ing15',
+      connectionName: 'ibm-jp-tok',
+      commonSpec:     'ibm+jp-tok+bx2-4x16',  // 2026-06-26 확인: bx2-2x8 미등록
+    },
+    nhn: {
+      mciName:        'mci16',
+      vmName:         'ing16',
+      connectionName: 'nhncloud-kr1',
+      commonSpec:     'nhn+kr1+m2.c2m4',
+      imageId:        '0f07c795-2a46-44fc-a61b-fa0d96763ce2',
+    },
+    // Tencent VM(MCI) — ap-seoul (2026-06-26 SearchImage 확인)
+    // img-487zeit5: Ubuntu Server 22.04 LTS 64bit (x86_64, non-UEFI)
+    tencent: {
+      mciName:        'mci17',
+      vmName:         'ing17',
+      connectionName: 'tencent-ap-seoul',
+      commonSpec:     'tencent+ap-seoul+s3.small1',
+      imageId:        'img-487zeit5',
+    },
+    // ── C4-01 전용: mci01 생성 (AWS ng1 — 첫 번째 subgroup)
+    // commonSpec 미지정 → TC가 vCPU 1→2→4 순으로 자동 선택
+    multi: {
+      mciName:        'mci01',
+      vmName:         'ng1',
+      connectionName: 'aws-ap-northeast-2',
+      subGroupSize:   '2',
+    },
+    // ── 대형 인스턴스 (scale-out / 특수 용도)
+    'aws-large': {
+      connectionName: 'aws-ap-northeast-2',
+      commonSpec:     'aws+ap-northeast-2+t2.medium',
+    },
+    // NCP VM(MCI) — kr (2026-06-26 확인)
+    ncp: {
+      mciName:        'mci18',
+      vmName:         'ing18',
+      connectionName: 'ncp-kr',
+      commonSpec:     'ncp+kr+s2-g3',
+      imageId:        '104630229',  // Ubuntu 24.04
+    },
+    // ── K8s Node 전용 variants (TC-INFRA-K8S-03에서 재사용)
+    // Tencent K8s Node — ap-tokyo 사용 (2026-06-24 확인)
+    'tencent-k8s': {
+      connectionName: 'tencent-ap-tokyo',
+      commonSpec:     'tencent+ap-tokyo+S5.MEDIUM4',
+    },
+    // NCP K8s Node (2026-06-24 확인)
+    'ncp-k8s': {
+      connectionName: 'ncp-kr',
+      commonSpec:     'ncp+kr+s2-g3',
+    },
+    // tencent+ap-seoul+s2.small1 — out of stock (2026-06-24 확인)
+    // 'tencent-seoul': {
+    //   connectionName: 'tencent-ap-seoul',
+    //   commonSpec:     'tencent+ap-seoul+s2.small1',
+    // },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/infra/TC-INFRA-DEPLOY-06.params.ts
+++ b/e2e/params/base/tc/infra/TC-INFRA-DEPLOY-06.params.ts
@@ -1,0 +1,61 @@
+/**
+ * deploy/params/base/tc/infra/TC-INFRA-DEPLOY-06.params.ts
+ * TC-INFRA-DEPLOY-06: MCI 생성 (Expert 모드)
+ *
+ * Express 모드(DEPLOY-05)와 달리 Provider / Region 드롭다운을 별도 선택하고
+ * #expert_server_configuration 폼을 사용한다.
+ *
+ * 런타임 OUT params:
+ *   store.set('mciId',   생성된 MCI ID)
+ *   store.set('mciName', mciName)
+ *   store.set('nsId',    nsId)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:    'default',
+    mciName: 'tc-exp-mci1',
+    // Expert 모드 — Provider / Region / Connection 별도 지정
+    provider:       'aws',
+    region:         'ap-northeast-2',
+    connectionName: 'aws-ap-northeast-2',
+    commonSpec:     'aws+ap-northeast-2+c4.large',
+    imageId:        'ami-0afe1fd15675c3f15',
+    subGroupSize:   '1',
+  },
+  variants: {
+    aws: {
+      mciName:        'tc-exp-mci1',
+      provider:       'aws',
+      region:         'ap-northeast-2',
+      connectionName: 'aws-ap-northeast-2',
+      commonSpec:     'aws+ap-northeast-2+c4.large',
+      imageId:        'ami-0afe1fd15675c3f15',
+    },
+    gcp: {
+      mciName:        'tc-exp-mci2',
+      provider:       'gcp',
+      region:         'asia-northeast3',
+      connectionName: 'gcp-asia-northeast3',
+      commonSpec:     'gcp+asia-northeast3+n1-standard-1',
+      imageId:        'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20260612',
+    },
+    azure: {
+      mciName:        'tc-exp-mci3',
+      provider:       'azure',
+      region:         'koreacentral',
+      connectionName: 'azure-koreacentral',
+      commonSpec:     'azure+koreacentral+standard_b4ms',
+      imageId:        'Canonical:ubuntu-22_04-lts:server:22.04.202603110',
+    },
+    ali: {
+      mciName:        'tc-exp-mci4',
+      provider:       'alibaba',
+      region:         'ap-northeast-1',
+      connectionName: 'alibaba-ap-northeast-1',
+      commonSpec:     'alibaba+eu-central-1+ecs.t6-c4m1.large',
+      imageId:        'ubuntu_22_04_x64_20G_alibase_20260522.vhd',
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/infra/TC-INFRA-DEPLOY-07.params.ts
+++ b/e2e/params/base/tc/infra/TC-INFRA-DEPLOY-07.params.ts
@@ -1,0 +1,139 @@
+/**
+ * deploy/params/base/tc/infra/TC-INFRA-DEPLOY-07.params.ts
+ * TC-INFRA-DEPLOY-07: MCI 서버 추가 (Add Server — Expert 모드)
+ *
+ * 기존 MCI에서 MCI Info > Default Tab > Add Server 버튼 클릭 후
+ * Deployment Algorithm = 'expert' 선택 → + VM 버튼 → 값 입력 → Deploy
+ *
+ * IN params (시나리오 실행 시):
+ *   store.require('mciId')   — TC-INFRA-DEPLOY-05 OUT
+ *   store.require('mciName') — TC-INFRA-DEPLOY-05 OUT
+ *
+ * 런타임 OUT params:
+ *   store.set('subGroupId',   추가된 SubGroup ID)
+ *   store.set('subGroupName', subGroupName)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:           'default',
+    mciName:        'mci11',      // 단독 실행 시 대상 MCI 이름
+    subGroupName:   'sg-exp1',
+    provider:       'aws',
+    region:         'ap-northeast-2',
+    connectionName: 'aws-ap-northeast-2',
+    commonSpec:     'aws+ap-northeast-2+c4.large',
+    imageId:        'ami-0afe1fd15675c3f15',
+    subGroupSize:   '1',
+  },
+  variants: {
+    aws: {
+      mciName:        'mci11',
+      subGroupName:   'sg-exp-aws',
+      provider:       'aws',
+      region:         'ap-northeast-2',
+      connectionName: 'aws-ap-northeast-2',
+      commonSpec:     'aws+ap-northeast-2+c4.large',
+      imageId:        'ami-0afe1fd15675c3f15',
+    },
+    gcp: {
+      mciName:        'mci13',
+      subGroupName:   'sg-exp-gcp',
+      provider:       'gcp',
+      region:         'asia-northeast3',
+      connectionName: 'gcp-asia-northeast3',
+      commonSpec:     'gcp+asia-northeast3+n1-standard-1',
+      imageId:        'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20260612',
+    },
+    azure: {
+      mciName:        'mci12',
+      subGroupName:   'sg-exp-azure',
+      provider:       'azure',
+      region:         'koreacentral',
+      connectionName: 'azure-koreacentral',
+      commonSpec:     'azure+koreacentral+standard_b4ms',
+      imageId:        'Canonical:ubuntu-22_04-lts:server:22.04.202603110',
+    },
+
+    // ── C4-01 전용: mci01에 ng2~ng8 subgroup 추가
+    // mciName: store.require('mciName') 으로 자동 주입 (mci01)
+    // commonSpec 미지정 → TC가 vCPU 1→2→4 순으로 자동 선택
+    'ng2-azure': {
+      subGroupName:   'ng2',
+      provider:       'azure',
+      region:         'koreacentral',
+      connectionName: 'azure-koreacentral',
+      subGroupSize:   '2',
+    },
+    'ng3-ali': {
+      subGroupName:   'ng3',
+      provider:       'alibaba',
+      region:         'ap-northeast-2',
+      connectionName: 'alibaba-ap-northeast-2',
+      subGroupSize:   '2',
+    },
+    'ng4-gcp': {
+      subGroupName:   'ng4',
+      provider:       'gcp',
+      region:         'asia-northeast3',
+      connectionName: 'gcp-asia-northeast3',
+      subGroupSize:   '2',
+    },
+    'ng5-ncp': {
+      subGroupName:   'ng5',
+      provider:       'ncp',
+      region:         'kr',
+      connectionName: 'ncp-kr',
+      subGroupSize:   '2',
+    },
+    'ng6-nhn': {
+      subGroupName:   'ng6',
+      provider:       'nhncloud',
+      region:         'kr1',
+      connectionName: 'nhncloud-kr1',
+      imageId:        '0f07c795-2a46-44fc-a61b-fa0d96763ce2',
+      subGroupSize:   '2',
+    },
+    'ng7-tencent': {
+      subGroupName:   'ng7',
+      provider:       'tencent',
+      region:         'ap-seoul',
+      connectionName: 'tencent-ap-seoul',
+      subGroupSize:   '2',
+    },
+    'ng8-ibm': {
+      subGroupName:   'ng8',
+      provider:       'ibm',
+      region:         'jp-tok',
+      connectionName: 'ibm-jp-tok',
+      subGroupSize:   '2',
+    },
+
+    // ── C5-01 전용: mci01 Scale Out — CSP별 ng{n}a / ng{n}b 추가
+    // AWS
+    ng1a: { subGroupName: 'ng1a', provider: 'aws',      region: 'ap-northeast-2', connectionName: 'aws-ap-northeast-2',      subGroupSize: '2' },
+    ng1b: { subGroupName: 'ng1b', provider: 'aws',      region: 'ap-northeast-2', connectionName: 'aws-ap-northeast-2',      subGroupSize: '2' },
+    // Azure
+    ng2a: { subGroupName: 'ng2a', provider: 'azure',    region: 'koreacentral',   connectionName: 'azure-koreacentral',      subGroupSize: '2' },
+    ng2b: { subGroupName: 'ng2b', provider: 'azure',    region: 'koreacentral',   connectionName: 'azure-koreacentral',      subGroupSize: '2' },
+    // Alibaba
+    ng3a: { subGroupName: 'ng3a', provider: 'alibaba',  region: 'ap-northeast-2', connectionName: 'alibaba-ap-northeast-2',  subGroupSize: '2' },
+    ng3b: { subGroupName: 'ng3b', provider: 'alibaba',  region: 'ap-northeast-2', connectionName: 'alibaba-ap-northeast-2',  subGroupSize: '2' },
+    // GCP
+    ng4a: { subGroupName: 'ng4a', provider: 'gcp',      region: 'asia-northeast3',connectionName: 'gcp-asia-northeast3',     subGroupSize: '2' },
+    ng4b: { subGroupName: 'ng4b', provider: 'gcp',      region: 'asia-northeast3',connectionName: 'gcp-asia-northeast3',     subGroupSize: '2' },
+    // NCP
+    ng5a: { subGroupName: 'ng5a', provider: 'ncp',      region: 'kr',             connectionName: 'ncp-kr',                  subGroupSize: '2' },
+    ng5b: { subGroupName: 'ng5b', provider: 'ncp',      region: 'kr',             connectionName: 'ncp-kr',                  subGroupSize: '2' },
+    // NHN
+    ng6a: { subGroupName: 'ng6a', provider: 'nhncloud', region: 'kr1',            connectionName: 'nhncloud-kr1', imageId: '0f07c795-2a46-44fc-a61b-fa0d96763ce2', subGroupSize: '2' },
+    ng6b: { subGroupName: 'ng6b', provider: 'nhncloud', region: 'kr1',            connectionName: 'nhncloud-kr1', imageId: '0f07c795-2a46-44fc-a61b-fa0d96763ce2', subGroupSize: '2' },
+    // Tencent
+    ng7a: { subGroupName: 'ng7a', provider: 'tencent',  region: 'ap-seoul',       connectionName: 'tencent-ap-seoul',        subGroupSize: '2' },
+    ng7b: { subGroupName: 'ng7b', provider: 'tencent',  region: 'ap-seoul',       connectionName: 'tencent-ap-seoul',        subGroupSize: '2' },
+    // IBM
+    ng8a: { subGroupName: 'ng8a', provider: 'ibm',      region: 'jp-tok',         connectionName: 'ibm-jp-tok',              subGroupSize: '2' },
+    ng8b: { subGroupName: 'ng8b', provider: 'ibm',      region: 'jp-tok',         connectionName: 'ibm-jp-tok',              subGroupSize: '2' },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/infra/TC-INFRA-K8S-03.params.ts
+++ b/e2e/params/base/tc/infra/TC-INFRA-K8S-03.params.ts
@@ -1,0 +1,95 @@
+/**
+ * deploy/params/base/tc/infra/TC-INFRA-K8S-03.params.ts
+ * TC-INFRA-K8S-03: K8s 클러스터(PMK) 직접 생성
+ *
+ * createK8sDynamic API를 사용하여 CSP별 K8s 클러스터를 생성한다.
+ *
+ * 지원 CSP (K8s 가능 확인):
+ *   - Tencent: ap-tokyo (tencent-k8s 스펙)
+ *   - NCP: kr
+ *
+ * 런타임 OUT params:
+ *   store.set('k8sId',             생성된 K8s 클러스터 ID)
+ *   store.set('k8sId_{variant}',   CSP별 K8s ID)
+ *   store.set('k8sName',           clusterName)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:           'default',
+    // 2라운드: pmk11/pmk12 (1라운드 pmk1/pmk2 삭제 완료 후)
+    clusterName:    'pmk11',
+    nodeGroupName:  'png11',
+    connectionName: 'tencent-ap-tokyo',
+    commonSpec:     'tencent+ap-tokyo+S5.MEDIUM4',
+    desiredNodeSize: 1,
+    minNodeSize:     1,
+    maxNodeSize:     3,
+    onAutoScaling:  'false',
+  },
+  variants: {
+    // Step 1: Tencent K8s — 2라운드 pmk11/png11
+    tencent: {
+      clusterName:    'pmk11',
+      nodeGroupName:  'png11',
+      connectionName: 'tencent-ap-tokyo',
+      commonSpec:     'tencent+ap-tokyo+S5.MEDIUM4',
+    },
+    // Step 2: NCP K8s — 2라운드 pmk12/png12
+    ncp: {
+      clusterName:    'pmk12',
+      nodeGroupName:  'png12',
+      connectionName: 'ncp-kr',
+      commonSpec:     'ncp+kr+s2-g3',
+    },
+
+    // ── C4-02 전용: 6개 CSP K8s 클러스터 (Dynamic 모드)
+    // commonSpec 미지정 → TC가 vCPU 2→4 순으로 자동 선택
+    aws: {
+      clusterName:     'k8s-aws',
+      nodeGroupName:   'png-aws',
+      connectionName:  'aws-ap-northeast-2',
+      desiredNodeSize: 1,
+      minNodeSize:     1,
+      maxNodeSize:     3,
+      onAutoScaling:   'false',
+    },
+    azure: {
+      clusterName:     'k8s-azure',
+      nodeGroupName:   'png-azure',
+      connectionName:  'azure-koreacentral',
+      desiredNodeSize: 1,
+      minNodeSize:     1,
+      maxNodeSize:     3,
+      onAutoScaling:   'false',
+    },
+    ali: {
+      clusterName:     'k8s-ali',
+      nodeGroupName:   'png-ali',
+      connectionName:  'alibaba-ap-northeast-2',
+      desiredNodeSize: 1,
+      minNodeSize:     1,
+      maxNodeSize:     3,
+      onAutoScaling:   'false',
+    },
+    gcp: {
+      clusterName:     'k8s-gcp',
+      nodeGroupName:   'png-gcp',
+      connectionName:  'gcp-asia-northeast3',
+      desiredNodeSize: 1,
+      minNodeSize:     1,
+      maxNodeSize:     3,
+      onAutoScaling:   'false',
+    },
+    nhn: {
+      clusterName:     'k8s-nhn',
+      nodeGroupName:   'png-nhn',
+      connectionName:  'nhncloud-kr1',
+      desiredNodeSize: 1,
+      minNodeSize:     1,
+      maxNodeSize:     3,
+      onAutoScaling:   'false',
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/infra/TC-INFRA-K8S-04.params.ts
+++ b/e2e/params/base/tc/infra/TC-INFRA-K8S-04.params.ts
@@ -1,0 +1,61 @@
+/**
+ * deploy/params/base/tc/infra/TC-INFRA-K8S-04.params.ts
+ * TC-INFRA-K8S-04: PMK 클러스터 생성 (Expert 모드)
+ *
+ * Dynamic 모드(K8S-03)와 달리 toggleExpertCreation() 버튼으로 전환된
+ * #create_expert 폼을 사용하며 Provider / Region 드롭다운이 추가된다.
+ *
+ * 런타임 OUT params:
+ *   store.set('k8sId',   생성된 K8s 클러스터 ID)
+ *   store.set('k8sName', clusterName)
+ *   store.set('nsId',    nsId)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:           'default',
+    clusterName:    'pmk-exp1',
+    nodeGroupName:  'png-exp1',
+    provider:       'tencent',
+    region:         'ap-tokyo',
+    connectionName: 'tencent-ap-tokyo',
+    commonSpec:     'tencent+ap-tokyo+S5.MEDIUM4',
+    desiredNodeSize: 1,
+    minNodeSize:     1,
+    maxNodeSize:     3,
+    onAutoScaling:  'false',
+  },
+  variants: {
+    tencent: {
+      clusterName:    'pmk-exp1',
+      nodeGroupName:  'png-exp1',
+      provider:       'tencent',
+      region:         'ap-tokyo',
+      connectionName: 'tencent-ap-tokyo',
+      commonSpec:     'tencent+ap-tokyo+S5.MEDIUM4',
+    },
+    ncp: {
+      clusterName:    'pmk-exp2',
+      nodeGroupName:  'png-exp2',
+      provider:       'ncp',
+      region:         'kr',
+      connectionName: 'ncp-kr',
+      commonSpec:     'ncp+kr+s2-g3',
+    },
+
+    // ── C4-02 전용: IBM K8s 클러스터 (Expert 모드)
+    // commonSpec 미지정 → TC가 vCPU 2→4 순으로 자동 선택
+    ibm: {
+      clusterName:     'k8s-ibm',
+      nodeGroupName:   'png-ibm',
+      provider:        'ibm',
+      region:          'jp-tok',
+      connectionName:  'ibm-jp-tok',
+      desiredNodeSize: 1,
+      minNodeSize:     1,
+      maxNodeSize:     3,
+      onAutoScaling:   'false',
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/infra/TC-INFRA-K8S-05.params.ts
+++ b/e2e/params/base/tc/infra/TC-INFRA-K8S-05.params.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/params/base/tc/infra/TC-INFRA-K8S-05.params.ts
+ * TC-INFRA-K8S-05: PMK KubeConfig 획득 — 기본 파라미터
+ *
+ * C7-k8s-per-csp (aws), C7-k8s-manage-ibm (ibm) 에서 사용.
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:        'default',
+    clusterName: 'pmk1',
+  },
+  variants: {
+    aws: { clusterName: 'tc-k8s-aws' },
+    ibm: { clusterName: 'tc-k8s-ibm' },
+    tencent: { clusterName: 'pmk11' },
+    ncp:     { clusterName: 'pmk12' },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/infra/TC-INFRA-K8S-07.params.ts
+++ b/e2e/params/base/tc/infra/TC-INFRA-K8S-07.params.ts
@@ -1,0 +1,21 @@
+/**
+ * deploy/params/base/tc/infra/TC-INFRA-K8S-07.params.ts
+ * TC-INFRA-K8S-07: PMK NodeGroup 삭제 — 기본 파라미터
+ *
+ * minNodeGroupRequired: true 인 CSP는 NodeGroup 개별 삭제 불가.
+ * 해당 variant 는 이 TC를 건너뛰고 TC-INFRA-K8S-08(PMK 삭제)로 일괄 처리.
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nodeGroupName:        'png1',
+    minNodeGroupRequired: false,
+  },
+  variants: {
+    tencent: { nodeGroupName: 'png11', minNodeGroupRequired: false },
+    ncp:     { nodeGroupName: 'png12', minNodeGroupRequired: false },
+    // 최소 1 NodeGroup을 요구하는 CSP 예시:
+    // someCSP: { minNodeGroupRequired: true },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/infra/TC-INFRA-K8S-08.params.ts
+++ b/e2e/params/base/tc/infra/TC-INFRA-K8S-08.params.ts
@@ -1,0 +1,25 @@
+/**
+ * deploy/params/base/tc/infra/TC-INFRA-K8S-08.params.ts
+ * TC-INFRA-K8S-08: PMK(K8s 클러스터) 삭제
+ *
+ * TC-INFRA-K8S-03 생성 params와 항상 쌍으로 맞춤.
+ * CSP가 최소 1 NodeGroup을 요구하는 경우 TC-INFRA-K8S-07 이 FAIL 처리되며,
+ * 이 TC에서 클러스터 삭제 시 NodeGroup도 함께 제거된다.
+ *
+ * 이름 체계:
+ *   1라운드 pmk1/pmk2 ← 현재 active (tencent pmk1 확인됨)
+ *   2라운드 pmk11/pmk12 (TC-INFRA-K8S-03 2라운드 생성 후 맞춤 예정)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:        'default',
+    clusterName: '',
+  },
+  variants: {
+    // 1라운드 active 클러스터
+    tencent: { clusterName: 'pmk1' },
+    ncp:     { clusterName: 'pmk2' },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/infra/TC-INFRA-LC-02.params.ts
+++ b/e2e/params/base/tc/infra/TC-INFRA-LC-02.params.ts
@@ -1,0 +1,32 @@
+/**
+ * deploy/params/base/tc/infra/TC-INFRA-LC-02.params.ts
+ * TC-INFRA-LC-02: MCI 삭제
+ *
+ * variant 를 통해 어느 MCI를 삭제할지 지정한다.
+ * mciId 가 비어있으면 runInfraLc02 는 런타임 store.mciId → MCI_ID 환경변수 순으로 폴백한다.
+ *
+ * 이름 체계: TC-INFRA-DEPLOY-05 생성 params와 항상 쌍으로 맞춤
+ *   1라운드 mci1~7  → 삭제 완료 (2026-06-25)
+ *   2라운드 mci11~17 ← 현재
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:  'default',
+    mciId: '',   // 빈 값: 시나리오 store 또는 MCI_ID 환경변수로 주입
+  },
+  variants: {
+    // C4-mci-per-csp 생성 MCI 이름 (mci11~mci18)
+    aws:     { mciId: 'mci11' },
+    azure:   { mciId: 'mci12' },
+    gcp:     { mciId: 'mci13' },
+    ali:     { mciId: 'mci14' },
+    ibm:     { mciId: 'mci15' },
+    nhn:     { mciId: 'mci16' },
+    tencent: { mciId: 'mci17' },
+    ncp:     { mciId: 'mci18' },
+    // C3-mci-multi-csp 가 생성한 MCI 이름
+    'multi-csp': { mciId: 'mci-multi' },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/infra/TC-INFRA-MCI-01.params.ts
+++ b/e2e/params/base/tc/infra/TC-INFRA-MCI-01.params.ts
@@ -1,0 +1,12 @@
+/**
+ * deploy/params/base/tc/infra/TC-INFRA-MCI-01.params.ts
+ * TC-INFRA-MCI-01: MCI 목록 조회
+ * TC-INFRA-MCI-02: MCI 상세 조회  (같은 파일 공유 — nsId 필요)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId: 'default',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/infra/TC-INFRA-MCI-03.params.ts
+++ b/e2e/params/base/tc/infra/TC-INFRA-MCI-03.params.ts
@@ -1,0 +1,101 @@
+/**
+ * deploy/params/base/tc/infra/TC-INFRA-MCI-03.params.ts
+ * TC-INFRA-MCI-03: MCI 생성
+ *
+ * CSP별 variant 를 통해 동일 TC를 여러 클라우드에서 실행할 수 있다.
+ *
+ * 런타임 OUT params:
+ *   store.set('mciId',   생성된 MCI ID)
+ *   store.set('mciName', mciName)
+ *   store.set('nsId',    nsId)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:    'default',
+    mciName: 'tc-mci-temp',
+    // 기본값: aws ap-northeast-2
+    connectionName: 'aws-ap-northeast-2',
+    commonSpec:     'aws+ap-northeast-2+c4.large',
+    imageId:        'ami-0afe1fd15675c3f15',
+    rootDiskType:   'default',
+    rootDiskSize:   '0',
+    subGroupSize:   '1',
+  },
+  variants: {
+    // ── VM(MCI) 생성 variants — mciName·vmName은 생성 순서 기반 (mci1~7, ing1~7)
+    // specId/imageId: SearchImage API + c4-record.json 검증값 (2026-06-25)
+    aws: {
+      mciName:        'mci1',
+      vmName:         'ing1',
+      connectionName: 'aws-ap-northeast-2',
+      commonSpec:     'aws+ap-northeast-2+c4.large',
+      imageId:        'ami-0afe1fd15675c3f15',
+    },
+    azure: {
+      mciName:        'mci2',
+      vmName:         'ing2',
+      connectionName: 'azure-koreacentral',
+      commonSpec:     'azure+koreacentral+standard_b4ms',
+      imageId:        'Canonical:ubuntu-22_04-lts:server:22.04.202603110',
+    },
+    gcp: {
+      mciName:        'mci3',
+      vmName:         'ing3',
+      connectionName: 'gcp-asia-northeast3',
+      commonSpec:     'gcp+asia-northeast3+n1-standard-1',
+      imageId:        'https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-2204-jammy-v20260612',
+    },
+    ali: {
+      mciName:        'mci4',
+      vmName:         'ing4',
+      connectionName: 'alibaba-ap-northeast-1',
+      commonSpec:     'alibaba+eu-central-1+ecs.t6-c4m1.large',
+      imageId:        'ubuntu_22_04_x64_20G_alibase_20260522.vhd',
+    },
+    ibm: {
+      mciName:        'mci5',
+      vmName:         'ing5',
+      connectionName: 'ibm-jp-tok',
+      commonSpec:     'ibm+jp-tok+bx2-2x8',
+      imageId:        'r022-7b087e37-53f6-4613-9670-e8cfed3d2527',
+    },
+    nhn: {
+      mciName:        'mci6',
+      vmName:         'ing6',
+      connectionName: 'nhncloud-kr1',
+      commonSpec:     'nhn+kr1+m2.c2m4',
+      imageId:        '0f07c795-2a46-44fc-a61b-fa0d96763ce2',
+    },
+    // Tencent VM(MCI) — ap-seoul (2026-06-26 SearchImage 확인)
+    // 중국 본토(ap-chongqing 등)는 사용 불가 → ap-seoul로 변경
+    // img-487zeit5: Ubuntu Server 22.04 LTS 64bit (x86_64, non-UEFI)
+    tencent: {
+      mciName:        'mci7',
+      vmName:         'ing7',
+      connectionName: 'tencent-ap-seoul',
+      commonSpec:     'tencent+ap-seoul+s3.small1',
+      imageId:        'img-487zeit5',
+    },
+    // ── 대형 인스턴스 (scale-out / 특수 용도)
+    'aws-large': {
+      connectionName: 'aws-ap-northeast-2',
+      commonSpec:     'aws+ap-northeast-2+t2.medium',
+    },
+    // ── K8s Node 전용 variants (TC-INFRA-K8S-03에서 재사용)
+    // Tencent K8s Node — ap-tokyo 사용 (2026-06-24 확인)
+    'tencent-k8s': {
+      connectionName: 'tencent-ap-tokyo',
+      commonSpec:     'tencent+ap-tokyo+S5.MEDIUM4',
+    },
+    // NCP K8s Node (2026-06-24 확인)
+    ncp: {
+      connectionName: 'ncp-kr',
+      commonSpec:     'ncp+kr+s2-g3',
+    },
+    // 폐기 이력:
+    // ap-chongqing+s5.medium4: ResourceInsufficient (2026-06-26)
+    // ap-seoul+s2.small1: out of stock (2026-06-24)
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/infra/TC-INFRA-MCI-05.params.ts
+++ b/e2e/params/base/tc/infra/TC-INFRA-MCI-05.params.ts
@@ -1,0 +1,27 @@
+/**
+ * deploy/params/base/tc/infra/TC-INFRA-MCI-05.params.ts
+ * TC-INFRA-MCI-05: MCI 삭제
+ *
+ * variant 를 통해 어느 MCI를 삭제할지 지정한다.
+ * mciId 가 비어있으면 runInfraMci05 는 런타임 store.mciId → MCI_ID 환경변수 순으로 폴백한다.
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:  'default',
+    mciId: '',   // 빈 값: 시나리오 store 또는 MCI_ID 환경변수로 주입
+  },
+  variants: {
+    // C3-mci-per-csp 가 생성한 MCI 이름 (mci1~mci7)
+    aws:     { mciId: 'mci1' },
+    azure:   { mciId: 'mci2' },
+    gcp:     { mciId: 'mci3' },
+    ali:     { mciId: 'mci4' },
+    ibm:     { mciId: 'mci5' },
+    nhn:     { mciId: 'mci6' },
+    tencent: { mciId: 'mci7' },
+    // C3-mci-multi-csp 가 생성한 MCI 이름
+    'multi-csp': { mciId: 'mci-multi' },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/obs/TC-OBS-METRIC-01.params.ts
+++ b/e2e/params/base/tc/obs/TC-OBS-METRIC-01.params.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/params/base/tc/obs/TC-OBS-METRIC-01.params.ts
+ * TC-OBS-METRIC-01 ~ 06 공통 파라미터
+ *
+ * 런타임 IN params:
+ *   store.require('mciId') — TC-INFRA-DEPLOY-05 OUT
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:        'default',
+    // mciId 는 런타임 스토어에서 주입
+    metricType:  'cpu',     // 'cpu' | 'memory' | 'disk' | 'network'
+    periodSec:   60,
+    agentPort:   9090,
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/sw/TC-APP-CAT-03.params.ts
+++ b/e2e/params/base/tc/sw/TC-APP-CAT-03.params.ts
@@ -1,0 +1,14 @@
+/**
+ * deploy/params/base/tc/sw/TC-APP-CAT-03.params.ts
+ * TC-APP-CAT-03: 외부 검색 결과 표시 (DockerHub/ArtifactHub)
+ *
+ * 런타임 OUT params:
+ *   store.set('searchKeyword', keyword)   — TC-APP-CAT-04에서 사용
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    searchKeyword: 'ghost',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/sw/TC-APP-CAT-04.params.ts
+++ b/e2e/params/base/tc/sw/TC-APP-CAT-04.params.ts
@@ -1,0 +1,21 @@
+/**
+ * deploy/params/base/tc/sw/TC-APP-CAT-04.params.ts
+ * TC-APP-CAT-04: 외부 검색 결과 업로드 (DockerHub → 내부 패키지 레지스트리)
+ *
+ * 런타임 IN params:
+ *   store.getOrDefault('searchKeyword', base.searchKeyword)   — TC-APP-CAT-03 OUT
+ *
+ * 런타임 OUT params:
+ *   store.set('uploadedPackageName', name)   — TC-APP-CAT-05에서 사용
+ *   store.set('uploadedTag', tag)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    searchKeyword: 'ghost',
+    sourceType:    'DockerHub',        // 'DockerHub' | 'ArtifactHub'
+    uploadTag:     'bookworm',         // Upload Application 팝업에서 선택할 Tag (부분 매칭)
+    packageName:   'ghost',            // 업로드 후 패키지 목록에서 확인할 이름
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/sw/TC-APP-CAT-05.params.ts
+++ b/e2e/params/base/tc/sw/TC-APP-CAT-05.params.ts
@@ -1,0 +1,28 @@
+/**
+ * deploy/params/base/tc/sw/TC-APP-CAT-05.params.ts
+ * TC-APP-CAT-05: Catalog 신규 등록 (Regist 버튼)
+ * TC-APP-CAT-06: Catalog 수정   (같은 파일 공유)
+ * TC-APP-CAT-07: Catalog 삭제   (같은 파일 공유)
+ *
+ * Wizard → Package Tab:
+ *   Target   : VM
+ *   Category : Content Management System
+ *   Package  : ghost  (TC-APP-CAT-04 Upload 결과물)
+ *   Version  : bookworm (부분 매칭)
+ *
+ * 런타임 IN params:
+ *   store.getOrDefault('uploadedPackageName', base.packageName)   — TC-APP-CAT-04 OUT
+ *
+ * 런타임 OUT params:
+ *   store.set('catalogName', packageName)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    target:      'VM',
+    category:    'Content Management System',
+    packageName: 'ghost',
+    version:     'bookworm',    // 버전 드롭다운에서 이 문자열을 포함하는 항목 선택
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/sw/TC-APP-DEP-01.params.ts
+++ b/e2e/params/base/tc/sw/TC-APP-DEP-01.params.ts
@@ -1,0 +1,57 @@
+/**
+ * deploy/params/base/tc/sw/TC-APP-DEP-01.params.ts
+ * TC-APP-DEP-01: SW 배포 — VM Standalone
+ * TC-APP-DEP-02: SW 배포 — VM Clustering   (같은 파일 공유)
+ * TC-APP-DEP-03: SW 배포 — K8s Helm        (같은 파일 공유, 'k8s' variant)
+ *
+ * 런타임 IN params:
+ *   store.require('mciId')    — TC-INFRA-DEPLOY-05 OUT
+ *   store.require('mciName')  — TC-INFRA-DEPLOY-05 OUT
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:        'default',
+    appName:     'tc-nginx',
+    catalogName: 'nginx',
+    version:     'latest',
+    // mciId, mciName 은 런타임 스토어에서 주입
+  },
+  variants: {
+    standalone: {
+      deployType:  'standalone',
+      replicaCount: 1,
+    },
+    clustering: {
+      deployType:  'clustering',
+      replicaCount: 3,
+    },
+    k8s: {
+      deployType:   'k8s',
+      helmChartUrl: '',
+      namespace:    'default',
+    },
+    mci11: {
+      mciId:       'mci11',
+      mciName:     'mci11',
+      nsId:        'default',
+      deployType:  'standalone',
+      replicaCount: 1,
+    },
+    mci16: {
+      mciId:       'mci16',
+      mciName:     'mci16',
+      nsId:        'default',
+      deployType:  'standalone',
+      replicaCount: 1,
+    },
+    mci18: {
+      mciId:       'mci18',
+      mciName:     'mci18',
+      nsId:        'default',
+      deployType:  'standalone',
+      replicaCount: 1,
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/sw/TC-APP-REP-02.params.ts
+++ b/e2e/params/base/tc/sw/TC-APP-REP-02.params.ts
@@ -1,0 +1,39 @@
+/**
+ * deploy/params/base/tc/sw/TC-APP-REP-02.params.ts
+ * TC-APP-REP-02: Repository 신규 생성
+ *
+ * variant 'api' / 'ui:helm' / 'ui:docker' 세 케이스에 대응
+ *
+ * 런타임 OUT params:
+ *   store.set('helmRepoName',   helmRepoName)
+ *   store.set('dockerRepoName', dockerRepoName)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    helmRepoName:   'e2e-repo-helm',
+    dockerRepoName: 'e2e-repo-docker',
+    blobStoreName:  'default',
+    writePolicy:    'allow',
+  },
+  variants: {
+    api: {
+      // API 케이스: helm + docker 모두 생성
+      helmRepoName:   'e2e-repo-helm',
+      dockerRepoName: 'e2e-repo-docker',
+    },
+    'ui:helm': {
+      repoName:   'e2e-ui-helm',
+      repoFormat: 'helm',
+      repoType:   'hosted',
+    },
+    'ui:docker': {
+      repoName:   'e2e-ui-docker',
+      repoFormat: 'docker',
+      repoType:   'hosted',
+      httpPort:   null,
+      httpsPort:  null,
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workflow/TC-WF-EL-01.params.ts
+++ b/e2e/params/base/tc/workflow/TC-WF-EL-01.params.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/params/base/tc/workflow/TC-WF-EL-01.params.ts
+ * TC-WF-EL-01: Event Listener 목록 조회
+ *
+ * 워크플로우 관리 화면(iframe) > Event Listener 탭 진입 후
+ * 목록 로드를 확인한다.
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    // 필터링 확인에 사용할 EL 이름 (빈 문자열이면 단순 탭 진입만 확인)
+    eventListenerName: '',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workflow/TC-WF-EL-02.params.ts
+++ b/e2e/params/base/tc/workflow/TC-WF-EL-02.params.ts
@@ -1,0 +1,21 @@
+/**
+ * deploy/params/base/tc/workflow/TC-WF-EL-02.params.ts
+ * TC-WF-EL-02: Event Listener 생성 (워크플로우 연결)
+ * TC-WF-EL-05: GET Trigger URL로 워크플로우 실행 (같은 파일 공유)
+ *
+ * 워크플로우 관리 화면(iframe) > Event Listener 탭에서
+ * EL을 생성하고 대상 워크플로우와 연결한다.
+ *
+ * 런타임 OUT params (TC-WF-EL-02):
+ *   store.set('elName', eventListenerName)   — 생성된 EL 이름
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    // 생성할 Event Listener 이름
+    eventListenerName: 'infra-create-el',
+    // 연결할 워크플로우 이름 (TC-WF-FLOW-03 workflowName과 동일해야 함)
+    workflowName:      'vm-mariadb-backup-import-data-init',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workflow/TC-WF-EL-03.params.ts
+++ b/e2e/params/base/tc/workflow/TC-WF-EL-03.params.ts
@@ -1,0 +1,11 @@
+/**
+ * TC-WF-EL-03: Event Listener 이름 중복 검사
+ * eventListenerName이 비어 있으면 store의 elName을 사용
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    eventListenerName: '',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workflow/TC-WF-EL-04.params.ts
+++ b/e2e/params/base/tc/workflow/TC-WF-EL-04.params.ts
@@ -1,0 +1,11 @@
+/**
+ * TC-WF-EL-04: Event Listener 상세 수정
+ * eventListenerName이 비어 있으면 store의 elName을 사용
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    eventListenerName: '',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workflow/TC-WF-EL-05.params.ts
+++ b/e2e/params/base/tc/workflow/TC-WF-EL-05.params.ts
@@ -1,0 +1,11 @@
+/**
+ * TC-WF-EL-05: Event Listener 삭제
+ * eventListenerName이 비어 있으면 store의 elName을 사용
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    eventListenerName: '',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workflow/TC-WF-EL-06.params.ts
+++ b/e2e/params/base/tc/workflow/TC-WF-EL-06.params.ts
@@ -1,0 +1,11 @@
+/**
+ * TC-WF-EL-06: Event Listener를 통한 Workflow 실행 (GET)
+ * eventListenerName이 비어 있으면 store의 elName을 사용
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    eventListenerName: '',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workflow/TC-WF-EL-07.params.ts
+++ b/e2e/params/base/tc/workflow/TC-WF-EL-07.params.ts
@@ -1,0 +1,13 @@
+/**
+ * TC-WF-EL-07: Event Listener를 통한 Workflow 실행 (POST)
+ * eventListenerName이 비어 있으면 store의 elName을 사용
+ * triggerBody: POST 요청 바디 (key-value)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    eventListenerName: '',
+    triggerBody: {},
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workflow/TC-WF-FLOW-01.params.ts
+++ b/e2e/params/base/tc/workflow/TC-WF-FLOW-01.params.ts
@@ -1,0 +1,8 @@
+/**
+ * TC-WF-FLOW-01: Workflow Engine(Jenkins) 등록 및 연동 확인
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {},
+} satisfies TCParams;

--- a/e2e/params/base/tc/workflow/TC-WF-FLOW-02.params.ts
+++ b/e2e/params/base/tc/workflow/TC-WF-FLOW-02.params.ts
@@ -1,0 +1,17 @@
+/**
+ * deploy/params/base/tc/workflow/TC-WF-FLOW-02.params.ts
+ * TC-WF-FLOW-02: 신규 워크플로우 생성 A (인프라 배포 + SW 설치)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    flowName:    'tc-flow-a-infra-sw',
+    description: 'E2E — 인프라 배포 + SW 설치 플로우',
+    // 노드 정의
+    nodes: [
+      { id: 'n1', type: 'infra-deploy' },
+      { id: 'n2', type: 'sw-install',  dependsOn: ['n1'] },
+    ],
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workflow/TC-WF-FLOW-03.params.ts
+++ b/e2e/params/base/tc/workflow/TC-WF-FLOW-03.params.ts
@@ -1,0 +1,70 @@
+/**
+ * deploy/params/base/tc/workflow/TC-WF-FLOW-03.params.ts
+ * TC-WF-FLOW-03: 워크플로우 생성 (정의)
+ * TC-WF-FLOW-06: 워크플로우 실행   (같은 파일 공유)
+ * TC-WF-FLOW-05: 워크플로우 삭제   (같은 파일 공유)
+ *
+ * 워크플로우 이름-역할 매핑:
+ *   vm-mariadb-backup-import-data-init   — 단일 CSP 인프라 배포 + SW(mariadb) 설치
+ *   vm-mariadb-data-init-cleanup         — 단일 CSP 인프라 삭제           ↑ 쌍
+ *
+ *   multi-csp-vm-deploy                  — 다중 CSP 인프라 배포
+ *   multi-csp-vm-cleanup                 — 다중 CSP 인프라 삭제            ↑ 쌍
+ *
+ *   k8s-mariadb-backup-import-data-init  — 단일 CSP 클러스터 배포 + SW 설치
+ *   k8s-mariadb-data-init-cleanup        — 단일 CSP 클러스터 삭제          ↑ 쌍
+ *
+ *   multi-csp-k8s-cluster-deploy         — 다중 CSP 클러스터 배포
+ *   multi-csp-k8s-cluster-cleanup        — 다중 CSP 클러스터 삭제          ↑ 쌍
+ *
+ * 런타임 OUT params (TC-WF-FLOW-03):
+ *   store.set('workflowId',   생성/조회된 workflow ID)
+ *   store.set('workflowName', workflowName)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    // 기본값 — 시나리오 params(Layer 3) 또는 PW_workflowName(Layer 4)로 덮어씀
+    workflowName:        'vm-mariadb-backup-import-data-init',
+    workflowDescription: '단일 CSP 인프라 배포 + SW 설치',
+  },
+
+  variants: {
+    // ── VM 인프라 ────────────────────────────────────────────────────────────
+    'infra-single': {
+      workflowName:        'vm-mariadb-backup-import-data-init',
+      workflowDescription: '단일 CSP 인프라 배포 + mariadb 설치',
+    },
+    'infra-single-cleanup': {
+      workflowName:        'vm-mariadb-data-init-cleanup',
+      workflowDescription: '단일 CSP 인프라 삭제',
+    },
+    'infra-multi': {
+      workflowName:        'multi-csp-vm-deploy',
+      workflowDescription: '다중 CSP 인프라 배포 (8종)',
+    },
+    'infra-multi-cleanup': {
+      workflowName:        'multi-csp-vm-cleanup',
+      workflowDescription: '다중 CSP 인프라 삭제 (8종)',
+    },
+
+    // ── K8s 클러스터 ─────────────────────────────────────────────────────────
+    'k8s-single': {
+      workflowName:        'k8s-mariadb-backup-import-data-init',
+      workflowDescription: '단일 CSP 클러스터 배포 + mariadb Helm 설치',
+    },
+    'k8s-single-cleanup': {
+      workflowName:        'k8s-mariadb-data-init-cleanup',
+      workflowDescription: '단일 CSP 클러스터 삭제',
+    },
+    'k8s-multi': {
+      workflowName:        'multi-csp-k8s-cluster-deploy',
+      workflowDescription: '다중 CSP 클러스터 배포',
+    },
+    'k8s-multi-cleanup': {
+      workflowName:        'multi-csp-k8s-cluster-cleanup',
+      workflowDescription: '다중 CSP 클러스터 삭제',
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workflow/TC-WF-FLOW-04.params.ts
+++ b/e2e/params/base/tc/workflow/TC-WF-FLOW-04.params.ts
@@ -1,0 +1,10 @@
+/**
+ * TC-WF-FLOW-04: Workflow 상세 수정
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    workflowName: '',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workflow/TC-WF-FLOW-05.params.ts
+++ b/e2e/params/base/tc/workflow/TC-WF-FLOW-05.params.ts
@@ -1,0 +1,10 @@
+/**
+ * TC-WF-FLOW-05: Workflow 삭제
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    workflowName: '',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workflow/TC-WF-FLOW-07.params.ts
+++ b/e2e/params/base/tc/workflow/TC-WF-FLOW-07.params.ts
@@ -1,0 +1,10 @@
+/**
+ * TC-WF-FLOW-07: Workflow 로그 모달 표시
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    workflowName: '',
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workflow/TC-WORKFLOW-02.params.ts
+++ b/e2e/params/base/tc/workflow/TC-WORKFLOW-02.params.ts
@@ -1,0 +1,70 @@
+/**
+ * deploy/params/base/tc/workflow/TC-WORKFLOW-02.params.ts
+ * TC-WORKFLOW-02: 워크플로우 생성 (정의)
+ * TC-WORKFLOW-03: 워크플로우 실행   (같은 파일 공유)
+ * TC-WORKFLOW-04: 워크플로우 삭제   (같은 파일 공유)
+ *
+ * 워크플로우 이름-역할 매핑:
+ *   vm-mariadb-backup-import-data-init   — 단일 CSP 인프라 배포 + SW(mariadb) 설치
+ *   vm-mariadb-data-init-cleanup         — 단일 CSP 인프라 삭제           ↑ 쌍
+ *
+ *   multi-csp-vm-deploy                  — 다중 CSP 인프라 배포
+ *   multi-csp-vm-cleanup                 — 다중 CSP 인프라 삭제            ↑ 쌍
+ *
+ *   k8s-mariadb-backup-import-data-init  — 단일 CSP 클러스터 배포 + SW 설치
+ *   k8s-mariadb-data-init-cleanup        — 단일 CSP 클러스터 삭제          ↑ 쌍
+ *
+ *   multi-csp-k8s-cluster-deploy         — 다중 CSP 클러스터 배포
+ *   multi-csp-k8s-cluster-cleanup        — 다중 CSP 클러스터 삭제          ↑ 쌍
+ *
+ * 런타임 OUT params (TC-WORKFLOW-02):
+ *   store.set('workflowId',   생성/조회된 workflow ID)
+ *   store.set('workflowName', workflowName)
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    // 기본값 — 시나리오 params(Layer 3) 또는 PW_workflowName(Layer 4)로 덮어씀
+    workflowName:        'vm-mariadb-backup-import-data-init',
+    workflowDescription: '단일 CSP 인프라 배포 + SW 설치',
+  },
+
+  variants: {
+    // ── VM 인프라 ────────────────────────────────────────────────────────────
+    'infra-single': {
+      workflowName:        'vm-mariadb-backup-import-data-init',
+      workflowDescription: '단일 CSP 인프라 배포 + mariadb 설치',
+    },
+    'infra-single-cleanup': {
+      workflowName:        'vm-mariadb-data-init-cleanup',
+      workflowDescription: '단일 CSP 인프라 삭제',
+    },
+    'infra-multi': {
+      workflowName:        'multi-csp-vm-deploy',
+      workflowDescription: '다중 CSP 인프라 배포 (8종)',
+    },
+    'infra-multi-cleanup': {
+      workflowName:        'multi-csp-vm-cleanup',
+      workflowDescription: '다중 CSP 인프라 삭제 (8종)',
+    },
+
+    // ── K8s 클러스터 ─────────────────────────────────────────────────────────
+    'k8s-single': {
+      workflowName:        'k8s-mariadb-backup-import-data-init',
+      workflowDescription: '단일 CSP 클러스터 배포 + mariadb Helm 설치',
+    },
+    'k8s-single-cleanup': {
+      workflowName:        'k8s-mariadb-data-init-cleanup',
+      workflowDescription: '단일 CSP 클러스터 삭제',
+    },
+    'k8s-multi': {
+      workflowName:        'multi-csp-k8s-cluster-deploy',
+      workflowDescription: '다중 CSP 클러스터 배포',
+    },
+    'k8s-multi-cleanup': {
+      workflowName:        'multi-csp-k8s-cluster-cleanup',
+      workflowDescription: '다중 CSP 클러스터 삭제',
+    },
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workload/TC-WORKLOAD-MCI-01.params.ts
+++ b/e2e/params/base/tc/workload/TC-WORKLOAD-MCI-01.params.ts
@@ -1,0 +1,19 @@
+/**
+ * deploy/params/base/tc/workload/TC-WORKLOAD-MCI-01.params.ts
+ * TC-WORKLOAD-MCI-01: MCI 터미널 접속·명령 실행
+ *
+ * 런타임 IN params:
+ *   store.require('mciId')   — TC-INFRA-DEPLOY-05 OUT
+ *   store.require('mciName') — TC-INFRA-DEPLOY-05 OUT
+ */
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:     'default',
+    // mciId, mciName 은 런타임 스토어에서 주입
+    command:  'echo hello-e2e && uptime',
+    username: 'cb-user',
+    sshPort:  22,
+  },
+} satisfies TCParams;

--- a/e2e/params/base/tc/workload/TC-WORKLOAD-MCI-02.params.ts
+++ b/e2e/params/base/tc/workload/TC-WORKLOAD-MCI-02.params.ts
@@ -1,0 +1,22 @@
+/**
+ * deploy/params/base/tc/workload/TC-WORKLOAD-MCI-02.params.ts
+ * TC-WORKLOAD-MCI-02: MCI 파일 전송
+ *
+ * 런타임 IN params:
+ *   store.require('mciId')   — TC-INFRA-DEPLOY-05 OUT
+ *   store.require('mciName') — TC-INFRA-DEPLOY-05 OUT
+ */
+import * as os from 'os';
+import * as path from 'path';
+import type { TCParams } from '../../../types';
+
+export default {
+  base: {
+    nsId:          'default',
+    // mciId, mciName 은 런타임 스토어에서 주입
+    localFilePath:  path.join(os.tmpdir(), 'tc-transfer-test.txt'),
+    remoteFilePath: '/home/cb-user/tc-transfer-test.txt',
+    username:       'cb-user',
+    sshPort:        22,
+  },
+} satisfies TCParams;

--- a/e2e/params/env/local.params.ts_sample
+++ b/e2e/params/env/local.params.ts_sample
@@ -1,0 +1,76 @@
+/**
+ * deploy/params/env/local.params.ts_sample
+ * 로컬 환경 파라미터 샘플
+ *
+ * ── 사용 방법 ──────────────────────────────────────────────────────
+ *   cp deploy/params/env/local.params.ts_sample deploy/params/env/local.params.ts
+ *   # local.params.ts 를 실제 값으로 편집 (커밋 금지 — .gitignore 적용됨)
+ *
+ * ── 파라미터 우선순위 ──────────────────────────────────────────────
+ *   Layer 1: base/tc/{domain}/{TC-ID}.params.ts   (기본값)
+ *   Layer 2: 이 파일 → local.params.ts             (환경별 공통 오버라이드)
+ *   Layer 3: base/scenarios/{id}.params.ts         (시나리오 스텝 오버라이드)
+ *   Layer 4: PW_* 환경변수                          (최고 우선순위 — CI/민감정보)
+ *
+ * ── 민감값 주입 방법 (Layer 4) ────────────────────────────────────
+ *   PW_adminPassword=실제비밀번호 npx playwright test ...
+ *   PW_credentialKeyId=AKIA... PW_credentialKeyValue=secret npx playwright test ...
+ */
+import type { EnvParams } from '../types';
+
+export default {
+  env: 'local',
+
+  // ── 전역 — 모든 TC에 적용 ───────────────────────────────────────────────
+  global: {
+    adminId:       'mcmp',
+    adminPassword: 'mcmp_password',       // 실제 값으로 변경 또는 PW_adminPassword 사용
+    baseUrl:       'http://localhost:3000',
+  },
+
+  // ── TC별 오버라이드 ──────────────────────────────────────────────────────
+  tc: {
+    // CSP Credential — 실제 Key 는 PW_credentialKeyId / PW_credentialKeyValue 로 주입 권장
+    'TC-CSP-CREDENTIAL-03': {
+      credentialHolder:   'e2e-credential',
+      credentialKeyId:    'AKIA_CHANGE_ME',
+      credentialKeyValue: 'SECRET_CHANGE_ME',
+    },
+
+    // RDB — 실제 DB 비밀번호는 PW_dbPassword 로 주입 권장
+    'TC-DATA-RDB-01': {
+      dbUser:     'e2e_user',
+      dbPassword: 'CHANGE_ME',
+    },
+
+    // mc-data-manager — AWS/Alibaba 접속정보 (deploy/params/base/tc/data/connections.ts)
+    'TC-DATA-RDB-01': {
+      sourcePoint: { password: 'mcmp_test' },
+      targetPoint: { password: 'mcmp_test123' },
+    },
+    'TC-DATA-RDB-MIG-01': {
+      sourcePoint: { password: 'mcmp_test' },
+      targetPoint: { password: 'mcmp_test123' },
+    },
+    'TC-DATA-NORDB-MIG-01': {
+      mongoPassword: 'mcmp_test123',
+    },
+  },
+
+  // ── 시나리오별 오버라이드 ────────────────────────────────────────────────
+  scenario: {
+    // C4 spec 검색 / MCI 중복 — Layer 4 PW_* 또는 shell env 로도 주입 가능
+    // 'C4-001': {
+    //   specSearch: { notFoundMode: 'fallback', maxCpu: 4, maxCost: 1 },
+    //   mciDuplicateMode: 'rename',
+    // },
+  },
+} satisfies EnvParams;
+
+// ── C4 시나리오 환경변수 (Layer 4, integration spec) ─────────────────────
+// C4_SPEC_NOT_FOUND_MODE=fail|fallback     (기본 fail)
+// C4_SPEC_MAX_CPU=4
+// C4_SPEC_MAX_COST=1
+// C4_MCI_DUPLICATE_MODE=rename|duplicate   (기본 rename)
+// C4_MCI_NAME=e2e-mci-c4
+// C5_MCI_NAME=c4-rec-aws

--- a/e2e/params/index.ts
+++ b/e2e/params/index.ts
@@ -1,0 +1,11 @@
+/**
+ * deploy/params/index.ts
+ * 파라미터 시스템 통합 진입점
+ *
+ * 사용 예:
+ *   import { loadTCParams, loadTCParamsForScenario, domainOf } from '../params';
+ *   import { ScenarioContext, StandaloneContext }               from '../params/runtime/context';
+ *   import { ScenarioRuntimeStore }                             from '../params/runtime/store';
+ */
+export { loadTCParams, loadTCParamsForScenario, domainOf } from './loader';
+export type { TCParams, EnvParams, ScenarioStaticParams, MergedParams, VariantSelector } from './types';

--- a/e2e/params/loader.ts
+++ b/e2e/params/loader.ts
@@ -1,0 +1,147 @@
+/**
+ * deploy/params/loader.ts
+ * 4-레이어 파라미터 로더
+ *
+ * 우선순위 (낮음 → 높음):
+ *   Layer 1: deploy/params/base/tc/{domain}/{TC-ID}.params.ts   (기본값, 커밋)
+ *   Layer 2: deploy/params/env/local.params.ts                   (.gitignore, 환경별)
+ *   Layer 3: deploy/params/base/scenarios/{scenario-id}.params.ts (시나리오 스텝 override)
+ *   Layer 4: process.env 의 PW_* 접두사 키                        (CI/민감정보, 최고 우선순위)
+ *
+ * process.env 매핑 예:
+ *   PW_adminId=mcmp        → params.adminId = 'mcmp'
+ *   PW_adminPassword=...   → params.adminPassword = '...'
+ *   PW_connectionName=aws-ap-northeast-2 → params.connectionName = '...'
+ */
+import * as path from 'path';
+import type { TCParams, EnvParams, ScenarioStaticParams, MergedParams, VariantSelector } from './types';
+
+// ── 도메인 매핑 ─────────────────────────────────────────────────────────────
+// TC ID의 두 번째 세그먼트(TC-{SEG}-...) → params 파일 폴더명
+const DOMAIN_MAP: Record<string, string> = {
+  IAM:      'iam',
+  CSP:      'csp',
+  INFRA:    'infra',
+  APP:      'sw',       // TC-APP-* → params/base/tc/sw/
+  DATA:     'data',
+  OBS:      'obs',
+  COST:     'cost',
+  COSTOPT:  'cost',    // TC-COSTOPT-* → params/base/tc/cost/
+  WF:       'workflow',
+  WORKFLOW: 'workflow',
+  WORKLOAD: 'workload',
+};
+
+/** TC ID → params 폴더명 */
+export function domainOf(tcId: string): string {
+  const parts   = tcId.split('-');      // ['TC', 'IAM', 'AUTH', '01', ...]
+  const segment = parts[1] ?? '';
+  return DOMAIN_MAP[segment] ?? segment.toLowerCase();
+}
+
+// params 루트: deploy/params/
+const PARAMS_ROOT = path.resolve(__dirname);
+
+// ── 동적 require 헬퍼 ────────────────────────────────────────────────────────
+
+function tryRequire<T>(absPath: string): T | undefined {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require(absPath) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+// ── Layer 1: base TC params ──────────────────────────────────────────────────
+
+function loadTCBaseParams(tcId: string, variant?: VariantSelector): MergedParams {
+  const domain   = domainOf(tcId);
+  const filePath = path.join(PARAMS_ROOT, 'base', 'tc', domain, `${tcId}.params`);
+  const mod      = tryRequire<{ default: TCParams }>(filePath);
+  if (!mod) return {};
+
+  const base = { ...(mod.default.base ?? {}) };
+  if (variant && mod.default.variants?.[variant]) {
+    return { ...base, ...mod.default.variants[variant] };
+  }
+  return base;
+}
+
+// ── Layer 2: env params ──────────────────────────────────────────────────────
+
+let _envParamsCache: EnvParams | null | undefined = undefined;
+
+function loadEnvParams(): EnvParams | undefined {
+  if (_envParamsCache !== undefined) return _envParamsCache ?? undefined;
+  const filePath = path.join(PARAMS_ROOT, 'env', 'local.params');
+  const mod      = tryRequire<{ default: EnvParams }>(filePath);
+  _envParamsCache = mod?.default ?? null;
+  return mod?.default;
+}
+
+// ── Layer 3: scenario static params ─────────────────────────────────────────
+
+function loadScenarioStaticParams(scenarioId: string, tcId: string): MergedParams {
+  const filePath = path.join(PARAMS_ROOT, 'base', 'scenarios', `${scenarioId}.params`);
+  const mod      = tryRequire<{ default: ScenarioStaticParams }>(filePath);
+  if (!mod) return {};
+
+  return {
+    ...(mod.default.global            ?? {}),
+    ...(mod.default.steps?.[tcId]     ?? {}),
+  };
+}
+
+// ── Layer 4: process.env (PW_* 접두사) ──────────────────────────────────────
+
+function extractProcessEnv(): MergedParams {
+  const result: MergedParams = {};
+  for (const [key, val] of Object.entries(process.env)) {
+    if (key.startsWith('PW_') && val !== undefined) {
+      // PW_adminId → adminId
+      result[key.slice(3)] = val;
+    }
+  }
+  return result;
+}
+
+// ── public API ───────────────────────────────────────────────────────────────
+
+/**
+ * TC 단독 실행용 파라미터 로드 (Layer 1 + 2 + 4)
+ *
+ * @param tcId    TC ID (예: 'TC-IAM-AUTH-01')
+ * @param variant variant 키 (예: 'aws', 'ui:helm') — 없으면 base만
+ */
+export function loadTCParams(tcId: string, variant?: VariantSelector): MergedParams {
+  const layer1      = loadTCBaseParams(tcId, variant);
+  const envParams   = loadEnvParams();
+  const layer2glob  = envParams?.global         ?? {};
+  const layer2tc    = envParams?.tc?.[tcId]     ?? {};
+  const layer4      = extractProcessEnv();
+
+  return { ...layer1, ...layer2glob, ...layer2tc, ...layer4 };
+}
+
+/**
+ * 시나리오 내 TC 파라미터 로드 (Layer 1 + 2 + 3 + 4)
+ *
+ * @param tcId       TC ID
+ * @param scenarioId 시나리오 ID (예: 'C4-001')
+ * @param variant    variant 키
+ */
+export function loadTCParamsForScenario(
+  tcId:       string,
+  scenarioId: string,
+  variant?:   VariantSelector,
+): MergedParams {
+  const layer1      = loadTCBaseParams(tcId, variant);
+  const envParams   = loadEnvParams();
+  const layer2glob  = envParams?.global             ?? {};
+  const layer2tc    = envParams?.tc?.[tcId]         ?? {};
+  const layer3      = loadScenarioStaticParams(scenarioId, tcId);
+  const layer4      = extractProcessEnv();
+
+  return { ...layer1, ...layer2glob, ...layer2tc, ...layer3, ...layer4 };
+}

--- a/e2e/params/runtime/context.ts
+++ b/e2e/params/runtime/context.ts
@@ -1,0 +1,113 @@
+/**
+ * deploy/params/runtime/context.ts
+ * 시나리오 실행 컨텍스트 — 정적 파라미터 + 런타임 스토어 통합
+ *
+ * 두 가지 컨텍스트를 제공한다:
+ *
+ *   ScenarioContext  — 시나리오 내에서 TC를 실행할 때 사용
+ *                      (4-레이어 정적 params + 런타임 store 모두 활성화)
+ *
+ *   StandaloneContext — TC를 독립 실행할 때 사용
+ *                       (Layer 1+2+4 정적 params만, store 없음)
+ *
+ * 사용 예 (시나리오 TC 파일):
+ *
+ *   import { ScenarioContext } from '../../deploy/params/runtime/context';
+ *
+ *   const ctx = new ScenarioContext('C4-001', 'TC-INFRA-DEPLOY-05');
+ *
+ *   test.afterAll(async () => {
+ *     ctx.store.set('mciId', createdMciId);
+ *     ctx.store.set('mciName', ctx.params.mciName as string);
+ *   });
+ *
+ * 사용 예 (독립 실행 TC 파일):
+ *
+ *   import { StandaloneContext } from '../../deploy/params/runtime/context';
+ *
+ *   const ctx = new StandaloneContext('TC-INFRA-DEPLOY-05', 'aws');
+ *   const nsId = ctx.require<string>('nsId');
+ */
+import { ScenarioRuntimeStore }                     from './store';
+import { loadTCParams, loadTCParamsForScenario }    from '../loader';
+import type { MergedParams, VariantSelector }        from '../types';
+
+// ── ScenarioContext ───────────────────────────────────────────────────────────
+
+export class ScenarioContext {
+  readonly scenarioId: string;
+  readonly tcId:       string;
+  readonly variant:    VariantSelector | undefined;
+  /** 4-레이어 병합된 정적 파라미터 */
+  readonly params:     MergedParams;
+  /** 시나리오 런타임 IN/OUT 스토어 */
+  readonly store:      ScenarioRuntimeStore;
+
+  constructor(scenarioId: string, tcId: string, variant?: VariantSelector) {
+    this.scenarioId = scenarioId;
+    this.tcId       = tcId;
+    this.variant    = variant;
+    this.params     = loadTCParamsForScenario(tcId, scenarioId, variant);
+    this.store      = new ScenarioRuntimeStore(scenarioId);
+  }
+
+  /** 정적 params에서 값 읽기 — 없으면 undefined */
+  get<T = unknown>(key: string): T | undefined {
+    return this.params[key] as T | undefined;
+  }
+
+  /** 정적 params에서 값 읽기 — 없으면 에러 throw */
+  require<T = unknown>(key: string): T {
+    const val = this.get<T>(key);
+    if (val === undefined) {
+      throw new Error(
+        `[ScenarioContext] 필수 정적 파라미터 없음: "${key}" (scenario: ${this.scenarioId}, tc: ${this.tcId})`,
+      );
+    }
+    return val;
+  }
+
+  /** 정적 params에서 값 읽기 — 없으면 fallback */
+  getOrDefault<T = unknown>(key: string, fallback: T): T {
+    const val = this.get<T>(key);
+    return val !== undefined ? val : fallback;
+  }
+}
+
+// ── StandaloneContext ─────────────────────────────────────────────────────────
+
+/** TC 독립 실행용 컨텍스트 (시나리오 없음, store 없음) */
+export class StandaloneContext {
+  readonly tcId:   string;
+  readonly variant: VariantSelector | undefined;
+  /** Layer 1 + 2 + 4 병합된 정적 파라미터 */
+  readonly params: MergedParams;
+
+  constructor(tcId: string, variant?: VariantSelector) {
+    this.tcId    = tcId;
+    this.variant = variant;
+    this.params  = loadTCParams(tcId, variant);
+  }
+
+  /** params에서 값 읽기 — 없으면 undefined */
+  get<T = unknown>(key: string): T | undefined {
+    return this.params[key] as T | undefined;
+  }
+
+  /** params에서 값 읽기 — 없으면 에러 throw */
+  require<T = unknown>(key: string): T {
+    const val = this.get<T>(key);
+    if (val === undefined) {
+      throw new Error(
+        `[StandaloneContext] 필수 파라미터 없음: "${key}" (tc: ${this.tcId})`,
+      );
+    }
+    return val;
+  }
+
+  /** params에서 값 읽기 — 없으면 fallback */
+  getOrDefault<T = unknown>(key: string, fallback: T): T {
+    const val = this.get<T>(key);
+    return val !== undefined ? val : fallback;
+  }
+}

--- a/e2e/params/runtime/discovered.ts
+++ b/e2e/params/runtime/discovered.ts
@@ -1,0 +1,36 @@
+/**
+ * deploy/params/runtime/discovered.ts
+ * 시나리오 실행 중 발견된 파라미터의 영속 관리 (Layer 2.5)
+ *
+ * 저장 경로: {outDir}/{scenarioId}/discovered.json
+ * - 시나리오 완료(afterAll) 시 store 스냅샷 전체를 저장한다.
+ * - 다음 실행 beforeAll에서 로드하여 store에 주입한다 (이미 있는 값은 덮지 않음).
+ * - 용도: mciId, k8sClusterId 등 UI에서 발견한 값을 다음 실행에서 재사용.
+ */
+import * as fs   from 'fs';
+import * as path from 'path';
+
+export function discoveredPath(outDir: string, scenarioId: string): string {
+  return path.join(outDir, scenarioId, 'discovered.json');
+}
+
+export function saveDiscovered(
+  outDir: string,
+  scenarioId: string,
+  params: Record<string, unknown>,
+): void {
+  const p = discoveredPath(outDir, scenarioId);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(params, null, 2), 'utf8');
+}
+
+export function loadDiscovered(
+  outDir: string,
+  scenarioId: string,
+): Record<string, unknown> {
+  try {
+    return JSON.parse(fs.readFileSync(discoveredPath(outDir, scenarioId), 'utf8')) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}

--- a/e2e/params/runtime/store.ts
+++ b/e2e/params/runtime/store.ts
@@ -1,0 +1,163 @@
+/**
+ * deploy/params/runtime/store.ts
+ * 시나리오 런타임 IN/OUT 파라미터 스토어
+ *
+ * 동작 원리:
+ *   - TC afterAll 에서 store.set(key, value)  → OUT param 저장
+ *   - 다음 TC beforeAll 에서 store.require(key) → IN param 읽기
+ *   - os.tmpdir()/scenario-runtime-{scenarioId}.json 에 파일로 지속
+ *     (Playwright 워커 간 격리를 우회하기 위해 fs 사용)
+ *   - resultDir 지정 시 {resultDir}/{scenarioId}/runtime-store.json 에도 동시 저장
+ *     (CI 재실행·머신 재시작 후에도 런타임 상태 복구 가능)
+ *
+ * 모든 TC 는 PASS 또는 FAIL 만 가능하다.
+ * 선행 TC 가 실패하면 store.require() 가 자동으로 throw 한다 — cascade 별도 처리 불필요.
+ */
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+interface StoreData {
+  params: Record<string, unknown>;
+}
+
+export class ScenarioRuntimeStore {
+  private readonly tmpPath: string;
+  private readonly resultPath: string | null;
+  private data: StoreData;
+
+  constructor(scenarioId: string, resultDir?: string) {
+    this.tmpPath    = path.join(os.tmpdir(), `scenario-runtime-${scenarioId}.json`);
+    this.resultPath = resultDir
+      ? path.join(resultDir, 'runtime-store.json')
+      : null;
+    this.data = this.load();
+  }
+
+  // ── 파일 I/O ──────────────────────────────────────────────────────────────
+
+  private load(): StoreData {
+    for (const p of [this.resultPath, this.tmpPath].filter((x): x is string => x !== null)) {
+      try {
+        return JSON.parse(fs.readFileSync(p, 'utf8')) as StoreData;
+      } catch { /* 없으면 다음 경로 시도 */ }
+    }
+    return { params: {} };
+  }
+
+  private save(): void {
+    const json = JSON.stringify(this.data, null, 2);
+    fs.writeFileSync(this.tmpPath, json, 'utf8');
+    if (this.resultPath) {
+      fs.mkdirSync(path.dirname(this.resultPath), { recursive: true });
+      fs.writeFileSync(this.resultPath, json, 'utf8');
+    }
+  }
+
+  // ── 초기화 ────────────────────────────────────────────────────────────────
+
+  /**
+   * 시나리오 시작 시 스토어를 초기화한다.
+   * 시나리오 spec 파일의 최상위 beforeAll 에서 호출한다.
+   */
+  reset(): void {
+    this.data = { params: {} };
+    for (const p of [this.tmpPath, this.resultPath].filter((x): x is string => x !== null)) {
+      try { fs.unlinkSync(p); } catch { /* 이미 없으면 무시 */ }
+    }
+  }
+
+  // ── OUT param 설정 ────────────────────────────────────────────────────────
+
+  /** TC afterAll 에서 호출: OUT param 하나 저장 */
+  set(key: string, value: unknown): void {
+    this.data.params[key] = value;
+    this.save();
+  }
+
+  /** TC afterAll 에서 호출: 여러 OUT param 한꺼번에 저장 */
+  setAll(pairs: Record<string, unknown>): void {
+    Object.assign(this.data.params, pairs);
+    this.save();
+  }
+
+  // ── IN param 읽기 ─────────────────────────────────────────────────────────
+
+  /** 키 조회 — 없으면 undefined */
+  get<T = unknown>(key: string): T | undefined {
+    return this.data.params[key] as T | undefined;
+  }
+
+  /**
+   * 키 조회 — 없으면 에러 throw
+   * 앞 단계 TC가 반드시 실행되었을 때 사용한다.
+   */
+  require<T = unknown>(key: string): T {
+    const val = this.get<T>(key);
+    if (val === undefined) {
+      throw new Error(
+        `[ScenarioRuntimeStore] 필수 런타임 파라미터가 없습니다: "${key}"\n` +
+        `  → 이전 TC 가 FAIL 하거나 set("${key}", ...) 를 호출하지 않았습니다.`,
+      );
+    }
+    return val;
+  }
+
+  /** 키 조회 — 없으면 fallback 반환 */
+  getOrDefault<T = unknown>(key: string, fallback: T): T {
+    const val = this.get<T>(key);
+    return val !== undefined ? val : fallback;
+  }
+
+  // ── 이전 실행 값 로드 ─────────────────────────────────────────────────────
+
+  /**
+   * 이전 실행에서 저장된 discovered.json 을 store에 주입한다.
+   * 이미 store에 값이 있는 키는 덮지 않는다 (initialStore 우선).
+   */
+  loadDiscovered(discoveredFilePath: string): void {
+    try {
+      const raw = JSON.parse(fs.readFileSync(discoveredFilePath, 'utf8')) as Record<string, unknown>;
+      for (const [k, v] of Object.entries(raw)) {
+        if (this.get(k) === undefined) {
+          this.data.params[k] = v;
+        }
+      }
+      this.save();
+    } catch { /* 이전 실행 없으면 무시 */ }
+  }
+
+  // ── 실패 체크포인트 ───────────────────────────────────────────────────────
+
+  /**
+   * TC 실패 시 체크포인트를 저장한다.
+   * 저장 경로: {resultDir}/checkpoint.json
+   * 재연 시 이 파일로 어느 스텝에서 어떤 파라미터로 실패했는지 확인한다.
+   */
+  checkpoint(step: { order: number; tcId: string }, error: Error): void {
+    if (!this.resultPath) return;
+    const data = {
+      failedAt:      step,
+      storeSnapshot: this.snapshot(),
+      error:         error.message,
+      timestamp:     new Date().toISOString(),
+    };
+    const p = path.join(path.dirname(this.resultPath), 'checkpoint.json');
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, JSON.stringify(data, null, 2), 'utf8');
+  }
+
+  // ── 디버그 / 요약 ─────────────────────────────────────────────────────────
+
+  /** 시나리오 종료 시 스토어 내용을 콘솔에 출력 */
+  dump(label = 'ScenarioRuntimeStore'): void {
+    console.log(`\n── ${label} ──────────────────────────`);
+    console.log('  params:', JSON.stringify(this.data.params, null, 4));
+    console.log('────────────────────────────────────────\n');
+  }
+
+  /** 현재 params 스냅샷 (읽기 전용 복사본) */
+  snapshot(): Record<string, unknown> {
+    return { ...this.data.params };
+  }
+}

--- a/e2e/params/types.ts
+++ b/e2e/params/types.ts
@@ -1,0 +1,70 @@
+/**
+ * deploy/params/types.ts
+ * 파라미터 시스템 핵심 타입 정의
+ *
+ * 4-레이어 우선순위 (낮음 → 높음):
+ *   Layer 1: base/tc/{domain}/{TC-ID}.params.ts   — 기본값, Git 커밋
+ *   Layer 2: env/local.params.ts                  — .gitignore, 환경별 오버라이드
+ *   Layer 3: base/scenarios/{scenario-id}.params.ts — 시나리오 내 스텝별 override
+ *   Layer 4: process.env (PW_* 접두사)             — CI / 민감정보, 최고 우선순위
+ */
+
+// ── TC 기본 파라미터 ──────────────────────────────────────────────────────────
+
+/**
+ * 각 TC params 파일이 `export default` 하는 구조.
+ *
+ * `base`       — variant 공통 기본값
+ * `variants`   — variant key → base 위에 덮어쓸 값
+ *
+ * @example
+ *   export default {
+ *     base: { nsId: 'default', mciName: 'tc-mci-temp' },
+ *     variants: {
+ *       'aws': { connectionName: 'aws-ap-northeast-2', commonSpec: 'aws+ap-northeast-2+t2.small' },
+ *       'gcp': { connectionName: 'gcp-asia-northeast3', commonSpec: 'gcp+asia-northeast3+n1-standard-1' },
+ *     },
+ *   } satisfies TCParams;
+ */
+export interface TCParams {
+  base:      Record<string, unknown>;
+  variants?: Record<string, Record<string, unknown>>;
+}
+
+// ── 환경별 오버라이드 ─────────────────────────────────────────────────────────
+
+/**
+ * deploy/params/env/local.params.ts 가 `export default` 하는 구조.
+ * 이 파일은 .gitignore 에 포함되어 환경별로 다르게 관리한다.
+ *
+ * `global`    — 모든 TC에 적용되는 전역 값 (adminId, adminPassword, baseUrl 등)
+ * `tc`        — TC ID별 오버라이드
+ * `scenario`  — 시나리오 ID별 오버라이드
+ */
+export interface EnvParams {
+  env:       string;   // 예: 'local' | 'ci' | 'staging'
+  global?:   Record<string, unknown>;
+  tc?:       Record<string, Record<string, unknown>>;
+  scenario?: Record<string, Record<string, unknown>>;
+}
+
+// ── 시나리오 정적 파라미터 ───────────────────────────────────────────────────
+
+/**
+ * deploy/params/base/scenarios/{scenario-id}.params.ts 가 `export default` 하는 구조.
+ *
+ * `global`  — 시나리오 전체에 적용 (모든 스텝 TC가 읽음)
+ * `steps`   — TC ID → 해당 스텝에만 적용할 override
+ */
+export interface ScenarioStaticParams {
+  global?: Record<string, unknown>;
+  steps?:  Record<string, Record<string, unknown>>;
+}
+
+// ── 최종 병합 결과 ────────────────────────────────────────────────────────────
+
+/** loadTCParams() / loadTCParamsForScenario() 가 반환하는 최종 병합된 파라미터 맵 */
+export type MergedParams = Record<string, unknown>;
+
+/** variant 선택자 — 동일 TC의 여러 케이스를 구분하는 문자열 (예: 'aws', 'ui:helm') */
+export type VariantSelector = string;

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,109 @@
+import { defineConfig } from '@playwright/test';
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+
+const accessMode = process.env.ACCESS_MODE || 'external-ip';
+dotenv.config({ path: path.resolve(__dirname, `.env.${accessMode}`), override: true });
+
+// 결과 디렉토리: {폴더명}_result (예: deploy → deploy_result, mc-web-console → mc-web-console_result)
+const folderName = path.basename(__dirname);
+const outDir = process.env.RUN_OUTPUT_DIR
+  ? path.resolve(process.env.RUN_OUTPUT_DIR)
+  : path.resolve(__dirname, `../${folderName}_result`);
+
+function resolveBaseUrl(): string {
+  if (accessMode === 'external-ip') {
+    const scheme = process.env.EXTERNAL_HTTPS === 'true' ? 'https' : 'http';
+    return `${scheme}://${process.env.EXTERNAL_IP}:${process.env.EXTERNAL_PORT || '3001'}`;
+  }
+  if (accessMode === 'external-domain') {
+    const port = process.env.EXTERNAL_PORT ? `:${process.env.EXTERNAL_PORT}` : '';
+    return `https://${process.env.EXTERNAL_DOMAIN}${port}`;
+  }
+  throw new Error(`Unknown ACCESS_MODE: ${accessMode}`);
+}
+
+// ── 세션 그룹 (병렬 실행 단위) ──────────────────────────────────────────────
+// 실행 순서 (project.dependencies 기반):
+//   C5 → C6 ┐
+//            ├→ C7 → C10
+//       C9 ──┘
+// C5: MCI+K8s 생성·App 배포·Scale out·App 라이프사이클·rating
+// C6: 모니터링·트레이싱·로깅
+// C7: 인프라 lifecycle (suspend·reboot·resume)
+// C9: 클라우드 비용 분석
+// C10: cleanup — 모든 세션 완료 후 수동 실행 (npx playwright test --project=session-f-c10-cleanup)
+//
+// 단일 세션 실행: npx playwright test --project=session-a-c5-svc-expand
+// 전체 실행: npx playwright test
+const SESSION_GROUPS = [
+  {
+    // C5: MCI + K8s 생성, App 배포, Scale out, App 라이프사이클, rating
+    name: 'session-a-c5-svc-expand',
+    testMatch: [
+      'scenarios/C5-svc-mgmt1/*.spec.ts',
+    ],
+  },
+  {
+    // C6: 모니터링·트레이싱·로깅 (C5의 MCI+K8s 기반)
+    name: 'session-b-c6-monitoring',
+    testMatch: [
+      'scenarios/C6-monitoring/*.spec.ts',
+    ],
+    dependencies: ['session-a-c5-svc-expand'],
+  },
+  {
+    // C9: 클라우드 비용 분석 (C5의 MCI+K8s 기반, C6과 병렬 가능)
+    name: 'session-e-c9-cost',
+    testMatch: [
+      'scenarios/C9-cost/*.spec.ts',
+    ],
+    dependencies: ['session-a-c5-svc-expand'],
+  },
+  {
+    // C7: 존재하는 인프라 lifecycle (suspend·reboot·resume)
+    // C6·C9 완료 후 실행 — 모니터링·비용분석 중 suspend 방지
+    name: 'session-c-c7-lifecycle',
+    testMatch: [
+      'scenarios/C7-svc-mgmt2/*.spec.ts',
+    ],
+    dependencies: ['session-b-c6-monitoring', 'session-e-c9-cost'],
+  },
+  {
+    // C10: 삭제·정리 — 수동 실행 전용 (npx playwright test --project=session-f-c10-cleanup)
+    name: 'session-f-c10-cleanup',
+    testMatch: [
+      'scenarios/C10-cleanup/*.spec.ts',
+    ],
+    dependencies: ['session-b-c6-monitoring', 'session-c-c7-lifecycle', 'session-e-c9-cost'],
+  },
+];
+
+export default defineConfig({
+  testDir: '.',
+  // testMatch 미지정 시 모든 tc/**와 scenarios/**를 포함 (project별 testMatch로 분기)
+  outputDir: `${outDir}/test-results`,
+  fullyParallel: false, // 각 project 내부 시나리오는 순차 실행 (스텝 의존성 보존)
+  workers: process.env.SESSION ? 1 : 4, // 단일 세션 실행 시 1, 전체 실행 시 4
+  reporter: [
+    ['list'],
+    ['json',  { outputFile: `${outDir}/results.json` }],
+    ['html',  { outputFolder: `${outDir}/report`, open: 'never' }],
+  ],
+  use: {
+    baseURL: resolveBaseUrl(),
+    headless: true,
+    ignoreHTTPSErrors: true,
+    screenshot: 'only-on-failure',
+    viewport: { width: 1920, height: 1080 },
+    video: 'retain-on-failure',
+    launchOptions: {
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-features=PrivateNetworkAccessChecks,LocalNetworkAccessChecks',
+      ],
+    },
+  },
+  projects: SESSION_GROUPS,
+});

--- a/e2e/registry/index.ts
+++ b/e2e/registry/index.ts
@@ -1,0 +1,146 @@
+/**
+ * deploy/registry/index.ts
+ * 전체 레지스트리 통합 진입점 + 조회 유틸
+ *
+ * 사용 예:
+ *   import { findTC, listByDomain, listScenariosByCode } from '../registry';
+ *   const tc = findTC('TC-INFRA-DEPLOY-05');
+ *   const iamTCs = listByDomain('iam');
+ *   const c4 = listScenariosByCode('C4');
+ */
+import type { TCEntry, ScenarioEntry, TCStatus, ScenarioStatus } from './types';
+
+// ── TC 레지스트리 전체 import ─────────────────────────────────────────────
+import { IAM_TC_REGISTRY }      from './tc/iam.registry';
+import { CSP_TC_REGISTRY }      from './tc/csp.registry';
+import { INFRA_TC_REGISTRY }    from './tc/infra.registry';
+import { SW_TC_REGISTRY }       from './tc/sw.registry';
+import { DATA_TC_REGISTRY }     from './tc/data.registry';
+import { OBS_TC_REGISTRY }      from './tc/obs.registry';
+import { COST_TC_REGISTRY }     from './tc/cost.registry';
+import { WORKFLOW_TC_REGISTRY } from './tc/workflow.registry';
+import { WORKLOAD_TC_REGISTRY } from './tc/workload.registry';
+
+// ── 시나리오 레지스트리 import ────────────────────────────────────────────
+import { SCENARIO_REGISTRY }    from './scenario/scenarios.registry';
+
+// ── 전체 TC 목록 (도메인 순서 고정) ─────────────────────────────────────
+export const ALL_TC: TCEntry[] = [
+  ...IAM_TC_REGISTRY,
+  ...CSP_TC_REGISTRY,
+  ...INFRA_TC_REGISTRY,
+  ...SW_TC_REGISTRY,
+  ...DATA_TC_REGISTRY,
+  ...OBS_TC_REGISTRY,
+  ...COST_TC_REGISTRY,
+  ...WORKFLOW_TC_REGISTRY,
+  ...WORKLOAD_TC_REGISTRY,
+];
+
+export const ALL_SCENARIOS: ScenarioEntry[] = SCENARIO_REGISTRY;
+
+// ── TC 조회 유틸 ──────────────────────────────────────────────────────────
+
+/** TC ID로 단건 조회 */
+export function findTC(id: string): TCEntry | undefined {
+  return ALL_TC.find(tc => tc.id === id);
+}
+
+/** TC ID로 단건 조회 — 없으면 에러 */
+export function requireTC(id: string): TCEntry {
+  const tc = findTC(id);
+  if (!tc) throw new Error(`[registry] TC 없음: ${id}`);
+  return tc;
+}
+
+/** 도메인별 TC 목록 */
+export function listByDomain(domain: string): TCEntry[] {
+  return ALL_TC.filter(tc => tc.domain === domain);
+}
+
+/** 상태별 TC 목록 */
+export function listByStatus(status: TCStatus): TCEntry[] {
+  return ALL_TC.filter(tc => tc.status === status);
+}
+
+/** Feature 코드별 TC 목록 */
+export function listByFeature(feature: string): TCEntry[] {
+  return ALL_TC.filter(tc => tc.feature === feature);
+}
+
+/** 태그로 TC 목록 필터 */
+export function listByTag(tag: string): TCEntry[] {
+  return ALL_TC.filter(tc => tc.tags?.includes(tag));
+}
+
+/** variant가 있는 TC 목록 */
+export function listVariantTCs(): TCEntry[] {
+  return ALL_TC.filter(tc => tc.variants && tc.variants.length > 0);
+}
+
+// ── 시나리오 조회 유틸 ────────────────────────────────────────────────────
+
+/** 시나리오 ID로 단건 조회 */
+export function findScenario(id: string): ScenarioEntry | undefined {
+  return ALL_SCENARIOS.find(s => s.id === id);
+}
+
+/** 시나리오 ID로 단건 조회 — 없으면 에러 */
+export function requireScenario(id: string): ScenarioEntry {
+  const s = findScenario(id);
+  if (!s) throw new Error(`[registry] 시나리오 없음: ${id}`);
+  return s;
+}
+
+/** 코드별 시나리오 목록 (예: 'C4') */
+export function listScenariosByCode(code: string): ScenarioEntry[] {
+  return ALL_SCENARIOS.filter(s => s.code === code);
+}
+
+/** 상태별 시나리오 목록 */
+export function listScenariosByStatus(status: ScenarioStatus): ScenarioEntry[] {
+  return ALL_SCENARIOS.filter(s => s.status === status);
+}
+
+// ── 통계 ─────────────────────────────────────────────────────────────────
+
+export interface RegistrySummary {
+  tc: {
+    total:      number;
+    byDomain:   Record<string, number>;
+    byStatus:   Record<TCStatus, number>;
+  };
+  scenario: {
+    total:      number;
+    byCode:     Record<string, number>;
+    byStatus:   Record<ScenarioStatus, number>;
+  };
+}
+
+export function summary(): RegistrySummary {
+  const tcByDomain: Record<string, number>   = {};
+  const tcByStatus: Record<string, number>   = {};
+  const scByCode:   Record<string, number>   = {};
+  const scByStatus: Record<string, number>   = {};
+
+  for (const tc of ALL_TC) {
+    tcByDomain[tc.domain] = (tcByDomain[tc.domain] ?? 0) + 1;
+    tcByStatus[tc.status] = (tcByStatus[tc.status] ?? 0) + 1;
+  }
+  for (const sc of ALL_SCENARIOS) {
+    scByCode[sc.code]     = (scByCode[sc.code]     ?? 0) + 1;
+    scByStatus[sc.status] = (scByStatus[sc.status] ?? 0) + 1;
+  }
+
+  return {
+    tc:       { total: ALL_TC.length,       byDomain: tcByDomain, byStatus: tcByStatus as Record<TCStatus, number> },
+    scenario: { total: ALL_SCENARIOS.length, byCode:   scByCode,   byStatus: scByStatus as Record<ScenarioStatus, number> },
+  };
+}
+
+// ── 편의 re-export ────────────────────────────────────────────────────────
+export type { TCEntry, ScenarioEntry } from './types';
+export { IAM_TC_REGISTRY, CSP_TC_REGISTRY, INFRA_TC_REGISTRY,
+         SW_TC_REGISTRY,  DATA_TC_REGISTRY, OBS_TC_REGISTRY,
+         COST_TC_REGISTRY, WORKFLOW_TC_REGISTRY, WORKLOAD_TC_REGISTRY };
+export { SCENARIO_REGISTRY };

--- a/e2e/registry/scenario/scenarios.registry.ts
+++ b/e2e/registry/scenario/scenarios.registry.ts
@@ -1,0 +1,939 @@
+/**
+ * deploy/registry/scenario/scenarios.registry.ts
+ * 시나리오 전체 목록
+ *
+ * Code 체계:
+ *   C2  — IAM·사용자 관리 (Onboarding)
+ *   C3  — WF 기반 서비스 생성 (정의·수정·실행·EL)
+ *   C4  — 직접 서비스 생성 (Infra·K8s배포 → Repository·Catalog → Infra설치·확인 → K8s설치·확인)
+ *   C5  — 서비스 운영 관리 (lifecycle·K8s 운영·App 운영)
+ *   C6  — 모니터링·로깅·트레이싱
+ *   C8  — 데이터 백업·복구·마이그레이션
+ *   C9  — 클라우드 비용 분석
+ *   C10 — 정리 / Cleanup
+ *
+ * 상태(status):
+ *   ready   — 전체 스텝 실행 가능
+ *   partial — 일부 wip/todo 포함, 나머지 실행 가능 (wip/todo 스텝은 FAIL)
+ *   wip     — 작업 중
+ *   todo    — 구현 예정
+ */
+import type { ScenarioEntry } from '../types';
+
+export const SCENARIO_REGISTRY: ScenarioEntry[] = [
+
+  // ── C2: IAM 온보딩 ────────────────────────────────────────────────────────
+  {
+    id: 'C2-01-onboarding-mc-iam-manager-user-create',
+    code: 'C2',
+    title: 'IAM 온보딩 — 사용자 추가·역할·그룹 할당',
+    description: '신규 사용자 생성부터 역할 배정, 그룹 할당, 워크스페이스 접근 확인까지의 전체 흐름.',
+    status: 'ready',
+    actor: '플랫폼 관리자',
+    specFile: 'deploy/scenarios/C2-admin-setup/C2-01-onboarding-mc-iam-manager-user-create.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-IAM-UG-03',           status: 'ready', description: '신규 사용자 생성' },
+      { order: 2, tcId: 'TC-IAM-UG-08',           status: 'ready', description: '그룹 생성' },
+      { order: 3, tcId: 'TC-IAM-UG-11',           status: 'ready', description: '그룹에 사용자 배정' },
+      { order: 4, tcId: 'TC-IAM-RBAC-06',         status: 'ready', description: '사용자에 플랫폼 역할 부여' },
+      { order: 5, tcId: 'TC-IAM-WS-05',           status: 'ready', description: '워크스페이스에 사용자 배정' },
+      { order: 6, tcId: 'TC-IAM-AUTH-01',         status: 'ready', description: '신규 사용자로 로그인 확인' },
+    ],
+  },
+
+  {
+    id: 'C2-02-onboarding-mc-iam-manager-role-assign',
+    code: 'C2',
+    title: '관리자 계정 생성·역할 할당·MCI 연동',
+    description: '관리자 사용자 생성 후 역할을 부여하고 MCI 접근 권한을 확인한다.',
+    status: 'ready',
+    actor: '플랫폼 관리자',
+    specFile: 'deploy/scenarios/C2-admin-setup/C2-02-onboarding-mc-iam-manager-role-assign.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-IAM-UG-03',           status: 'ready', description: '관리자 사용자 생성' },
+      { order: 2, tcId: 'TC-IAM-RBAC-06',         status: 'ready', description: '플랫폼 역할 부여' },
+      { order: 3, tcId: 'TC-INFRA-DEPLOY-01',     status: 'ready', description: 'MCI 목록 접근 확인' },
+    ],
+  },
+
+  {
+    id: 'C2-04-onboarding-mc-iam-manager-workspace-mgmt',
+    code: 'C2',
+    title: 'Workspace 관리 UI 전체 검증',
+    description: '워크스페이스 목록·생성·수정·삭제·Projects 탭·테이블 UX를 검증한다.',
+    status: 'ready',
+    actor: '플랫폼 관리자',
+    specFile: 'deploy/scenarios/C2-admin-setup/C2-04-onboarding-mc-iam-manager-workspace-mgmt.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-IAM-WS-01',           status: 'ready', description: '워크스페이스 목록 조회' },
+      { order: 2, tcId: 'TC-IAM-WS-02',           status: 'ready', description: '워크스페이스 생성' },
+      { order: 3, tcId: 'TC-IAM-WS-08',           status: 'ready', description: '대시보드 카운트 확인' },
+      { order: 4, tcId: 'TC-IAM-WS-10',           status: 'ready', description: '추가 모달 UI 확인' },
+      { order: 5, tcId: 'TC-IAM-WS-13',           status: 'ready', description: 'Projects 탭 관리' },
+      { order: 6, tcId: 'TC-IAM-WS-14',           status: 'ready', description: '테이블 정렬·다중선택' },
+      { order: 7, tcId: 'TC-IAM-WS-04',           status: 'ready', description: '워크스페이스 삭제' },
+    ],
+  },
+
+  {
+    id: 'C2-03-onboarding-mc-iam-manager-signup-approval',
+    code: 'C2',
+    title: '가입 신청 승인 — 관리자 승인 화면 API·UI 검증',
+    description: '사용자가 회원가입을 신청하고 관리자가 API 또는 UI로 승인한 후 로그인을 확인한다.',
+    status: 'ready',
+    actor: '플랫폼 관리자',
+    specFile: 'deploy/scenarios/C2-admin-setup/C2-03-onboarding-mc-iam-manager-signup-approval.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-IAM-AUTH-05',           status: 'ready', description: '사용자 회원가입 신청' },
+      { order: 2, tcId: 'TC-IAM-USER-LIFECYCLE-01', status: 'ready', description: '관리자 API 승인 후 로그인' },
+      { order: 3, tcId: 'TC-IAM-USER-LIFECYCLE-02', status: 'ready', description: '관리자 UI 승인 후 로그인' },
+    ],
+  },
+
+  // ── C3: Workflow 기반 서비스 생성 ─────────────────────────────────────────
+  // Phase 1: 정의
+  {
+    id: 'C3-01-wf-define',
+    code: 'C3',
+    title: 'WF 등록 (서비스 생성용·삭제용)',
+    description: '서비스 생성 및 삭제용 Workflow를 각각 정의하고 등록한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C3-svc-wf/C3-01-wf-define.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-WF-FLOW-03', status: 'ready', description: '서비스 생성용 Workflow 등록', variant: 'create' },
+      { order: 2, tcId: 'TC-WF-FLOW-03', status: 'ready', description: '서비스 삭제용 Workflow 등록', variant: 'delete' },
+    ],
+  },
+
+  // Phase 2: 수정
+  {
+    id: 'C3-02-wf-modify',
+    code: 'C3',
+    title: 'WF 조회·수정',
+    description: '등록된 Workflow 목록을 조회하고 상세 내용을 수정한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C3-svc-wf/C3-02-wf-modify.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-WF-FLOW-02', status: 'ready', description: 'Workflow 목록 조회' },
+      { order: 2, tcId: 'TC-WF-FLOW-04', status: 'ready', description: 'Workflow 상세 수정' },
+    ],
+  },
+
+  // Phase 3: 실행
+  {
+    id: 'C3-03-wf-run-infra',
+    code: 'C3',
+    title: 'WF 실행 — 인프라 배포',
+    description: '정의된 인프라 생성 Workflow를 RUN 버튼으로 실행하고 로그를 확인한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C3-svc-wf/C3-03-wf-run-infra.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-WF-FLOW-06', status: 'ready', description: '인프라 배포 Workflow 실행 (RUN)' },
+      { order: 2, tcId: 'TC-WF-FLOW-07', status: 'ready', description: 'Workflow 로그 모달 확인' },
+    ],
+  },
+
+  {
+    id: 'C3-04-wf-run-infra-app',
+    code: 'C3',
+    title: 'WF 실행 — 인프라 + Application 통합 배포',
+    description: '인프라와 애플리케이션을 함께 배포하는 Workflow를 실행하고 로그를 확인한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C3-svc-wf/C3-04-wf-run-infra-app.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-WF-FLOW-06', status: 'ready', description: '인프라+App 통합 배포 Workflow 실행 (RUN)', variant: 'infra-app' },
+      { order: 2, tcId: 'TC-WF-FLOW-07', status: 'ready', description: 'Workflow 로그 모달 확인' },
+    ],
+  },
+
+  {
+    id: 'C3-05-wf-run-k8s',
+    code: 'C3',
+    title: 'WF 실행 — K8s 배포',
+    description: 'K8s 클러스터를 배포하는 Workflow를 실행한다.',
+    status: 'wip',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C3-svc-wf/C3-05-wf-run-k8s.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-WF-FLOW-06', status: 'wip', description: 'K8s 배포 Workflow 실행 (RUN)', variant: 'k8s' },
+    ],
+  },
+
+  // Phase 4: Event Listener
+  {
+    id: 'C3-06-wf-el-register',
+    code: 'C3',
+    title: 'Event Listener 등록 (WF 연결)',
+    description: 'Workflow와 연결된 Event Listener를 생성하고 이름 중복을 검사한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C3-svc-wf/C3-06-wf-el-register.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-WF-EL-02', status: 'ready', description: 'Event Listener 생성 (Workflow 연결)' },
+      { order: 2, tcId: 'TC-WF-EL-03', status: 'ready', description: 'Event Listener 이름 중복 검사' },
+    ],
+  },
+
+  {
+    id: 'C3-07-wf-el-run',
+    code: 'C3',
+    title: 'Event Listener로 WF 실행 (GET / POST)',
+    description: 'Event Listener를 통해 외부에서 Workflow를 GET/POST 방식으로 실행한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C3-svc-wf/C3-07-wf-el-run.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-WF-EL-06', status: 'ready', description: 'Event Listener GET Trigger로 Workflow 실행' },
+      { order: 2, tcId: 'TC-WF-EL-07', status: 'ready', description: 'Event Listener POST Trigger로 Workflow 실행' },
+    ],
+  },
+
+  // ── C4: 직접 서비스 생성 ──────────────────────────────────────────────────
+  // Phase 1: 인프라 배포
+
+  // C4-01: Multi-CSP MCI 통합 + Clustering NodeGroup
+  {
+    id: 'C4-01-mci-multi-csp-cluster',
+    code: 'C4',
+    title: 'MCI 배포 — Multi-CSP 통합 + Clustering SubGroup',
+    description: '여러 CSP의 VM을 1개 MCI에 통합 생성하고, Clustering용 NodeGroup에 N개 VM을 추가한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-01-mci-multi-csp-cluster.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-DEPLOY-05', status: 'ready', description: 'mci01 생성 (AWS ng1 첫 번째 subgroup)', variant: 'multi',
+        outputParams: ['mciId', 'mciName', 'nsId'] },
+      { order: 2, tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng2 (Azure) subgroup 추가', variant: 'ng2-azure' },
+      { order: 3, tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng3 (Alibaba) subgroup 추가', variant: 'ng3-ali' },
+      { order: 4, tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng4 (GCP) subgroup 추가', variant: 'ng4-gcp' },
+      { order: 5, tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng5 (NCP) subgroup 추가', variant: 'ng5-ncp' },
+      { order: 6, tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng6 (NHN) subgroup 추가', variant: 'ng6-nhn' },
+      { order: 7, tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng7 (Tencent) subgroup 추가', variant: 'ng7-tencent' },
+      { order: 8, tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng8 (IBM) subgroup 추가', variant: 'ng8-ibm' },
+      { order: 9, tcId: 'TC-INFRA-DEPLOY-01', status: 'ready', description: '8개 CSP 전체 VM Running 상태 확인' },
+    ],
+  },
+
+  // C4-02-k8s-{csp}: K8s 배포 per CSP (9종, 동일 spec 공유)
+  // spec 파일: C4-02-k8s-deploy.spec.ts — SCENARIO_ID env var로 CSP 선택
+  // Playwright projects 방식으로 CSP별 반복 실행
+  {
+    id: 'C4-02-k8s-aws',
+    code: 'C4',
+    title: 'K8s 배포 — AWS',
+    description: 'AWS K8s 클러스터를 배포(Dynamic)하고 KubeConfig를 획득한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-02-k8s-deploy.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-K8S-03', status: 'ready', description: 'AWS K8s 클러스터 배포 (Dynamic)', variant: 'aws',
+        outputParams: ['k8sClusterId', 'k8sName'] },
+      { order: 2, tcId: 'TC-INFRA-K8S-05', status: 'ready', description: 'AWS KubeConfig 획득', variant: 'aws' },
+    ],
+  },
+
+  {
+    id: 'C4-02-k8s-azure',
+    code: 'C4',
+    title: 'K8s 배포 — Azure',
+    description: 'Azure K8s 클러스터를 배포(Dynamic)하고 KubeConfig를 획득한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-02-k8s-deploy.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-K8S-03', status: 'ready', description: 'Azure K8s 클러스터 배포 (Dynamic)', variant: 'azure' },
+      { order: 2, tcId: 'TC-INFRA-K8S-05', status: 'ready', description: 'Azure KubeConfig 획득',              variant: 'azure' },
+    ],
+  },
+
+  {
+    id: 'C4-02-k8s-gcp',
+    code: 'C4',
+    title: 'K8s 배포 — GCP',
+    description: 'GCP K8s 클러스터를 배포(Dynamic)하고 KubeConfig를 획득한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-02-k8s-deploy.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-K8S-03', status: 'ready', description: 'GCP K8s 클러스터 배포 (Dynamic)', variant: 'gcp' },
+      { order: 2, tcId: 'TC-INFRA-K8S-05', status: 'ready', description: 'GCP KubeConfig 획득',              variant: 'gcp' },
+    ],
+  },
+
+  {
+    id: 'C4-02-k8s-ali',
+    code: 'C4',
+    title: 'K8s 배포 — Alibaba',
+    description: 'Alibaba K8s 클러스터를 배포(Dynamic)하고 KubeConfig를 획득한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-02-k8s-deploy.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-K8S-03', status: 'ready', description: 'Alibaba K8s 클러스터 배포 (Dynamic)', variant: 'ali' },
+      { order: 2, tcId: 'TC-INFRA-K8S-05', status: 'ready', description: 'Alibaba KubeConfig 획득',              variant: 'ali' },
+    ],
+  },
+
+  {
+    id: 'C4-02-k8s-ibm',
+    code: 'C4',
+    title: 'K8s 배포 — IBM',
+    description: 'IBM K8s 클러스터를 배포(Expert)하고 KubeConfig를 획득한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-02-k8s-deploy.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-K8S-04', status: 'ready', description: 'IBM K8s 클러스터 배포 (Expert)', variant: 'ibm' },
+      { order: 2, tcId: 'TC-INFRA-K8S-05', status: 'ready', description: 'IBM KubeConfig 획득',             variant: 'ibm' },
+    ],
+  },
+
+  {
+    id: 'C4-02-k8s-nhn',
+    code: 'C4',
+    title: 'K8s 배포 — NHN',
+    description: 'NHN K8s 클러스터를 배포(Dynamic)하고 KubeConfig를 획득한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-02-k8s-deploy.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-K8S-03', status: 'ready', description: 'NHN K8s 클러스터 배포 (Dynamic)', variant: 'nhn' },
+      { order: 2, tcId: 'TC-INFRA-K8S-05', status: 'ready', description: 'NHN KubeConfig 획득',              variant: 'nhn' },
+    ],
+  },
+
+  {
+    id: 'C4-02-k8s-tencent',
+    code: 'C4',
+    title: 'K8s 배포 — Tencent',
+    description: 'Tencent K8s 클러스터를 배포(Dynamic)하고 KubeConfig를 획득한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-02-k8s-deploy.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-K8S-03', status: 'ready', description: 'Tencent K8s 클러스터 배포 (Dynamic)', variant: 'tencent' },
+      { order: 2, tcId: 'TC-INFRA-K8S-05', status: 'ready', description: 'Tencent KubeConfig 획득',              variant: 'tencent' },
+    ],
+  },
+
+  {
+    id: 'C4-02-k8s-ncp',
+    code: 'C4',
+    title: 'K8s 배포 — NCP',
+    description: 'NCP K8s 클러스터를 배포(Dynamic)하고 KubeConfig를 획득한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-02-k8s-deploy.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-K8S-03', status: 'ready', description: 'NCP K8s 클러스터 배포 (Dynamic)', variant: 'ncp' },
+      { order: 2, tcId: 'TC-INFRA-K8S-05', status: 'ready', description: 'NCP KubeConfig 획득',              variant: 'ncp' },
+    ],
+  },
+  // TODO: 9번째 K8s CSP 항목 추가 (CSP 확정 후)
+
+  // Phase 2: SW Repository·Catalog 구성 (공통)
+  {
+    id: 'C4-03-sw-repo-create',
+    code: 'C4',
+    title: 'SW Repository 생성',
+    description: '애플리케이션 검색·배포를 위한 SW Repository를 신규 생성한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-03-sw-repo-create.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-APP-REP-02', status: 'ready', description: 'SW Repository 신규 생성' },
+    ],
+  },
+
+  {
+    id: 'C4-04-app-catalog-register',
+    code: 'C4',
+    title: 'SW 검색 → Catalog 등록',
+    description: '외부(DockerHub)에서 애플리케이션을 검색·Upload하고 SW Catalog에 등록한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-04-app-catalog-register.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-APP-CAT-03', status: 'ready', description: '외부 검색 결과 표시 (DockerHub)' },
+      { order: 2, tcId: 'TC-APP-CAT-04', status: 'ready', description: 'DockerHub 이미지 → Repository Upload' },
+      { order: 3, tcId: 'TC-APP-CAT-05', status: 'ready', description: 'Catalog 신규 등록 (VM 타겟)' },
+    ],
+  },
+
+  // Phase 3: Infra 설치·확인
+  {
+    id: 'C4-05-app-deploy-standalone',
+    code: 'C4',
+    title: 'SW Standalone 배포 (Infra VM 단일)',
+    description: 'MCI의 단일 VM에 애플리케이션을 Standalone 방식으로 배포한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-05-app-deploy-standalone.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-APP-DEP-01', status: 'ready', description: 'VM 단일 Standalone 배포' },
+    ],
+  },
+
+  {
+    id: 'C4-06-app-deploy-clustering',
+    code: 'C4',
+    title: 'SW Clustering 배포 (NodeGroup N개 VM)',
+    description: 'C4-01에서 생성한 Clustering NodeGroup(N개 VM)에 애플리케이션을 Clustering 방식으로 배포한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-06-app-deploy-clustering.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-APP-DEP-02', status: 'ready', description: 'NodeGroup Clustering 배포' },
+    ],
+  },
+
+  {
+    id: 'C4-07-infra-app-verify',
+    code: 'C4',
+    title: 'Infra Application 상태 확인',
+    description: 'Infra(MCI VM)에 배포된 애플리케이션의 상태 목록을 조회하고 상세 정보를 확인한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-07-infra-app-verify.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-APP-APPS-01', status: 'ready', description: 'Apps Status 목록 조회 (Infra)' },
+      { order: 2, tcId: 'TC-APP-APPS-02', status: 'ready', description: 'Apps Status 상세 팝업 확인 (Infra)' },
+    ],
+  },
+
+  // Phase 4: K8s 설치·확인
+  // C4-08/09는 Playwright projects로 각 K8s 환경(C4-02-k8s-*)마다 반복 실행
+  {
+    id: 'C4-08-app-deploy-k8s-helm',
+    code: 'C4',
+    title: 'SW K8s Helm 배포',
+    description: 'K8s 클러스터에 Catalog(K8s 타겟)를 등록하고 Helm으로 애플리케이션을 배포한다.',
+    status: 'todo',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-08-app-deploy-k8s-helm.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-APP-REP-03',  status: 'todo', description: 'SW Catalog 등록 (K8s 타겟)' },
+      { order: 2, tcId: 'TC-APP-DEP-03',  status: 'todo', description: 'SW K8s 배포 (Helm)' },
+    ],
+  },
+
+  {
+    id: 'C4-09-k8s-app-verify',
+    code: 'C4',
+    title: 'K8s Application 상태 확인',
+    description: 'K8s 클러스터에 배포된 애플리케이션의 상태 목록을 조회하고 상세 정보를 확인한다.',
+    status: 'todo',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C4-svc-direct/C4-09-k8s-app-verify.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-APP-APPS-01', status: 'todo', description: 'Apps Status 목록 조회 (K8s)' },
+      { order: 2, tcId: 'TC-APP-APPS-02', status: 'todo', description: 'Apps Status 상세 팝업 확인 (K8s)' },
+    ],
+  },
+
+  // ── C7: 인프라 라이프사이클 ──────────────────────────────────────────────
+  {
+    id: 'C7-01-mci-lifecycle',
+    code: 'C7',
+    title: '운영 중 MCI 관리',
+    description: '운영 중인 MCI 인프라의 라이프사이클(suspend·reboot·resume)을 관리한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C7-svc-mgmt2/C7-01-mci-lifecycle.spec.ts',
+    requiredInputs: ['mciId'],
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-LC-01a', status: 'ready', description: 'MCI suspend (Running→Stopped)' },
+      { order: 2, tcId: 'TC-INFRA-LC-01c', status: 'ready', description: 'MCI reboot  (Stopped→Running)' },
+      { order: 3, tcId: 'TC-INFRA-LC-01a', status: 'ready', description: 'MCI suspend (Running→Stopped)' },
+      { order: 4, tcId: 'TC-INFRA-LC-01b', status: 'ready', description: 'MCI resume  (Stopped→Running)' },
+    ],
+  },
+
+  {
+    id: 'C7-02-mci-resume',
+    code: 'C7',
+    title: 'MCI Resume 시나리오',
+    description: 'suspend 상태의 MCI를 resume하여 Running으로 복구한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C7-svc-mgmt2/C7-02-mci-resume.spec.ts',
+    requiredInputs: ['mciId'],
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-DEPLOY-02', status: 'ready', description: 'MCI 상태 확인' },
+      { order: 2, tcId: 'TC-INFRA-LC-01b',    status: 'ready', description: 'MCI resume (Stopped→Running)' },
+      { order: 3, tcId: 'TC-INFRA-DEPLOY-01', status: 'ready', description: 'Running 상태 확인' },
+    ],
+  },
+
+  {
+    id: 'C7-03-k8s-cluster-manage',
+    code: 'C7',
+    title: 'K8s 클러스터 운영 관리',
+    description: 'K8s 클러스터·NodeGroup 목록/상세 조회, Helm 앱 배포, NodeGroup 크기 변경을 수행한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C7-svc-mgmt2/C7-03-k8s-cluster-manage.spec.ts',
+    requiredInputs: ['k8sClusterId'],
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-K8S-01', status: 'ready', description: 'K8s 클러스터·NodeGroup 목록/상세 조회' },
+      { order: 2, tcId: 'TC-INFRA-K8S-05', status: 'ready', description: 'KubeConfig 획득 (kubectl 접속 정보)' },
+      { order: 3, tcId: 'TC-APP-DEP-03',   status: 'ready', description: 'K8s Helm 앱 배포' },
+      { order: 4, tcId: 'TC-INFRA-K8S-06', status: 'ready', description: 'K8s NodeGroup 크기 변경' },
+    ],
+  },
+
+  // ── C5: 서비스 확인·확장 ─────────────────────────────────────────────────
+
+  // C5-01: Infra Scale Out — mci01 CSP별 NodeGroup 2개 추가
+  {
+    id: 'C5-01-infra-scaleout',
+    code: 'C5',
+    title: 'Infra Scale Out — CSP별 NodeGroup 2개 추가',
+    description: 'mci01의 각 CSP subgroup에 nodegroup을 2개씩 추가하여 수평 확장한다. (8 CSP × 2 = 16 subgroup 추가)',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C5-svc-mgmt1/C5-01-infra-scaleout.spec.ts',
+    steps: [
+      { order: 1,  tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng1a (AWS) subgroup 추가',    variant: 'ng1a' },
+      { order: 2,  tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng1b (AWS) subgroup 추가',    variant: 'ng1b' },
+      { order: 3,  tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng2a (Azure) subgroup 추가',  variant: 'ng2a' },
+      { order: 4,  tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng2b (Azure) subgroup 추가',  variant: 'ng2b' },
+      { order: 5,  tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng3a (Ali) subgroup 추가',    variant: 'ng3a' },
+      { order: 6,  tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng3b (Ali) subgroup 추가',    variant: 'ng3b' },
+      { order: 7,  tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng4a (GCP) subgroup 추가',    variant: 'ng4a' },
+      { order: 8,  tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng4b (GCP) subgroup 추가',    variant: 'ng4b' },
+      { order: 9,  tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng5a (NCP) subgroup 추가',    variant: 'ng5a' },
+      { order: 10, tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng5b (NCP) subgroup 추가',    variant: 'ng5b' },
+      { order: 11, tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng6a (NHN) subgroup 추가',    variant: 'ng6a' },
+      { order: 12, tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng6b (NHN) subgroup 추가',    variant: 'ng6b' },
+      { order: 13, tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng7a (Tencent) subgroup 추가', variant: 'ng7a' },
+      { order: 14, tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng7b (Tencent) subgroup 추가', variant: 'ng7b' },
+      { order: 15, tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng8a (IBM) subgroup 추가',     variant: 'ng8a' },
+      { order: 16, tcId: 'TC-INFRA-DEPLOY-07', status: 'ready', description: 'ng8b (IBM) subgroup 추가',     variant: 'ng8b' },
+      { order: 17, tcId: 'TC-INFRA-DEPLOY-01', status: 'ready', description: '전체 VM Running 상태 확인' },
+    ],
+  },
+
+  {
+    id: 'C5-04-app-ops-verify',
+    code: 'C5',
+    title: '애플리케이션 운영 액션',
+    description: '배포된 애플리케이션의 상태 목록 갱신·상세 조회 후 운영 액션(Restart/Stop/Uninstall)을 수행한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C5-svc-mgmt1/C5-04-app-ops-verify.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-APP-APPS-01', status: 'ready', description: '배포 상태 목록 갱신·Refresh' },
+      { order: 2, tcId: 'TC-APP-APPS-02', status: 'ready', description: '배포 상세 조회' },
+      { order: 3, tcId: 'TC-APP-APPS-03', status: 'ready', description: '운영 액션 (Restart / Stop / Uninstall)' },
+    ],
+  },
+
+  {
+    id: 'C5-05-app-rating',
+    code: 'C5',
+    title: '애플리케이션 Rating 제출',
+    description: '사용한 애플리케이션에 대한 Rating(별점)을 제출한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C5-svc-mgmt1/C5-05-app-rating.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-APP-APPS-04', status: 'ready', description: 'Rating 제출' },
+    ],
+  },
+
+  // ── C6: 모니터링·로깅·트레이싱 ───────────────────────────────────────────
+
+  {
+    id: 'C6-01-obs-agent',
+    code: 'C6',
+    title: 'OBS Agent 관리 — MCI VM (Node 조회·설치·폴링·플러그인·제거)',
+    description: '모니터링 대상 MCI VM Node를 조회하고 Agent를 설치·상태확인·플러그인 등록 후 제거한다.',
+    status: 'partial',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C6-monitoring/C6-01-obs-agent.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-OBS-AGENT-01', status: 'ready', description: '등록 가능 Node 조회 (Config)' },
+      { order: 2, tcId: 'TC-OBS-AGENT-02', status: 'ready', description: 'Agent 설치' },
+      { order: 3, tcId: 'TC-OBS-AGENT-03', status: 'ready', description: 'Agent 설치 상태 폴링' },
+      { order: 4, tcId: 'TC-OBS-AGENT-04', status: 'ready', description: '모니터링 플러그인(item) 등록' },
+      { order: 5, tcId: 'TC-OBS-AGENT-05', status: 'ready', description: 'Agent 제거' },
+    ],
+    initialStore: {
+      obsTargetMciId:   'mci-aws',
+      obsTargetInfraId: 'node-aws-1',
+    },
+  },
+
+  {
+    id: 'C6-02-obs-metric',
+    code: 'C6',
+    title: 'OBS Metric 조회 (Agent 시계열·CSP·K8s·오버뷰)',
+    description: 'InfluxDB Agent 메트릭, CSP API 메트릭, K8s 노드 메트릭, Infra/NS 오버뷰를 조회한다.',
+    status: 'partial',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C6-monitoring/C6-02-obs-metric.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-OBS-METRIC-01', status: 'ready', description: 'Agent 시계열 메트릭 (InfluxDB)' },
+      { order: 2, tcId: 'TC-OBS-METRIC-02', status: 'todo',  description: 'CSP API 메트릭 (cb-spider)' },
+      { order: 3, tcId: 'TC-OBS-METRIC-03', status: 'todo',  description: 'K8s Cluster 노드 메트릭' },
+      { order: 4, tcId: 'TC-OBS-METRIC-04', status: 'todo',  description: 'Infra / NS 레벨 오버뷰' },
+    ],
+  },
+
+  {
+    id: 'C6-03-obs-insight',
+    code: 'C6',
+    title: 'OBS Insight 분석 (Anomaly·예측·LLM 오류분석)',
+    description: 'Anomaly Detection 설정 → History 조회 → Prediction → LLM 기반 서버 오류 분석 전체 흐름.',
+    status: 'partial',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C6-monitoring/C6-03-obs-insight.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-OBS-INSIGHT-01', status: 'ready', description: 'Anomaly Detection 설정' },
+      { order: 2, tcId: 'TC-OBS-INSIGHT-02', status: 'todo',  description: 'Anomaly History 조회' },
+      { order: 3, tcId: 'TC-OBS-INSIGHT-03', status: 'todo',  description: 'Prediction(예측)' },
+      { order: 4, tcId: 'TC-OBS-INSIGHT-04', status: 'todo',  description: 'Server Error Analysis (LLM)' },
+    ],
+  },
+
+  {
+    id: 'C6-04-obs-log',
+    code: 'C6',
+    title: 'OBS Log 조회 (라벨·LogQL 검색)',
+    description: 'Loki 라벨 목록을 조회하고 LogQL로 키워드 검색을 수행한다.',
+    status: 'partial',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C6-monitoring/C6-04-obs-log.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-OBS-LOG-01', status: 'ready', description: '라벨 조회' },
+      { order: 2, tcId: 'TC-OBS-LOG-02', status: 'todo',  description: '키워드 검색 (LogQL)' },
+    ],
+  },
+
+  {
+    id: 'C6-05-obs-trace',
+    code: 'C6',
+    title: 'OBS Trace 조회 (Tempo 검색·상세·iframe)',
+    description: 'Grafana Tempo에서 Trace를 검색하고 상세 Call Sequence와 iframe 임베드를 확인한다.',
+    status: 'partial',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C6-monitoring/C6-05-obs-trace.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-OBS-TRACE-01', status: 'ready', description: 'Trace 검색 (Tempo)' },
+      { order: 2, tcId: 'TC-OBS-TRACE-02', status: 'todo',  description: 'Trace 상세 / Call Sequence' },
+      { order: 3, tcId: 'TC-OBS-TRACE-03', status: 'todo',  description: 'Trace iframe 임베드' },
+    ],
+  },
+
+  {
+    id: 'C6-06-obs-trigger',
+    code: 'C6',
+    title: 'OBS Trigger 관리 (Policy·채널·알림)',
+    description: 'Trigger Policy 생성/목록/삭제, 타겟 연결, 알림 채널 설정, History 조회, 임계값 수정 전체 흐름.',
+    status: 'todo',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C6-monitoring/C6-06-obs-trigger.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-OBS-TRIG-01', status: 'todo', description: 'Trigger Policy 생성/목록/삭제' },
+      { order: 2, tcId: 'TC-OBS-TRIG-02', status: 'todo', description: '정책 ↔ Node/Infra 타겟 연결' },
+      { order: 3, tcId: 'TC-OBS-TRIG-03', status: 'todo', description: '알림 채널 설정' },
+      { order: 4, tcId: 'TC-OBS-TRIG-04', status: 'todo', description: 'Trigger / Notification History' },
+      { order: 5, tcId: 'TC-OBS-TRIG-05', status: 'todo', description: '정책 수정 (임계값 등)' },
+    ],
+  },
+
+  // C6-08: PMK K8s Agent 관리 (C6-01의 MCI VM 전용과 분리)
+  {
+    id: 'C6-08-obs-agent-pmk',
+    code: 'C6',
+    title: 'OBS Agent 관리 — PMK K8s (설치·상태확인·제거)',
+    description: 'PMK K8s 클러스터에 모니터링 Agent를 설치·상태확인·제거한다. (C6-01 MCI VM 버전과 분리)',
+    status: 'todo',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C6-monitoring/C6-08-obs-agent-pmk.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-OBS-AGENT-01', status: 'todo', description: 'PMK K8s Node 조회 (Config)', variant: 'pmk' },
+      { order: 2, tcId: 'TC-OBS-AGENT-02', status: 'todo', description: 'PMK K8s Agent 설치',         variant: 'pmk' },
+      { order: 3, tcId: 'TC-OBS-AGENT-03', status: 'todo', description: 'PMK K8s Agent 설치 상태 폴링', variant: 'pmk' },
+    ],
+  },
+
+  // ── C8: 데이터 백업·복구·마이그레이션 ───────────────────────────────────
+  // Object Storage (4종)
+  {
+    id: 'C8-01-objstore-generate',
+    code: 'C8',
+    title: 'Object Storage 생성',
+    description: 'Object Storage 버킷을 생성하고 초기 데이터를 준비한다.',
+    status: 'ready',
+    actor: 'DBA / 인프라 엔지니어',
+    specFile: 'deploy/scenarios/C8-data/C8-01-objstore-generate.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-DATA-OS-01', status: 'ready', description: 'Object Storage 생성 (Generate)' },
+    ],
+  },
+
+  {
+    id: 'C8-02-objstore-migrate',
+    code: 'C8',
+    title: 'Object Storage Migration',
+    description: 'Object Storage 데이터를 다른 버킷으로 마이그레이션한다.',
+    status: 'ready',
+    actor: 'DBA / 인프라 엔지니어',
+    specFile: 'deploy/scenarios/C8-data/C8-02-objstore-migrate.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-DATA-OS-02', status: 'ready', description: 'Object Storage 마이그레이션' },
+    ],
+  },
+
+  {
+    id: 'C8-03-objstore-backup',
+    code: 'C8',
+    title: 'Object Storage Backup',
+    description: 'Object Storage 버킷을 백업한다.',
+    status: 'ready',
+    actor: 'DBA / 인프라 엔지니어',
+    specFile: 'deploy/scenarios/C8-data/C8-03-objstore-backup.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-DATA-OS-03', status: 'ready', description: 'Object Storage 백업' },
+    ],
+  },
+
+  {
+    id: 'C8-04-objstore-restore',
+    code: 'C8',
+    title: 'Object Storage Restore',
+    description: 'Object Storage 백업에서 데이터를 복원한다.',
+    status: 'ready',
+    actor: 'DBA / 인프라 엔지니어',
+    specFile: 'deploy/scenarios/C8-data/C8-04-objstore-restore.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-DATA-OS-04', status: 'ready', description: 'Object Storage 복원' },
+    ],
+  },
+
+  // RDBMS (4종)
+  {
+    id: 'C8-05-rdb-generate',
+    code: 'C8',
+    title: 'RDBMS 데이터 생성',
+    description: 'RDBMS에 테스트 데이터를 생성(Generate)한다.',
+    status: 'ready',
+    actor: 'DBA / 인프라 엔지니어',
+    specFile: 'deploy/scenarios/C8-data/C8-05-rdb-generate.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-DATA-RDB-01', status: 'ready', description: 'RDBMS 데이터 생성 (Generate)' },
+    ],
+  },
+
+  {
+    id: 'C8-06-rdb-migration',
+    code: 'C8',
+    title: 'RDBMS Migration',
+    description: 'RDBMS 데이터를 다른 인스턴스로 마이그레이션한다.',
+    status: 'ready',
+    actor: 'DBA / 인프라 엔지니어',
+    specFile: 'deploy/scenarios/C8-data/C8-06-rdb-migration.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-DATA-RDB-02', status: 'ready', description: 'RDBMS 마이그레이션' },
+    ],
+  },
+
+  {
+    id: 'C8-07-rdb-backup',
+    code: 'C8',
+    title: 'RDBMS Backup',
+    description: 'RDBMS 데이터베이스를 백업한다.',
+    status: 'ready',
+    actor: 'DBA / 인프라 엔지니어',
+    specFile: 'deploy/scenarios/C8-data/C8-07-rdb-backup.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-DATA-RDB-03', status: 'ready', description: 'RDBMS 백업' },
+    ],
+  },
+
+  {
+    id: 'C8-08-rdb-restore',
+    code: 'C8',
+    title: 'RDBMS Restore',
+    description: 'RDBMS 백업에서 데이터베이스를 복원한다.',
+    status: 'ready',
+    actor: 'DBA / 인프라 엔지니어',
+    specFile: 'deploy/scenarios/C8-data/C8-08-rdb-restore.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-DATA-RDB-04', status: 'ready', description: 'RDBMS 복원' },
+    ],
+  },
+
+  // NRDBMS (4종)
+  {
+    id: 'C8-09-nrdb-generate',
+    code: 'C8',
+    title: 'NRDBMS 데이터 생성',
+    description: 'NoRDBMS에 테스트 데이터를 생성(Generate)한다.',
+    status: 'ready',
+    actor: 'DBA / 인프라 엔지니어',
+    specFile: 'deploy/scenarios/C8-data/C8-09-nrdb-generate.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-DATA-NRDB-01', status: 'ready', description: 'NoRDBMS 데이터 생성 (Generate)' },
+    ],
+  },
+
+  {
+    id: 'C8-10-nrdb-migration',
+    code: 'C8',
+    title: 'NRDBMS Migration',
+    description: 'NoRDBMS 데이터를 다른 인스턴스로 마이그레이션한다.',
+    status: 'ready',
+    actor: 'DBA / 인프라 엔지니어',
+    specFile: 'deploy/scenarios/C8-data/C8-10-nrdb-migration.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-DATA-NRDB-02', status: 'ready', description: 'NoRDBMS 마이그레이션' },
+    ],
+  },
+
+  {
+    id: 'C8-11-nrdb-backup',
+    code: 'C8',
+    title: 'NRDBMS Backup',
+    description: 'NoRDBMS 데이터베이스를 백업한다.',
+    status: 'ready',
+    actor: 'DBA / 인프라 엔지니어',
+    specFile: 'deploy/scenarios/C8-data/C8-11-nrdb-backup.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-DATA-NRDB-03', status: 'ready', description: 'NoRDBMS 백업' },
+    ],
+  },
+
+  {
+    id: 'C8-12-nrdb-restore',
+    code: 'C8',
+    title: 'NRDBMS Restore',
+    description: 'NoRDBMS 백업에서 데이터베이스를 복원한다.',
+    status: 'ready',
+    actor: 'DBA / 인프라 엔지니어',
+    specFile: 'deploy/scenarios/C8-data/C8-12-nrdb-restore.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-DATA-NRDB-04', status: 'ready', description: 'NoRDBMS 복원' },
+    ],
+  },
+
+  // ── C9: 클라우드 비용 분석 ────────────────────────────────────────────────
+  {
+    id: 'C9-01-cost-analysis',
+    code: 'C9',
+    title: '클라우드 비용 확인',
+    description: 'Cost Analysis iframe에서 당월 청구 및 Top5 비용을 확인한다.',
+    status: 'ready',
+    actor: '과금 관리자',
+    specFile: 'deploy/scenarios/C9-cost/C9-01-cost-analysis.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-COSTOPT-BILL-01',   status: 'ready', description: 'API 호스트 조회' },
+      { order: 2, tcId: 'TC-COSTOPT-BILL-02',   status: 'ready', description: '당월 청구 조회' },
+      { order: 3, tcId: 'TC-COSTOPT-BILL-03',   status: 'ready', description: 'Top5 청구 조회' },
+      { order: 4, tcId: 'TC-COSTOPT-IFRAME-01', status: 'ready', description: 'Cost Analysis iframe 확인' },
+    ],
+  },
+
+  // ── C10: 정리 / Cleanup ───────────────────────────────────────────────────
+  {
+    id: 'C10-01-wf-infra-delete',
+    code: 'C10',
+    title: 'WF로 인프라 삭제',
+    description: '워크플로우를 통해 MCI 인프라를 자동으로 삭제한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C10-cleanup/C10-01-wf-infra-delete.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-WF-FLOW-03',      status: 'ready', description: '인프라 삭제 Workflow 정의 확인' },
+      { order: 2, tcId: 'TC-WF-FLOW-06',      status: 'ready', description: '인프라 삭제 Workflow 실행' },
+      { order: 3, tcId: 'TC-INFRA-DEPLOY-01', status: 'ready', description: 'MCI 삭제 확인' },
+    ],
+  },
+
+  {
+    id: 'C10-02-wf-k8s-delete',
+    code: 'C10',
+    title: 'WF로 K8s 삭제',
+    description: 'K8s 삭제 Workflow를 실행하여 K8s 클러스터를 삭제한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C10-cleanup/C10-02-wf-k8s-delete.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-WF-FLOW-03',   status: 'ready', description: 'K8s 삭제 Workflow 존재 확인' },
+      { order: 2, tcId: 'TC-WF-FLOW-06',   status: 'ready', description: 'K8s 삭제 Workflow 실행' },
+      { order: 3, tcId: 'TC-INFRA-K8S-08', status: 'ready', description: 'K8s 클러스터 삭제 완료 확인', variant: 'tencent' },
+    ],
+  },
+
+  {
+    id: 'C10-03-mci-per-csp-delete',
+    code: 'C10',
+    title: 'CSP별 MCI 삭제 (자동화)',
+    description: 'CSP별 MCI(mci11~mci18)를 순서대로 삭제한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C10-cleanup/C10-03-mci-per-csp-delete.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-LC-02', status: 'ready', description: 'AWS MCI(mci11) 삭제',     variant: 'aws' },
+      { order: 2, tcId: 'TC-INFRA-LC-02', status: 'ready', description: 'Azure MCI(mci12) 삭제',   variant: 'azure' },
+      { order: 3, tcId: 'TC-INFRA-LC-02', status: 'ready', description: 'GCP MCI(mci13) 삭제',     variant: 'gcp' },
+      { order: 4, tcId: 'TC-INFRA-LC-02', status: 'ready', description: 'Alibaba MCI(mci14) 삭제', variant: 'ali' },
+      { order: 5, tcId: 'TC-INFRA-LC-02', status: 'ready', description: 'IBM MCI(mci15) 삭제',     variant: 'ibm' },
+      { order: 6, tcId: 'TC-INFRA-LC-02', status: 'ready', description: 'NHN MCI(mci16) 삭제',     variant: 'nhn' },
+      { order: 7, tcId: 'TC-INFRA-LC-02', status: 'ready', description: 'Tencent MCI(mci17) 삭제', variant: 'tencent' },
+      { order: 8, tcId: 'TC-INFRA-LC-02', status: 'ready', description: 'NCP MCI(mci18) 삭제',     variant: 'ncp' },
+    ],
+  },
+
+  {
+    id: 'C10-04-mci-multi-csp-delete',
+    code: 'C10',
+    title: 'Multi-CSP MCI 삭제',
+    description: 'C4-01-mci-multi-csp-cluster 가 생성한 Multi-CSP MCI(mci-multi)를 삭제한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C10-cleanup/C10-04-mci-multi-csp-delete.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-LC-02', status: 'ready', description: 'Multi-CSP MCI(mci-multi) 삭제', variant: 'multi-csp' },
+    ],
+  },
+
+  {
+    id: 'C10-05-mci-cleanup',
+    code: 'C10',
+    title: 'mc* MCI 일괄 삭제 (case 분류)',
+    description: '이름이 mc로 시작하는 모든 MCI를 Total Servers 수(0/1/2+)로 case 분류하여 일괄 삭제한다.',
+    status: 'ready',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C10-cleanup/C10-05-mci-cleanup.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-LC-03', status: 'ready', description: 'mc* MCI 스캔 → case1/2/3 분류 → 전체 삭제' },
+    ],
+  },
+
+  {
+    id: 'C10-06-k8s-per-csp-delete',
+    code: 'C10',
+    title: 'CSP별 K8s 클러스터(PMK) 삭제',
+    description: 'C4-02-k8s-* 가 생성한 CSP별 K8s 클러스터를 순서대로 삭제한다.',
+    status: 'partial',
+    actor: 'SRE 엔지니어',
+    specFile: 'deploy/scenarios/C10-cleanup/C10-06-k8s-per-csp-delete.spec.ts',
+    steps: [
+      { order: 1, tcId: 'TC-INFRA-K8S-08', status: 'todo',  description: 'AWS PMK 삭제',     variant: 'aws' },
+      { order: 2, tcId: 'TC-INFRA-K8S-08', status: 'todo',  description: 'Azure PMK 삭제',   variant: 'azure' },
+      { order: 3, tcId: 'TC-INFRA-K8S-08', status: 'todo',  description: 'GCP PMK 삭제',     variant: 'gcp' },
+      { order: 4, tcId: 'TC-INFRA-K8S-08', status: 'todo',  description: 'Alibaba PMK 삭제', variant: 'ali' },
+      { order: 5, tcId: 'TC-INFRA-K8S-08', status: 'wip',   description: 'IBM PMK 삭제',     variant: 'ibm' },
+      { order: 6, tcId: 'TC-INFRA-K8S-08', status: 'todo',  description: 'NHN PMK 삭제',     variant: 'nhn' },
+      { order: 7, tcId: 'TC-INFRA-K8S-08', status: 'ready', description: 'Tencent PMK 삭제', variant: 'tencent' },
+      { order: 8, tcId: 'TC-INFRA-K8S-08', status: 'ready', description: 'NCP PMK 삭제',     variant: 'ncp' },
+    ],
+  },
+];

--- a/e2e/registry/tc/cost.registry.ts
+++ b/e2e/registry/tc/cost.registry.ts
@@ -1,0 +1,36 @@
+/**
+ * deploy/registry/tc/cost.registry.ts
+ * COST(비용 최적화) 도메인 TC 전체 목록
+ *
+ * Feature 코드 (Excel mc-cost-optimizer 기준):
+ *   BILL   — 청구·비용 API 조회
+ *   IFRAME — Cost Analysis iframe 화면 테스트
+ *   INIT   — CUR 데이터 수집·알림/LLM 채널 설정 (초기화)
+ *   OPER   — 비용 수집 알람 수신·ML/LLM 자원 추천 (운영)
+ *
+ * 엑셀 TC ID 체계: TC-COSTOPT-{FEATURE}-{NN}
+ * 구 TC-COST-{FEATURE}-{NN} 에서 프레임워크 세그먼트 COST → COSTOPT 로 변경.
+ */
+import type { TCEntry } from '../types';
+
+export const COST_TC_REGISTRY: TCEntry[] = [
+  // ── BILL: 청구·비용 API 조회 ───────────────────────────────────────────────
+  { id: 'TC-COSTOPT-BILL-01',   domain: 'cost', feature: 'BILL',   title: 'API 호스트 조회',          status: 'ready', channel: 'api', specFile: 'mc-web-console/specs/cost/TC-COST-BILL-01-getApiHosts.spec.ts' },
+  { id: 'TC-COSTOPT-BILL-02',   domain: 'cost', feature: 'BILL',   title: '당월 청구 조회',            status: 'ready', channel: 'api', specFile: 'mc-web-console/specs/cost/TC-COST-BILL-02-getCurMonthBill.spec.ts' },
+  { id: 'TC-COSTOPT-BILL-03',   domain: 'cost', feature: 'BILL',   title: 'Top5 청구 조회',            status: 'ready', channel: 'api', specFile: 'mc-web-console/specs/cost/TC-COST-BILL-03-getTop5Bill.spec.ts' },
+  { id: 'TC-COSTOPT-BILL-04',   domain: 'cost', feature: 'BILL',   title: '자산별 청구 조회',          status: 'ready', channel: 'api', specFile: 'mc-web-console/specs/cost/TC-COST-BILL-04-getBillAsset.spec.ts' },
+  { id: 'TC-COSTOPT-IFRAME-01', domain: 'cost', feature: 'IFRAME', title: 'Cost Analysis iframe 화면', status: 'ready', channel: 'ui',  specFile: 'mc-web-console/specs/cost/TC-COST-IFRAME-cost-analysis-iframe.spec.ts' },
+
+  // ── INIT: CUR 데이터 수집 설정 + 채널 설정 ────────────────────────────────
+  { id: 'TC-COSTOPT-INIT-01', domain: 'cost', feature: 'INIT', title: 'AWS CUR 데이터 수집 설정',                      status: 'todo', channel: 'ui', specFile: 'deploy/scenarios/C9-cost/C9-02-cost-cur-init.spec.ts' },
+  { id: 'TC-COSTOPT-INIT-02', domain: 'cost', feature: 'INIT', title: 'NCP CUR 데이터 수집 설정',                      status: 'todo', channel: 'ui', specFile: 'deploy/scenarios/C9-cost/C9-02-cost-cur-init.spec.ts' },
+  { id: 'TC-COSTOPT-INIT-03', domain: 'cost', feature: 'INIT', title: 'Azure CUR 데이터 수집 설정',                    status: 'todo', channel: 'ui', specFile: 'deploy/scenarios/C9-cost/C9-02-cost-cur-init.spec.ts' },
+  { id: 'TC-COSTOPT-INIT-04', domain: 'cost', feature: 'INIT', title: 'GCP CUR 데이터 수집 설정',                      status: 'todo', channel: 'ui', specFile: 'deploy/scenarios/C9-cost/C9-02-cost-cur-init.spec.ts' },
+  { id: 'TC-COSTOPT-INIT-05', domain: 'cost', feature: 'INIT', title: '알림 채널 설정 (Gmail / Slack)',                 status: 'todo', channel: 'ui', specFile: 'deploy/scenarios/C9-cost/C9-03-cost-channel-init.spec.ts' },
+  { id: 'TC-COSTOPT-INIT-06', domain: 'cost', feature: 'INIT', title: 'LLM 채널 설정',                                 status: 'todo', channel: 'ui', specFile: 'deploy/scenarios/C9-cost/C9-03-cost-channel-init.spec.ts' },
+
+  // ── OPER: 비용 수집 알람 수신 + ML/LLM 자원 추천 ─────────────────────────
+  { id: 'TC-COSTOPT-OPER-01', domain: 'cost', feature: 'OPER', title: '비용 수집 및 최적화 알람 수신',                  status: 'todo', channel: 'ui', specFile: 'deploy/scenarios/C9-cost/C9-04-cost-oper-alarm.spec.ts' },
+  { id: 'TC-COSTOPT-OPER-02', domain: 'cost', feature: 'OPER', title: '덤프데이터를 통한 비용 수집 및 최적화 알람 수신', status: 'todo', channel: 'ui', specFile: 'deploy/scenarios/C9-cost/C9-04-cost-oper-alarm.spec.ts' },
+  { id: 'TC-COSTOPT-OPER-03', domain: 'cost', feature: 'OPER', title: 'ML/LLM 자원 추천 (Resource Recommendation)',     status: 'todo', channel: 'ui', specFile: 'deploy/scenarios/C9-cost/C9-05-cost-oper-recommendation.spec.ts' },
+];

--- a/e2e/registry/tc/csp.registry.ts
+++ b/e2e/registry/tc/csp.registry.ts
@@ -1,0 +1,86 @@
+/**
+ * deploy/registry/tc/csp.registry.ts
+ * CSP 도메인 TC 전체 목록 (44개)
+ *
+ * Feature 코드:
+ *   CONNECTION   — CSP 연결 관리
+ *   CREDENTIAL   — CSP 인증 자격증명
+ *   IMG          — 서버 이미지 관리
+ *   IMPORT-DISK  — 데이터 디스크 가져오기
+ *   IMPORT-NET   — VNet 가져오기
+ *   IMPORT-SG    — 보안그룹 가져오기
+ *   IMPORT-SSH   — SSH 키 가져오기
+ *   IMPORT-VM    — VM 가져오기 (5단계 워크플로우)
+ *   KEY          — SSH 키 관리
+ *   SG           — 보안그룹 관리
+ *   SPEC         — 서버 스펙 관리
+ *   VPC          — VPC 관리
+ */
+import type { TCEntry } from '../types';
+
+export const CSP_TC_REGISTRY: TCEntry[] = [
+
+  // ── CONNECTION (3) ───────────────────────────────────────────────────────
+  { id: 'TC-CSP-CONNECTION-01', domain: 'csp', feature: 'CONNECTION', title: 'CSP 연결 목록 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/csp/TC-CSP-CONNECTION-01-list-connections.spec.ts' },
+  { id: 'TC-CSP-CONNECTION-02', domain: 'csp', feature: 'CONNECTION', title: 'CSP 연결 생성', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/csp/TC-CSP-CONNECTION-02-create-connection.spec.ts' },
+  { id: 'TC-CSP-CONNECTION-03', domain: 'csp', feature: 'CONNECTION', title: 'CSP 연결 삭제', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/csp/TC-CSP-CONNECTION-03-delete-connection.spec.ts' },
+
+  // ── CREDENTIAL → TC-INFRA-CSP-* 로 이관 (infra.registry.ts 참조) ──────────
+
+  // ── IMG (4) ──────────────────────────────────────────────────────────────
+  { id: 'TC-CSP-IMG-01', domain: 'csp', feature: 'IMG', title: '서버 이미지 목록 표시', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMG-01-server-image-목록-표시.spec.ts' },
+  { id: 'TC-CSP-IMG-02', domain: 'csp', feature: 'IMG', title: '이미지 등록 팝업·자동채움·등록', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMG-02-register-image-팝업-선택-자동채움-등록.spec.ts' },
+  { id: 'TC-CSP-IMG-03', domain: 'csp', feature: 'IMG', title: '이미지 행 클릭·상세 패널', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMG-03-image-행-클릭-상세-패널.spec.ts' },
+  { id: 'TC-CSP-IMG-04', domain: 'csp', feature: 'IMG', title: '이미지 삭제·패널 닫힘', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMG-04-delete-image-패널-닫힘.spec.ts' },
+
+  // ── IMPORT-DISK (2) ──────────────────────────────────────────────────────
+  { id: 'TC-CSP-IMPORT-DISK-01', domain: 'csp', feature: 'IMPORT-DISK', title: '데이터디스크 가져오기 버튼·모달 오픈', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-DISK-01-import-datadisk-버튼-모달-오픈.spec.ts' },
+  { id: 'TC-CSP-IMPORT-DISK-02', domain: 'csp', feature: 'IMPORT-DISK', title: '연결 선택 후 데이터디스크 가져오기 성공', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-DISK-02-connection-선택-후-datadisk-import-성공.spec.ts' },
+
+  // ── IMPORT-NET (3) ───────────────────────────────────────────────────────
+  { id: 'TC-CSP-IMPORT-NET-01', domain: 'csp', feature: 'IMPORT-NET', title: 'VNet 가져오기 버튼·모달 오픈', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-NET-01-import-vnet-버튼-모달-오픈.spec.ts' },
+  { id: 'TC-CSP-IMPORT-NET-02', domain: 'csp', feature: 'IMPORT-NET', title: '미관리·등록됨 VNet 구분 표시', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-NET-02-미관리-등록됨-vnet-구분-표시.spec.ts' },
+  { id: 'TC-CSP-IMPORT-NET-03', domain: 'csp', feature: 'IMPORT-NET', title: '미관리 VNet 선택 후 가져오기 성공', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-NET-03-미관리-vnet-선택-후-import-성공.spec.ts' },
+
+  // ── IMPORT-SG (3) ────────────────────────────────────────────────────────
+  { id: 'TC-CSP-IMPORT-SG-01', domain: 'csp', feature: 'IMPORT-SG', title: '보안그룹 가져오기 버튼·모달 오픈', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-SG-01-import-securitygroup-버튼-모달-오픈.spec.ts' },
+  { id: 'TC-CSP-IMPORT-SG-02', domain: 'csp', feature: 'IMPORT-SG', title: '연결 선택 후 보안그룹 가져오기 성공', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-SG-02-connection-선택-후-sg-import-성공.spec.ts' },
+  { id: 'TC-CSP-IMPORT-SG-03', domain: 'csp', feature: 'IMPORT-SG', title: '연결 미선택 시 가져오기 경고', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-SG-03-connection-미선택-시-import-경고.spec.ts' },
+
+  // ── IMPORT-SSH (2) ───────────────────────────────────────────────────────
+  { id: 'TC-CSP-IMPORT-SSH-01', domain: 'csp', feature: 'IMPORT-SSH', title: 'SSH 키 가져오기 버튼·모달 오픈', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-SSH-01-import-ssh-key-버튼-모달-오픈.spec.ts' },
+  { id: 'TC-CSP-IMPORT-SSH-02', domain: 'csp', feature: 'IMPORT-SSH', title: '연결 선택 후 SSH 키 가져오기 성공', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-SSH-02-connection-선택-후-ssh-key-import-성공.spec.ts' },
+
+  // ── IMPORT-VM (5) ────────────────────────────────────────────────────────
+  { id: 'TC-CSP-IMPORT-VM-01', domain: 'csp', feature: 'IMPORT-VM', title: 'VM 가져오기 버튼 표시·Step1 모달 오픈', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-VM-01-import-vm-버튼-표시-step1-모달-오픈.spec.ts' },
+  { id: 'TC-CSP-IMPORT-VM-02', domain: 'csp', feature: 'IMPORT-VM', title: '연결 선택 후 VM 목록 조회', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-VM-02-connection-선택-후-vm-목록-조회.spec.ts' },
+  { id: 'TC-CSP-IMPORT-VM-03', domain: 'csp', feature: 'IMPORT-VM', title: 'VM 선택 후 Step2 전환·의존 자원 상태', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-VM-03-vm-선택-후-step2-전환-의존-자원-상태.spec.ts' },
+  { id: 'TC-CSP-IMPORT-VM-04', domain: 'csp', feature: 'IMPORT-VM', title: 'Step3 MCI 이름 입력 후 가져오기 성공', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-VM-04-step3-mci-이름-입력-후-import-성공.spec.ts' },
+  { id: 'TC-CSP-IMPORT-VM-05', domain: 'csp', feature: 'IMPORT-VM', title: 'MCI 이름 미입력 경고', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-IMPORT-VM-05-mci-이름-미입력-경고.spec.ts' },
+
+  // ── KEY (3) ──────────────────────────────────────────────────────────────
+  { id: 'TC-CSP-KEY-01', domain: 'csp', feature: 'KEY', title: 'SSH 키 목록 표시', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/csp/TC-CSP-KEY-01-ssh-key-목록-표시.spec.ts' },
+  { id: 'TC-CSP-KEY-02', domain: 'csp', feature: 'KEY', title: 'SSH 키 생성·Private Key Alert 포함', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-KEY-02-ssh-key-생성-private-key-alert-포함.spec.ts' },
+  { id: 'TC-CSP-KEY-03', domain: 'csp', feature: 'KEY', title: 'Private Key blur 마스킹·togglePrivateKey', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-KEY-03-private-key-blur-마스킹-toggleprivatekey.spec.ts' },
+
+  // ── SG (4) ───────────────────────────────────────────────────────────────
+  { id: 'TC-CSP-SG-01', domain: 'csp', feature: 'SG', title: '보안그룹 목록 표시', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/csp/TC-CSP-SG-01-security-group-목록-표시.spec.ts' },
+  { id: 'TC-CSP-SG-02', domain: 'csp', feature: 'SG', title: '보안그룹 행 클릭·상세 패널·방화벽 규칙', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-SG-02-sg-행-클릭-상세-패널-방화벽-규칙.spec.ts' },
+  { id: 'TC-CSP-SG-03', domain: 'csp', feature: 'SG', title: '보안그룹 생성·방화벽 룰 포함', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-SG-03-create-security-group-방화벽-룰-포함-생성-성공.spec.ts' },
+  { id: 'TC-CSP-SG-04', domain: 'csp', feature: 'SG', title: '보안그룹 삭제·패널 닫힘', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-SG-04-delete-security-group-패널-닫힘.spec.ts' },
+
+  // ── SPEC (4) ─────────────────────────────────────────────────────────────
+  { id: 'TC-CSP-SPEC-01', domain: 'csp', feature: 'SPEC', title: '서버 스펙 목록 표시', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/csp/TC-CSP-SPEC-01-server-spec-목록-표시.spec.ts' },
+  { id: 'TC-CSP-SPEC-02', domain: 'csp', feature: 'SPEC', title: '스펙 등록 팝업·자동채움·등록', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-SPEC-02-register-spec-팝업-선택-자동채움-등록.spec.ts' },
+  { id: 'TC-CSP-SPEC-03', domain: 'csp', feature: 'SPEC', title: '스펙 행 클릭·상세 패널', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-SPEC-03-spec-행-클릭-상세-패널.spec.ts' },
+  { id: 'TC-CSP-SPEC-04', domain: 'csp', feature: 'SPEC', title: '스펙 삭제·패널 닫힘', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-SPEC-04-delete-spec-패널-닫힘.spec.ts' },
+
+  // ── VPC (7) ──────────────────────────────────────────────────────────────
+  { id: 'TC-CSP-VPC-01', domain: 'csp', feature: 'VPC', title: 'VPC 목록 표시', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/csp/TC-CSP-VPC-01-vpc-목록-표시.spec.ts' },
+  { id: 'TC-CSP-VPC-02', domain: 'csp', feature: 'VPC', title: 'VPC 행 클릭·상세 패널·Subnet 테이블', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-VPC-02-vpc-행-클릭-상세-패널-subnet-테이블.spec.ts' },
+  { id: 'TC-CSP-VPC-03', domain: 'csp', feature: 'VPC', title: 'VPC 생성·모달·Subnet 포함', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-VPC-03-create-vpc-모달-subnet-포함-생성-성공.spec.ts' },
+  { id: 'TC-CSP-VPC-04', domain: 'csp', feature: 'VPC', title: 'VPC 삭제·Confirm·패널 닫힘', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-VPC-04-delete-vpc-confirm-패널-닫힘.spec.ts' },
+  { id: 'TC-CSP-VPC-05', domain: 'csp', feature: 'VPC', title: 'Edit 버튼·Edit Form 전환·Cancel', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-VPC-05-edit-버튼-edit-form-전환-cancel.spec.ts' },
+  { id: 'TC-CSP-VPC-06', domain: 'csp', feature: 'VPC', title: 'Subnet 추가·postSubnet API 호출', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-VPC-06-subnet-추가-postsubnet-api-호출.spec.ts' },
+  { id: 'TC-CSP-VPC-07', domain: 'csp', feature: 'VPC', title: 'Subnet 삭제·delSubnet API 호출', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/csp/TC-CSP-VPC-07-subnet-삭제-delsubnet-api-호출.spec.ts' },
+];

--- a/e2e/registry/tc/data.registry.ts
+++ b/e2e/registry/tc/data.registry.ts
@@ -1,0 +1,56 @@
+/**
+ * deploy/registry/tc/data.registry.ts
+ * DATA 도메인 TC 전체 목록 (mc-data-manager)
+ *
+ * Feature 코드:
+ *   OS    — Object Storage CRUD (01~04)
+ *   RDB   — RDBMS CRUD (01~04, BAK, MIG)
+ *   NORDB — NoRDBMS (BAK, MIG)
+ *   NRDB  — NoRDBMS CRUD (01~04)
+ *   OBJ   — Object Storage (BAK, MIG)
+ *   UI    — 포털 iframe UI (01~06)
+ *
+ * spec 파일 위치: deploy/tc/data/
+ */
+import type { TCEntry } from '../types';
+
+export const DATA_TC_REGISTRY: TCEntry[] = [
+
+  // ── Object Storage CRUD (4) ──────────────────────────────────────────────
+  { id: 'TC-DATA-OS-01', domain: 'data', feature: 'OS', title: 'Object Storage 생성', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-OS-01-04.spec.ts' },
+  { id: 'TC-DATA-OS-02', domain: 'data', feature: 'OS', title: 'Object Storage 마이그레이션', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-OS-01-04.spec.ts' },
+  { id: 'TC-DATA-OS-03', domain: 'data', feature: 'OS', title: 'Object Storage 백업', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-OS-01-04.spec.ts' },
+  { id: 'TC-DATA-OS-04', domain: 'data', feature: 'OS', title: 'Object Storage 복원', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-OS-01-04.spec.ts' },
+
+  // ── OBJ (2) ──────────────────────────────────────────────────────────────
+  { id: 'TC-DATA-OBJ-MIG-01', domain: 'data', feature: 'OBJ', title: 'Object Storage 마이그레이션 (상세)', status: 'ready', channel: 'api+ui', specFile: 'deploy/tc/data/TC-DATA-OBJ-MIG-01.spec.ts' },
+  { id: 'TC-DATA-OBJ-BAK-01', domain: 'data', feature: 'OBJ', title: 'Object Storage 백업 (상세)', status: 'ready', channel: 'api+ui', specFile: 'deploy/tc/data/TC-DATA-OBJ-BAK-01.spec.ts' },
+
+  // ── RDB — CRUD (4) ───────────────────────────────────────────────────────
+  { id: 'TC-DATA-RDB-01', domain: 'data', feature: 'RDB', title: 'RDBMS 데이터 생성 (Generate)', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-RDB-01-04.spec.ts' },
+  { id: 'TC-DATA-RDB-02', domain: 'data', feature: 'RDB', title: 'RDBMS 마이그레이션', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-RDB-01-04.spec.ts' },
+  { id: 'TC-DATA-RDB-03', domain: 'data', feature: 'RDB', title: 'RDBMS 백업', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-RDB-01-04.spec.ts' },
+  { id: 'TC-DATA-RDB-04', domain: 'data', feature: 'RDB', title: 'RDBMS 복원', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-RDB-01-04.spec.ts' },
+
+  // ── RDB — 상세 (2) ───────────────────────────────────────────────────────
+  { id: 'TC-DATA-RDB-BAK-01', domain: 'data', feature: 'RDB', title: 'RDBMS 백업 (상세)', status: 'ready', channel: 'api+ui', specFile: 'deploy/tc/data/TC-DATA-RDB-BAK-01.spec.ts' },
+  { id: 'TC-DATA-RDB-MIG-01', domain: 'data', feature: 'RDB', title: 'RDBMS 마이그레이션 (상세)', status: 'ready', channel: 'api+ui', specFile: 'deploy/tc/data/TC-DATA-RDB-MIG-01.spec.ts' },
+
+  // ── NRDB — CRUD (4) ──────────────────────────────────────────────────────
+  { id: 'TC-DATA-NRDB-01', domain: 'data', feature: 'NRDB', title: 'NoRDBMS 데이터 생성 (Generate)', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-NRDB-01-04.spec.ts' },
+  { id: 'TC-DATA-NRDB-02', domain: 'data', feature: 'NRDB', title: 'NoRDBMS 마이그레이션', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-NRDB-01-04.spec.ts' },
+  { id: 'TC-DATA-NRDB-03', domain: 'data', feature: 'NRDB', title: 'NoRDBMS 백업', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-NRDB-01-04.spec.ts' },
+  { id: 'TC-DATA-NRDB-04', domain: 'data', feature: 'NRDB', title: 'NoRDBMS 복원', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-NRDB-01-04.spec.ts' },
+
+  // ── NORDB — 상세 (2) ─────────────────────────────────────────────────────
+  { id: 'TC-DATA-NORDB-BAK-01', domain: 'data', feature: 'NORDB', title: 'NoRDBMS 백업 (상세)', status: 'ready', channel: 'api+ui', specFile: 'deploy/tc/data/TC-DATA-NORDB-BAK-01.spec.ts' },
+  { id: 'TC-DATA-NORDB-MIG-01', domain: 'data', feature: 'NORDB', title: 'NoRDBMS 마이그레이션 (상세)', status: 'ready', channel: 'api+ui', specFile: 'deploy/tc/data/TC-DATA-NORDB-MIG-01.spec.ts' },
+
+  // ── UI — 포털 iframe (6) ─────────────────────────────────────────────────
+  { id: 'TC-DATA-UI-01', domain: 'data', feature: 'UI', title: 'Data Migration 페이지 로드 및 iframe 초기화', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-UI.spec.ts' },
+  { id: 'TC-DATA-UI-02', domain: 'data', feature: 'UI', title: 'Nav 탭 Navigation', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-UI.spec.ts' },
+  { id: 'TC-DATA-UI-03', domain: 'data', feature: 'UI', title: 'Service 탭 전환', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-UI.spec.ts' },
+  { id: 'TC-DATA-UI-04', domain: 'data', feature: 'UI', title: 'Object Storage Migration 태스크 목록', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-UI.spec.ts' },
+  { id: 'TC-DATA-UI-05', domain: 'data', feature: 'UI', title: 'Generate 페이지', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-UI.spec.ts' },
+  { id: 'TC-DATA-UI-06', domain: 'data', feature: 'UI', title: 'Back up / Restore 등록 페이지', status: 'ready', channel: 'ui', specFile: 'deploy/tc/data/TC-DATA-UI.spec.ts' },
+];

--- a/e2e/registry/tc/iam.registry.ts
+++ b/e2e/registry/tc/iam.registry.ts
@@ -1,0 +1,117 @@
+/**
+ * deploy/registry/tc/iam.registry.ts
+ * IAM 도메인 TC 전체 목록 (76개)
+ *
+ * Feature 코드:
+ *   AUTH          — 인증 (로그인·로그아웃·토큰)
+ *   COMPANY       — 회사 관리
+ *   MENU          — 메뉴 관리
+ *   ORG           — 조직 관리
+ *   POLICY        — 정책 관리
+ *   PROJECT       — 프로젝트 관리
+ *   ROLE          — 역할 관리
+ *   USER-LIFECYCLE— 사용자 가입·승인 전체 흐름
+ *   USERGROUP     — 사용자·그룹 CRUD + 역할 관계
+ *   WORKSPACE     — 워크스페이스 CRUD + 멤버·UI
+ */
+import type { TCEntry } from '../types';
+
+export const IAM_TC_REGISTRY: TCEntry[] = [
+
+  // ── AUTH (11) ─────────────────────────────────────────────────────────────
+  { id: 'TC-IAM-AUTH-01', domain: 'iam', feature: 'AUTH', title: '로그인', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-AUTH-01-login.spec.ts' },
+  { id: 'TC-IAM-AUTH-02', domain: 'iam', feature: 'AUTH', title: '로그아웃', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-AUTH-02-logout.spec.ts' },
+  { id: 'TC-IAM-AUTH-03', domain: 'iam', feature: 'AUTH', title: '토큰 갱신', status: 'ready', channel: 'api', specFile: 'mc-web-console/specs/iam/TC-IAM-AUTH-03-refresh.spec.ts' },
+  { id: 'TC-IAM-AUTH-04', domain: 'iam', feature: 'AUTH', title: '토큰 유효성 검증', status: 'ready', channel: 'api', specFile: 'mc-web-console/specs/iam/TC-IAM-AUTH-04-validate.spec.ts' },
+  { id: 'TC-IAM-AUTH-05', domain: 'iam', feature: 'AUTH', title: '회원가입', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-AUTH-05-signup.spec.ts' },
+  { id: 'TC-IAM-AUTH-06', domain: 'iam', feature: 'AUTH', title: 'Workspace 티켓 발급', status: 'ready', channel: 'api', specFile: 'mc-web-console/specs/iam/TC-IAM-AUTH-06-workspace-ticket.spec.ts' },
+  { id: 'TC-IAM-AUTH-07', domain: 'iam', feature: 'AUTH', title: 'JWT 토큰 구조 검증', status: 'ready', channel: 'api', specFile: 'mc-web-console/specs/iam/TC-IAM-AUTH-07-JWT-token-structure.spec.ts' },
+  { id: 'TC-IAM-AUTH-08', domain: 'iam', feature: 'AUTH', title: '만료 토큰 갱신 처리', status: 'ready', channel: 'api', specFile: 'mc-web-console/specs/iam/TC-IAM-AUTH-08-expired-token-refresh.spec.ts' },
+  { id: 'TC-IAM-AUTH-09', domain: 'iam', feature: 'AUTH', title: '갱신 입력값 유효성 검증', status: 'ready', channel: 'api', specFile: 'mc-web-console/specs/iam/TC-IAM-AUTH-09-refresh-input-validation.spec.ts' },
+  { id: 'TC-IAM-AUTH-10', domain: 'iam', feature: 'AUTH', title: '갱신 엔드포인트 접근성', status: 'ready', channel: 'api', specFile: 'mc-web-console/specs/iam/TC-IAM-AUTH-10-refresh-endpoint-accessibility.spec.ts' },
+  { id: 'TC-IAM-AUTH-11', domain: 'iam', feature: 'AUTH', title: '세션 보호', status: 'ready', channel: 'api', specFile: 'mc-web-console/specs/iam/TC-IAM-AUTH-11-session-protection.spec.ts' },
+
+  // ── COMPANY (4) ──────────────────────────────────────────────────────────
+  { id: 'TC-IAM-COMP-01', domain: 'iam', feature: 'COMP', title: '회사 목록 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-COMPANY-01-list-companies.spec.ts' },
+  { id: 'TC-IAM-COMP-02', domain: 'iam', feature: 'COMP', title: '회사 생성', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-COMPANY-02-create-company.spec.ts' },
+  { id: 'TC-IAM-COMP-03', domain: 'iam', feature: 'COMP', title: '회사 수정', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-COMPANY-03-update-company.spec.ts' },
+  { id: 'TC-IAM-COMP-04', domain: 'iam', feature: 'COMP', title: '회사 삭제', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-COMPANY-04-delete-company.spec.ts' },
+
+  // ── MENU (5) ─────────────────────────────────────────────────────────────
+  { id: 'TC-IAM-MENU-01', domain: 'iam', feature: 'MENU', title: '메뉴 목록 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-MENU-01-list-menus.spec.ts' },
+  { id: 'TC-IAM-MENU-02', domain: 'iam', feature: 'MENU', title: '메뉴별 역할 체크박스 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-MENU-02-list-roles-for-menu-checkbox.spec.ts' },
+  { id: 'TC-IAM-MENU-03', domain: 'iam', feature: 'MENU', title: '메뉴 생성', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-MENU-03-create-menu.spec.ts' },
+  { id: 'TC-IAM-MENU-04', domain: 'iam', feature: 'MENU', title: '메뉴 수정', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-MENU-04-update-menu.spec.ts' },
+  { id: 'TC-IAM-MENU-05', domain: 'iam', feature: 'MENU', title: '메뉴 삭제', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-MENU-05-delete-menu.spec.ts' },
+
+  // ── ORG (5) ──────────────────────────────────────────────────────────────
+  { id: 'TC-IAM-ORG-01', domain: 'iam', feature: 'ORG', title: '조직 목록 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-ORG-01-list-orgs.spec.ts' },
+  { id: 'TC-IAM-ORG-02', domain: 'iam', feature: 'ORG', title: '조직 트리 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-ORG-02-org-tree.spec.ts' },
+  { id: 'TC-IAM-ORG-03', domain: 'iam', feature: 'ORG', title: '조직 생성', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-ORG-03-create-org.spec.ts' },
+  { id: 'TC-IAM-ORG-04', domain: 'iam', feature: 'ORG', title: '조직 수정', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-ORG-04-update-org.spec.ts' },
+  { id: 'TC-IAM-ORG-05', domain: 'iam', feature: 'ORG', title: '조직 삭제', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-ORG-05-delete-org.spec.ts' },
+
+  // ── POLICY (4) ───────────────────────────────────────────────────────────
+  { id: 'TC-IAM-POLICY-01', domain: 'iam', feature: 'POLICY', title: '정책 목록 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-POLICY-01-list-policies.spec.ts' },
+  { id: 'TC-IAM-POLICY-02', domain: 'iam', feature: 'POLICY', title: '정책 생성', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-POLICY-02-create-policy.spec.ts' },
+  { id: 'TC-IAM-POLICY-03', domain: 'iam', feature: 'POLICY', title: '정책 수정', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-POLICY-03-update-policy.spec.ts' },
+  { id: 'TC-IAM-POLICY-04', domain: 'iam', feature: 'POLICY', title: '정책 삭제', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-POLICY-04-delete-policy.spec.ts' },
+
+  // ── PROJECT (4) ──────────────────────────────────────────────────────────
+  { id: 'TC-IAM-PRJ-01', domain: 'iam', feature: 'PRJ', title: '프로젝트 목록 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-PROJECT-01-list-projects.spec.ts' },
+  { id: 'TC-IAM-PRJ-02', domain: 'iam', feature: 'PRJ', title: '프로젝트 생성', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-PROJECT-02-create-project.spec.ts' },
+  { id: 'TC-IAM-PRJ-03', domain: 'iam', feature: 'PRJ', title: '프로젝트 수정', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-PROJECT-03-update-project.spec.ts' },
+  { id: 'TC-IAM-PRJ-04', domain: 'iam', feature: 'PRJ', title: '프로젝트 삭제', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-PROJECT-04-delete-project.spec.ts' },
+
+  // ── ROLE (8) ─────────────────────────────────────────────────────────────
+  { id: 'TC-IAM-RBAC-01', domain: 'iam', feature: 'RBAC', title: '역할 목록 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-ROLE-01-list-roles.spec.ts' },
+  { id: 'TC-IAM-RBAC-02', domain: 'iam', feature: 'RBAC', title: '역할 생성', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-ROLE-02-create-role.spec.ts' },
+  { id: 'TC-IAM-RBAC-03', domain: 'iam', feature: 'RBAC', title: '역할 수정', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-ROLE-03-update-role.spec.ts' },
+  { id: 'TC-IAM-RBAC-04', domain: 'iam', feature: 'RBAC', title: '역할 삭제', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-ROLE-04-delete-role.spec.ts' },
+  { id: 'TC-IAM-RBAC-05', domain: 'iam', feature: 'RBAC', title: '플랫폼 역할 목록 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-ROLE-05-list-platform-roles.spec.ts' },
+  { id: 'TC-IAM-RBAC-06', domain: 'iam', feature: 'RBAC', title: '사용자에 플랫폼 역할 부여', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-ROLE-06-assign-platform-role-to-user.spec.ts' },
+  { id: 'TC-IAM-RBAC-07', domain: 'iam', feature: 'RBAC', title: '그룹에 플랫폼 역할 부여', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-ROLE-07-assign-platform-role-to-group.spec.ts' },
+  { id: 'TC-IAM-RBAC-08', domain: 'iam', feature: 'RBAC', title: '워크스페이스 역할 목록 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-ROLE-08-list-workspace-roles.spec.ts' },
+
+  // ── USER-LIFECYCLE (3) ───────────────────────────────────────────────────
+  { id: 'TC-IAM-USER-LIFECYCLE-01', domain: 'iam', feature: 'USER-LIFECYCLE', title: '가입 신청·관리자 API 승인 후 로그인', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USER-LIFECYCLE-01-signup-approve-via-api-then-login.spec.ts' },
+  { id: 'TC-IAM-USER-LIFECYCLE-02', domain: 'iam', feature: 'USER-LIFECYCLE', title: '가입 신청·관리자 UI 승인 후 로그인', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USER-LIFECYCLE-02-signup-approve-via-ui-then-login.spec.ts' },
+  { id: 'TC-IAM-USER-LIFECYCLE-03', domain: 'iam', feature: 'USER-LIFECYCLE', title: '가입 승인 후 역할·워크스페이스 선택', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USER-LIFECYCLE-03-signup-approve-roles-workspace-select.spec.ts' },
+
+  // ── USERGROUP (17) ───────────────────────────────────────────────────────
+  { id: 'TC-IAM-UG-01', domain: 'iam', feature: 'UG', title: '사용자 목록 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-01-list-users.spec.ts' },
+  { id: 'TC-IAM-UG-02', domain: 'iam', feature: 'UG', title: '사용자 단건 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-02-get-user.spec.ts' },
+  { id: 'TC-IAM-UG-03', domain: 'iam', feature: 'UG', title: '사용자 생성', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-03-create-user.spec.ts' },
+  { id: 'TC-IAM-UG-04', domain: 'iam', feature: 'UG', title: '사용자 수정', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-04-update-user.spec.ts' },
+  { id: 'TC-IAM-UG-05', domain: 'iam', feature: 'UG', title: '사용자 삭제', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-05-delete-user.spec.ts' },
+  { id: 'TC-IAM-UG-06', domain: 'iam', feature: 'UG', title: '그룹 목록 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-06-list-groups.spec.ts' },
+  { id: 'TC-IAM-UG-07', domain: 'iam', feature: 'UG', title: '그룹 단건 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-07-get-group.spec.ts' },
+  { id: 'TC-IAM-UG-08', domain: 'iam', feature: 'UG', title: '그룹 생성', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-08-create-group.spec.ts' },
+  { id: 'TC-IAM-UG-09', domain: 'iam', feature: 'UG', title: '그룹 수정', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-09-update-group.spec.ts' },
+  { id: 'TC-IAM-UG-10', domain: 'iam', feature: 'UG', title: '그룹 삭제', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-10-delete-group.spec.ts' },
+  { id: 'TC-IAM-UG-11', domain: 'iam', feature: 'UG', title: '그룹에 사용자 배정', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-11-assign-user-to-group.spec.ts' },
+  { id: 'TC-IAM-UG-12', domain: 'iam', feature: 'UG', title: '그룹에서 사용자 제거', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-12-remove-user-from-group.spec.ts' },
+  { id: 'TC-IAM-UG-13', domain: 'iam', feature: 'UG', title: '사용자에 플랫폼 역할 부여', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-13-assign-platform-role-to-user.spec.ts' },
+  { id: 'TC-IAM-UG-14', domain: 'iam', feature: 'UG', title: '사용자 플랫폼 역할 제거', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-14-remove-platform-role-from-user.spec.ts' },
+  { id: 'TC-IAM-UG-15', domain: 'iam', feature: 'UG', title: '사용자 비밀번호 초기화', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-15-reset-user-password.spec.ts' },
+  { id: 'TC-IAM-UG-16', domain: 'iam', feature: 'UG', title: '사용자 상태 변경', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-16-update-user-status.spec.ts' },
+  { id: 'TC-IAM-UG-17', domain: 'iam', feature: 'UG', title: '활성 멤버 보유 그룹 삭제 거부', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-USERGROUP-17-reject-delete-group-with-active-member.spec.ts' },
+
+  // ── WORKSPACE (15) ───────────────────────────────────────────────────────
+  { id: 'TC-IAM-WS-01', domain: 'iam', feature: 'WS', title: '워크스페이스 목록 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-01-list-workspaces.spec.ts' },
+  { id: 'TC-IAM-WS-02', domain: 'iam', feature: 'WS', title: '워크스페이스 생성', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-02-create-workspace.spec.ts' },
+  { id: 'TC-IAM-WS-03', domain: 'iam', feature: 'WS', title: '워크스페이스 수정', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-03-update-workspace.spec.ts' },
+  { id: 'TC-IAM-WS-04', domain: 'iam', feature: 'WS', title: '워크스페이스 삭제', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-04-delete-workspace.spec.ts' },
+  { id: 'TC-IAM-WS-05', domain: 'iam', feature: 'WS', title: '워크스페이스에 사용자 배정', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-05-assign-user-to-workspace.spec.ts' },
+  { id: 'TC-IAM-WS-06', domain: 'iam', feature: 'WS', title: '워크스페이스 역할과 함께 사용자 배정', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-06-assign-user-with-workspace-role.spec.ts' },
+  { id: 'TC-IAM-WS-07', domain: 'iam', feature: 'WS', title: '배정된 워크스페이스 사용자 확인', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-07-user-sees-assigned-workspace.spec.ts' },
+  { id: 'TC-IAM-WS-08', domain: 'iam', feature: 'WS', title: '대시보드 카운트 표시', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-08-dashboard-count-display.spec.ts' },
+  { id: 'TC-IAM-WS-09', domain: 'iam', feature: 'WS', title: '상세 카드·탭 네비게이션', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-09-detail-card-and-tab-navigation.spec.ts' },
+  { id: 'TC-IAM-WS-10', domain: 'iam', feature: 'WS', title: '워크스페이스 추가 모달 UI', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-10-add-workspace-modal-ui.spec.ts' },
+  { id: 'TC-IAM-WS-11', domain: 'iam', feature: 'WS', title: '편집 모달 UI', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-11-edit-modal-ui.spec.ts' },
+  { id: 'TC-IAM-WS-12', domain: 'iam', feature: 'WS', title: '삭제 확인 모달 UI', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-12-delete-confirm-modal-ui.spec.ts' },
+  { id: 'TC-IAM-WS-13', domain: 'iam', feature: 'WS', title: 'Projects 탭 관리', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-13-projects-tab-management.spec.ts' },
+  { id: 'TC-IAM-WS-14', domain: 'iam', feature: 'WS', title: '테이블 정렬·다중선택', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-14-table-sort-and-multi-select.spec.ts' },
+  { id: 'TC-IAM-WS-15', domain: 'iam', feature: 'WS', title: '워크스페이스 역할 배정 (신규 API·UI)', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/iam/TC-IAM-WORKSPACE-15-assign-workspace-role-via-new-api-ui.spec.ts' },
+
+];

--- a/e2e/registry/tc/infra.registry.ts
+++ b/e2e/registry/tc/infra.registry.ts
@@ -1,0 +1,236 @@
+/**
+ * deploy/registry/tc/infra.registry.ts
+ * INFRA 도메인 TC 전체 목록
+ *
+ * Feature 코드:
+ *   DEPLOY       — MCI 배포·조회 (TC-INFRA-DEPLOY-XX, Excel 기준)
+ *   MCI-LC       — MCI 라이프사이클·삭제 (TC-INFRA-LC-XX)
+ *   SSH          — SSH 키 CRUD (TC-INFRA-SSH-XX, Excel 기준)
+ *   MCI-WORKLOAD — MCI 워크로드 터미널·파일 (역할별 기능)
+ *   CSP          — CSP 자격증명 관리 (Settings > Cloud SPs > Credentials)
+ *   PMK          — PMK 조회·생성·KubeConfig·크기변경 (TC-INFRA-K8S-01, 03, 04, 05, 06)
+ *   PMK-LC       — PMK NodeGroup·클러스터 삭제 (TC-INFRA-K8S-07, 08)
+ *
+ * 엑셀 TC ID 매핑:
+ *   TC-INFRA-DEPLOY-01 ← 구 TC-INFRA-MCI-01 (MCI 목록 조회)
+ *   TC-INFRA-DEPLOY-02 ← 구 TC-INFRA-MCI-02 (MCI 단건 조회)
+ *   TC-INFRA-DEPLOY-05 ← 구 TC-INFRA-MCI-03 (MCI 생성 Express, Excel DEPLOY-05)
+ *   TC-INFRA-DEPLOY-06 — MCI 생성 Expert 모드
+ *   TC-INFRA-LC-01     ← 구 TC-INFRA-MCI-04 (MCI 라이프사이클)
+ *   TC-INFRA-LC-02     ← 구 TC-INFRA-MCI-05 (MCI 삭제)
+ *   TC-INFRA-SSH-01~03 ← 구 TC-INFRA-SSH-KEY-01~03
+ *
+ * CSP variant:
+ *   TC-INFRA-DEPLOY-05/06 는 CSP별로 다른 param을 사용한다.
+ *   deploy/params/base/tc/infra/TC-INFRA-DEPLOY-05.params.ts 의
+ *   variants.{aws|azure|gcp|ali|ibm|nhn|tencent} 참조.
+ */
+import type { TCEntry } from '../types';
+
+export const INFRA_TC_REGISTRY: TCEntry[] = [
+
+  // ── DEPLOY (4) — MCI 목록/단건 조회 + MCI 생성(Express·Expert) ─────────
+  {
+    id: 'TC-INFRA-DEPLOY-01',
+    domain: 'infra', feature: 'DEPLOY',
+    title: 'MCI 목록 조회',
+    status: 'ready', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/infra/TC-INFRA-MCI-01-list-mci.spec.ts',
+  },
+  {
+    id: 'TC-INFRA-DEPLOY-02',
+    domain: 'infra', feature: 'DEPLOY',
+    title: 'MCI 단건 조회',
+    status: 'ready', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/infra/TC-INFRA-MCI-02-get-mci.spec.ts',
+  },
+  {
+    id: 'TC-INFRA-DEPLOY-05',
+    domain: 'infra', feature: 'DEPLOY',
+    title: 'MCI 생성',
+    status: 'ready', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/infra/TC-INFRA-MCI-03-create-mci.spec.ts',
+    tags: ['csp-variant'],
+    // CSP variant: TC_VARIANT=aws|azure|gcp|ali|ibm|nhn|tencent 로 실행
+  },
+  {
+    id: 'TC-INFRA-DEPLOY-06',
+    domain: 'infra', feature: 'DEPLOY',
+    title: 'MCI 생성 Expert 모드 — 오류 상태 확인',
+    status: 'ready', channel: 'ui',
+    specFile: 'deploy/tc/infra/TC-INFRA-DEPLOY-06.spec.ts',
+    tags: ['mode:expert', 'error-verification'],
+    // Expert 모드 선택 시 오류가 발생하는지 확인하는 회귀 테스트
+  },
+  {
+    id: 'TC-INFRA-DEPLOY-07',
+    domain: 'infra', feature: 'DEPLOY',
+    title: 'MCI 서버 추가 (Add Server — Expert 모드)',
+    status: 'ready', channel: 'ui',
+    specFile: 'deploy/tc/infra/TC-INFRA-DEPLOY-07.spec.ts',
+    tags: ['csp-variant', 'mode:expert'],
+    // MCI Info > Default Tab > Add Server > Deployment Algorithm: expert > +VM
+    // IN: mciId (store 또는 p.mciName)
+  },
+
+  // ── MCI-LC (3) — MCI 라이프사이클·삭제 ──────────────────────────────────
+  {
+    id: 'TC-INFRA-LC-01',
+    domain: 'infra', feature: 'MCI-LC',
+    title: 'MCI 라이프사이클 (suspend·resume·reboot)',
+    status: 'ready', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/infra/TC-INFRA-MCI-04-mci-lifecycle.spec.ts',
+  },
+  {
+    id: 'TC-INFRA-LC-02',
+    domain: 'infra', feature: 'MCI-LC',
+    title: 'MCI 삭제',
+    status: 'ready', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/infra/TC-INFRA-MCI-05-delete-mci.spec.ts',
+  },
+  {
+    id: 'TC-INFRA-LC-03',
+    domain: 'infra', feature: 'MCI-LC',
+    title: 'MCI 일괄 삭제 (mc* 접두사 기준)',
+    status: 'ready', channel: 'ui',
+    specFile: 'deploy/tc/infra/TC-INFRA-LC-03.spec.ts',
+    tags: ['cleanup'],
+  },
+
+  // ── MCI-WORKLOAD (3) ─────────────────────────────────────────────────────
+  {
+    id: 'TC-INFRA-MCI-WORKLOAD-01',
+    domain: 'infra', feature: 'MCI-WORKLOAD',
+    title: 'MCI 워크로드 (admin) — 터미널 접속',
+    status: 'ready', channel: 'ui',
+    specFile: 'mc-web-console/specs/infra/TC-INFRA-MCI-WORKLOAD-01~02-mci-workload-admin.spec.ts',
+    tags: ['role:admin'],
+  },
+  {
+    id: 'TC-INFRA-MCI-WORKLOAD-02',
+    domain: 'infra', feature: 'MCI-WORKLOAD',
+    title: 'MCI 워크로드 (admin) — 파일 전송',
+    status: 'ready', channel: 'ui',
+    specFile: 'mc-web-console/specs/infra/TC-INFRA-MCI-WORKLOAD-01~02-mci-workload-admin.spec.ts',
+    tags: ['role:admin'],
+  },
+  {
+    id: 'TC-INFRA-MCI-WORKLOAD-03',
+    domain: 'infra', feature: 'MCI-WORKLOAD',
+    title: 'MCI 워크로드 (viewer) — 접근 제한 확인',
+    status: 'ready', channel: 'ui',
+    specFile: 'mc-web-console/specs/infra/TC-INFRA-MCI-WORKLOAD-03-mci-workload-viewer.spec.ts',
+    tags: ['role:viewer'],
+  },
+
+  // ── CSP (4) — Settings > Cloud SPs > Credentials 자격증명 관리 ─────────────
+  { id: 'TC-INFRA-CSP-01', domain: 'infra', feature: 'CSP', title: 'CSP 자격증명 목록 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/csp/TC-CSP-CREDENTIAL-01-list-credentials.spec.ts' },
+  { id: 'TC-INFRA-CSP-02', domain: 'infra', feature: 'CSP', title: 'CSP 자격증명 단건 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/csp/TC-CSP-CREDENTIAL-02-get-credential.spec.ts' },
+  {
+    id: 'TC-INFRA-CSP-03',
+    domain: 'infra', feature: 'CSP',
+    title: 'CSP 자격증명 등록',
+    status: 'ready', channel: 'api+ui',
+    // variant 'api'  : API 직접 호출 (CredentialHolder 생성)
+    // variant 'aws'~ : UI — Settings > Cloud SPs > Credentials > Register Credential
+    //                  Provider별 KV 입력 양식이 달라 CSP마다 variant 분리
+    variants: [
+      { key: 'api',       channel: 'api', specFile: 'mc-web-console/specs/csp/TC-CSP-CREDENTIAL-03-create-credential.spec.ts' },
+      { key: 'aws',       channel: 'ui',  specFile: 'deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts' },
+      { key: 'gcp',       channel: 'ui',  specFile: 'deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts' },
+      { key: 'azure',     channel: 'ui',  specFile: 'deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts' },
+      { key: 'alibaba',   channel: 'ui',  specFile: 'deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts' },
+      { key: 'ibm',       channel: 'ui',  specFile: 'deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts' },
+      { key: 'ncp',       channel: 'ui',  specFile: 'deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts' },
+      { key: 'nhn',       channel: 'ui',  specFile: 'deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts' },
+      { key: 'kt',        channel: 'ui',  specFile: 'deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts' },
+      { key: 'openstack', channel: 'ui',  specFile: 'deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts' },
+      { key: 'tencent',   channel: 'ui',  specFile: 'deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts' },
+    ],
+  },
+  { id: 'TC-INFRA-CSP-04', domain: 'infra', feature: 'CSP', title: 'CSP 자격증명 삭제', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/csp/TC-CSP-CREDENTIAL-04-delete-credential.spec.ts' },
+
+  // ── PMK (5) — PMK 조회·생성·KubeConfig·NodeGroup 크기 변경 ─────────────────
+  {
+    id: 'TC-INFRA-K8S-01',
+    domain: 'infra', feature: 'PMK',
+    title: 'K8s 클러스터·NodeGroup 목록/상세 조회',
+    status: 'ready', channel: 'ui',
+    specFile: 'deploy/tc/infra/TC-INFRA-K8S-01.spec.ts',
+    tags: ['csp-variant'],
+  },
+  {
+    id: 'TC-INFRA-K8S-06',
+    domain: 'infra', feature: 'PMK',
+    title: 'K8s NodeGroup 크기 변경',
+    status: 'ready', channel: 'ui',
+    specFile: 'deploy/tc/infra/TC-INFRA-K8S-06.spec.ts',
+    tags: ['csp-variant'],
+  },
+  {
+    id: 'TC-INFRA-K8S-03',
+    domain: 'infra', feature: 'PMK',
+    title: 'PMK 클러스터 생성 (Dynamic 모드)',
+    status: 'ready', channel: 'ui',
+    specFile: 'deploy/tc/infra/TC-INFRA-K8S-03.spec.ts',
+    tags: ['csp-variant'],
+  },
+  {
+    id: 'TC-INFRA-K8S-04',
+    domain: 'infra', feature: 'PMK',
+    title: 'PMK 클러스터 생성 (Expert 모드)',
+    status: 'ready', channel: 'ui',
+    specFile: 'deploy/tc/infra/TC-INFRA-K8S-04.spec.ts',
+    tags: ['csp-variant', 'mode:expert'],
+  },
+  {
+    id: 'TC-INFRA-K8S-05',
+    domain: 'infra', feature: 'PMK',
+    title: 'PMK KubeConfig 획득',
+    status: 'ready', channel: 'ui',
+    specFile: 'deploy/tc/infra/TC-INFRA-K8S-05.spec.ts',
+    tags: ['csp-variant'],
+  },
+
+  // ── PMK-LC (2) — PMK NodeGroup·클러스터 삭제 ─────────────────────────────
+  {
+    id: 'TC-INFRA-K8S-07',
+    domain: 'infra', feature: 'PMK-LC',
+    title: 'PMK NodeGroup 삭제',
+    status: 'ready', channel: 'ui',
+    specFile: 'deploy/tc/infra/TC-INFRA-K8S-07.spec.ts',
+    tags: ['csp-variant'],
+    // minNodeGroupRequired=true 인 CSP는 이 TC를 건너뛰고 K8S-08에서 일괄 삭제
+  },
+  {
+    id: 'TC-INFRA-K8S-08',
+    domain: 'infra', feature: 'PMK-LC',
+    title: 'PMK 클러스터 삭제',
+    status: 'ready', channel: 'ui',
+    specFile: 'deploy/tc/infra/TC-INFRA-K8S-08.spec.ts',
+    tags: ['csp-variant'],
+  },
+
+  // ── SSH (3) ──────────────────────────────────────────────────────────────
+  {
+    id: 'TC-INFRA-SSH-01',
+    domain: 'infra', feature: 'SSH',
+    title: 'SSH 키 목록 조회',
+    status: 'ready', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/infra/TC-INFRA-SSH-KEY-01-list-ssh-keys.spec.ts',
+  },
+  {
+    id: 'TC-INFRA-SSH-02',
+    domain: 'infra', feature: 'SSH',
+    title: 'SSH 키 생성',
+    status: 'ready', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/infra/TC-INFRA-SSH-KEY-02-create-ssh-key.spec.ts',
+  },
+  {
+    id: 'TC-INFRA-SSH-03',
+    domain: 'infra', feature: 'SSH',
+    title: 'SSH 키 삭제',
+    status: 'ready', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/infra/TC-INFRA-SSH-KEY-03-delete-ssh-key.spec.ts',
+  },
+];

--- a/e2e/registry/tc/obs.registry.ts
+++ b/e2e/registry/tc/obs.registry.ts
@@ -1,0 +1,54 @@
+/**
+ * deploy/registry/tc/obs.registry.ts
+ * OBS(Observability) 도메인 TC 전체 목록
+ *
+ * Feature 코드:
+ *   AGENT   — Node 조회·에이전트 설치·상태폴링·플러그인·제거 (C6-01)
+ *   METRIC  — 시계열/CSP/K8s/오버뷰 메트릭 조회 (C6-02)
+ *   INSIGHT — Anomaly Detection·History·Prediction·LLM 분석 (C6-03)
+ *   LOG     — 라벨 조회·LogQL 키워드 검색 (C6-04)
+ *   TRACE   — Trace 검색·상세·iframe 임베드 (C6-05)
+ *   TRIG    — Trigger Policy 생성/목록/삭제·타겟연결·채널·히스토리·수정 (C6-06)
+ *   IFRAME  — 콘솔 iframe 임베드 (C6-07)
+ */
+import type { TCEntry } from '../types';
+
+export const OBS_TC_REGISTRY: TCEntry[] = [
+  // ── C6-01: Agent 관리 ──────────────────────────────────────────────────────
+  { id: 'TC-OBS-AGENT-01', domain: 'obs', feature: 'AGENT', title: '모니터링 등록 가능 Node 조회(Config)', status: 'ready',  channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-AGENT-01-list-agent-nodes.spec.ts' },
+  { id: 'TC-OBS-AGENT-02', domain: 'obs', feature: 'AGENT', title: '모니터링 에이전트 설치',               status: 'ready',  channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-MON-CONFIG-02-install-monitoring-agent.spec.ts' },
+  { id: 'TC-OBS-AGENT-03', domain: 'obs', feature: 'AGENT', title: 'Agent 설치 상태 폴링',                status: 'todo',   channel: 'api',    specFile: 'mc-web-console/specs/obs/TC-OBS-AGENT-03-agent-status-poll.spec.ts' },
+  { id: 'TC-OBS-AGENT-04', domain: 'obs', feature: 'AGENT', title: '모니터링 플러그인(item) 등록',         status: 'todo',   channel: 'api',    specFile: 'mc-web-console/specs/obs/TC-OBS-AGENT-04-register-plugin.spec.ts' },
+  { id: 'TC-OBS-AGENT-05', domain: 'obs', feature: 'AGENT', title: 'Agent 제거',                         status: 'todo',   channel: 'api',    specFile: 'mc-web-console/specs/obs/TC-OBS-AGENT-05-delete-agent.spec.ts' },
+
+  // ── C6-02: Metric 조회 ─────────────────────────────────────────────────────
+  { id: 'TC-OBS-METRIC-01', domain: 'obs', feature: 'METRIC', title: 'Agent 시계열 메트릭(InfluxDB)',  status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-METRIC-01-agent-timeseries.spec.ts' },
+  { id: 'TC-OBS-METRIC-02', domain: 'obs', feature: 'METRIC', title: 'CSP API 메트릭(cb-spider)',     status: 'todo',  channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-METRIC-02-csp-api-metrics.spec.ts' },
+  { id: 'TC-OBS-METRIC-03', domain: 'obs', feature: 'METRIC', title: 'K8s Cluster 노드 메트릭',       status: 'todo',  channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-METRIC-03-k8s-node-metrics.spec.ts' },
+  { id: 'TC-OBS-METRIC-04', domain: 'obs', feature: 'METRIC', title: 'Infra / NS 레벨 오버뷰',        status: 'todo',  channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-METRIC-04-infra-ns-overview.spec.ts' },
+
+  // ── C6-03: Insight 분석 ────────────────────────────────────────────────────
+  { id: 'TC-OBS-INSIGHT-01', domain: 'obs', feature: 'INSIGHT', title: 'Anomaly Detection 설정',      status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-INSIGHT-01-anomaly-detection-config.spec.ts' },
+  { id: 'TC-OBS-INSIGHT-02', domain: 'obs', feature: 'INSIGHT', title: 'Anomaly History 조회',        status: 'todo',  channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-INSIGHT-02-anomaly-history.spec.ts' },
+  { id: 'TC-OBS-INSIGHT-03', domain: 'obs', feature: 'INSIGHT', title: 'Prediction(예측)',            status: 'todo',  channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-INSIGHT-03-prediction.spec.ts' },
+  { id: 'TC-OBS-INSIGHT-04', domain: 'obs', feature: 'INSIGHT', title: 'Server Error Analysis(LLM)', status: 'todo',  channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-INSIGHT-04-server-error-analysis.spec.ts' },
+
+  // ── C6-04: Log 조회 ────────────────────────────────────────────────────────
+  { id: 'TC-OBS-LOG-01', domain: 'obs', feature: 'LOG', title: '라벨 조회',          status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-LOG-01-list-logs.spec.ts' },
+  { id: 'TC-OBS-LOG-02', domain: 'obs', feature: 'LOG', title: '키워드 검색(LogQL)', status: 'todo',  channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-LOG-02-logql-search.spec.ts' },
+
+  // ── C6-05: Trace 조회 ──────────────────────────────────────────────────────
+  { id: 'TC-OBS-TRACE-01', domain: 'obs', feature: 'TRACE', title: 'Trace 검색(Tempo)',          status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-TRACE-01-list-traces.spec.ts' },
+  { id: 'TC-OBS-TRACE-02', domain: 'obs', feature: 'TRACE', title: 'Trace 상세 / Call Sequence', status: 'todo',  channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-TRACE-02-trace-detail.spec.ts' },
+  { id: 'TC-OBS-TRACE-03', domain: 'obs', feature: 'TRACE', title: 'Trace iframe 임베드',        status: 'todo',  channel: 'ui',     specFile: 'mc-web-console/specs/obs/TC-OBS-TRACE-03-trace-iframe.spec.ts' },
+
+  // ── C6-06: Trigger 관리 ────────────────────────────────────────────────────
+  { id: 'TC-OBS-TRIG-01', domain: 'obs', feature: 'TRIG', title: 'Trigger Policy 생성/목록/삭제',   status: 'todo', channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-TRIG-01-trigger-policy-crud.spec.ts' },
+  { id: 'TC-OBS-TRIG-02', domain: 'obs', feature: 'TRIG', title: '정책 ↔ Node/Infra 타겟 연결',    status: 'todo', channel: 'api',    specFile: 'mc-web-console/specs/obs/TC-OBS-TRIG-02-policy-target-link.spec.ts' },
+  { id: 'TC-OBS-TRIG-03', domain: 'obs', feature: 'TRIG', title: '알림 채널 설정',                 status: 'todo', channel: 'api',    specFile: 'mc-web-console/specs/obs/TC-OBS-TRIG-03-notify-channel.spec.ts' },
+  { id: 'TC-OBS-TRIG-04', domain: 'obs', feature: 'TRIG', title: 'Trigger / Notification History', status: 'todo', channel: 'api+ui', specFile: 'mc-web-console/specs/obs/TC-OBS-TRIG-04-trigger-history.spec.ts' },
+  { id: 'TC-OBS-TRIG-05', domain: 'obs', feature: 'TRIG', title: '정책 수정(임계값 등)',            status: 'todo', channel: 'api',    specFile: 'mc-web-console/specs/obs/TC-OBS-TRIG-05-policy-update.spec.ts' },
+
+  // ── C6-07: iframe 임베드 ───────────────────────────────────────────────────
+  { id: 'TC-OBS-IFRAME-01', domain: 'obs', feature: 'IFRAME', title: '콘솔 iframe 진입(임베드)', status: 'todo', channel: 'ui', specFile: 'mc-web-console/specs/obs/TC-OBS-IFRAME-01-console-iframe.spec.ts' },
+];

--- a/e2e/registry/tc/sw.registry.ts
+++ b/e2e/registry/tc/sw.registry.ts
@@ -1,0 +1,116 @@
+/**
+ * deploy/registry/tc/sw.registry.ts
+ * SW(Application) 도메인 TC 전체 목록 (25개 엔트리)
+ *
+ * 주의: TC 이름은 APP-* 이지만 폴더는 mc-web-console/specs/sw/ 이다.
+ *
+ * Feature 코드:
+ *   APP-APPS     — 배포된 앱 목록·상세·운영 액션
+ *   APP-CAT      — App Catalog CRUD
+ *   APP-DEP      — 애플리케이션 배포 (아키텍처별 variant)
+ *   APP-REP      — 레포지토리 CRUD (format별 variant: api / ui:helm / ui:docker)
+ *   SW-CATALOG   — SW Catalog 목록·배포·제거
+ *
+ * Variant 규칙:
+ *   TC-APP-REP-02 — 같은 기능(레포 생성)을 채널·포맷별로 3개 파일로 나눔
+ *     api      → TC-APP-REP-02-repository-신규-생성-api.spec.ts
+ *     ui:helm  → TC-APP-REP-02-repository-신규-생성-ui-helm.spec.ts
+ *     ui:docker→ TC-APP-REP-02-repository-신규-생성-ui-docker.spec.ts
+ *
+ *   TC-APP-DEP-* — 아키텍처별 파일 분리
+ *     standalone → TC-APP-DEP-01-vm-standalone.spec.ts
+ *     clustering → TC-APP-DEP-02-vm-clustering.spec.ts
+ *     k8s        → TC-APP-DEP-03-k8s-helm.spec.ts
+ */
+import type { TCEntry } from '../types';
+
+export const SW_TC_REGISTRY: TCEntry[] = [
+
+  // ── APP-APPS (4) ─────────────────────────────────────────────────────────
+  { id: 'TC-APP-APPS-01', domain: 'sw', feature: 'APP-APPS', title: '배포 상태 목록 갱신·Refresh', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/sw/TC-APP-APPS-01-배포-상태-목록-갱신-refresh.spec.ts' },
+  { id: 'TC-APP-APPS-02', domain: 'sw', feature: 'APP-APPS', title: '배포 상세 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/sw/TC-APP-APPS-02-배포-상세-조회.spec.ts' },
+  { id: 'TC-APP-APPS-03', domain: 'sw', feature: 'APP-APPS', title: '운영 액션 (restart·stop·uninstall)', status: 'wip', channel: 'api+ui', specFile: 'mc-web-console/specs/sw/TC-APP-APPS-03-운영-액션-restart-stop-uninstall.spec.ts' },
+  { id: 'TC-APP-APPS-04', domain: 'sw', feature: 'APP-APPS', title: '평점 제출', status: 'wip', channel: 'ui', specFile: 'mc-web-console/specs/sw/TC-APP-APPS-04-rating-제출.spec.ts' },
+
+  // ── APP-CAT (7) ──────────────────────────────────────────────────────────
+  { id: 'TC-APP-CAT-01', domain: 'sw', feature: 'APP-CAT', title: '빌트인 Catalog 목록 표시', status: 'wip', channel: 'api+ui', specFile: 'mc-web-console/specs/sw/TC-APP-CAT-01-빌트인-catalog-목록-표시.spec.ts' },
+  { id: 'TC-APP-CAT-02', domain: 'sw', feature: 'APP-CAT', title: 'Catalog 상세 펼침·접힘', status: 'wip', channel: 'ui', specFile: 'mc-web-console/specs/sw/TC-APP-CAT-02-catalog-상세-펼침-접힘.spec.ts' },
+  { id: 'TC-APP-CAT-03', domain: 'sw', feature: 'APP-CAT', title: '외부 검색 결과 표시', status: 'wip', channel: 'api+ui', specFile: 'mc-web-console/specs/sw/TC-APP-CAT-03-외부-검색-결과-표시.spec.ts' },
+  { id: 'TC-APP-CAT-04', domain: 'sw', feature: 'APP-CAT', title: '외부 검색 결과 업로드', status: 'wip', channel: 'api+ui', specFile: 'mc-web-console/specs/sw/TC-APP-CAT-04-외부-검색-결과-업로드.spec.ts' },
+  { id: 'TC-APP-CAT-05', domain: 'sw', feature: 'APP-CAT', title: 'Catalog 신규 등록', status: 'wip', channel: 'api+ui', specFile: 'mc-web-console/specs/sw/TC-APP-CAT-05-catalog-신규-등록.spec.ts' },
+  { id: 'TC-APP-CAT-06', domain: 'sw', feature: 'APP-CAT', title: 'Catalog 수정', status: 'wip', channel: 'api+ui', specFile: 'mc-web-console/specs/sw/TC-APP-CAT-06-catalog-수정.spec.ts' },
+  { id: 'TC-APP-CAT-07', domain: 'sw', feature: 'APP-CAT', title: 'Catalog 삭제', status: 'wip', channel: 'api+ui', specFile: 'mc-web-console/specs/sw/TC-APP-CAT-07-catalog-삭제.spec.ts' },
+
+  // ── APP-DEP (3 — 아키텍처별 variant) ────────────────────────────────────
+  {
+    id: 'TC-APP-DEP-01',
+    domain: 'sw', feature: 'APP-DEP',
+    title: 'VM Standalone 배포',
+    status: 'ready', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/sw/TC-APP-DEP-01-vm-standalone.spec.ts',
+    tags: ['arch:standalone'],
+  },
+  {
+    id: 'TC-APP-DEP-02',
+    domain: 'sw', feature: 'APP-DEP',
+    title: 'VM Clustering 배포',
+    status: 'wip', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/sw/TC-APP-DEP-02-vm-clustering.spec.ts',
+    tags: ['arch:clustering'],
+  },
+  {
+    id: 'TC-APP-DEP-03',
+    domain: 'sw', feature: 'APP-DEP',
+    title: 'K8s Helm 배포',
+    status: 'wip', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/sw/TC-APP-DEP-03-k8s-helm.spec.ts',
+    tags: ['arch:k8s'],
+  },
+
+  // ── APP-REP (8 엔트리 — 01·03·04·05 단일 / 02는 3-variant) ─────────────
+  {
+    id: 'TC-APP-REP-01',
+    domain: 'sw', feature: 'APP-REP',
+    title: 'Repository 목록 조회',
+    status: 'wip', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/sw/TC-APP-REP-01-repository-목록-조회.spec.ts',
+  },
+  {
+    id: 'TC-APP-REP-02',
+    domain: 'sw', feature: 'APP-REP',
+    title: 'Repository 신규 생성',
+    status: 'wip', channel: 'api+ui',
+    // variant 파일 3개 — specFile 대신 variants 사용
+    variants: [
+      { key: 'api',       channel: 'api', specFile: 'mc-web-console/specs/sw/TC-APP-REP-02-repository-신규-생성-api.spec.ts' },
+      { key: 'ui:helm',   channel: 'ui',  specFile: 'mc-web-console/specs/sw/TC-APP-REP-02-repository-신규-생성-ui-helm.spec.ts' },
+      { key: 'ui:docker', channel: 'ui',  specFile: 'mc-web-console/specs/sw/TC-APP-REP-02-repository-신규-생성-ui-docker.spec.ts' },
+    ],
+  },
+  {
+    id: 'TC-APP-REP-03',
+    domain: 'sw', feature: 'APP-REP',
+    title: 'Repository 상세 진입',
+    status: 'wip', channel: 'ui',
+    specFile: 'mc-web-console/specs/sw/TC-APP-REP-03-repository-상세-진입.spec.ts',
+  },
+  {
+    id: 'TC-APP-REP-04',
+    domain: 'sw', feature: 'APP-REP',
+    title: 'Repository 컴포넌트 삭제',
+    status: 'wip', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/sw/TC-APP-REP-04-repository-컴포넌트-삭제.spec.ts',
+  },
+  {
+    id: 'TC-APP-REP-05',
+    domain: 'sw', feature: 'APP-REP',
+    title: 'Repository 삭제',
+    status: 'wip', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/sw/TC-APP-REP-05-repository-삭제.spec.ts',
+  },
+
+  // ── SW-CATALOG (3) ───────────────────────────────────────────────────────
+  { id: 'TC-SW-CATALOG-01', domain: 'sw', feature: 'SW-CATALOG', title: 'SW Catalog 목록 조회', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/sw/TC-SW-CATALOG-01-list-sw-catalog.spec.ts' },
+  { id: 'TC-SW-CATALOG-02', domain: 'sw', feature: 'SW-CATALOG', title: 'SW 배포', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/sw/TC-SW-CATALOG-02-deploy-sw.spec.ts' },
+  { id: 'TC-SW-CATALOG-03', domain: 'sw', feature: 'SW-CATALOG', title: 'SW 제거 (undeploy)', status: 'ready', channel: 'api+ui', specFile: 'mc-web-console/specs/sw/TC-SW-CATALOG-03-undeploy-sw.spec.ts' },
+];

--- a/e2e/registry/tc/workflow.registry.ts
+++ b/e2e/registry/tc/workflow.registry.ts
@@ -1,0 +1,123 @@
+/**
+ * deploy/registry/tc/workflow.registry.ts
+ * WORKFLOW 도메인 TC 전체 목록 (14개)
+ *
+ * Feature 코드:
+ *   WF-FLOW  — 워크플로우 Engine 연동·목록·생성·수정·실행·삭제·로그
+ *   WF-EL    — 이벤트 리스너 목록·생성·중복검사·수정·삭제·GET/POST 트리거
+ *
+ * 엑셀 TC ID 매핑 (Excel mc-workflow-manager 기준):
+ *   TC-WF-FLOW-01 ← Workflow Engine(Jenkins) 등록·연동 확인
+ *   TC-WF-FLOW-02 ← 구 TC-WORKFLOW-01 (목록 조회)
+ *   TC-WF-FLOW-03 ← 구 TC-WORKFLOW-02 (API 생성) + 구 TC-WF-FLOW-02 (UI 생성 A)
+ *   TC-WF-FLOW-04 ← Workflow 상세 수정
+ *   TC-WF-FLOW-05 ← 구 TC-WORKFLOW-04 (삭제)
+ *   TC-WF-FLOW-06 ← 구 TC-WORKFLOW-03 (실행 — 콘솔 RUN 버튼)
+ *   TC-WF-FLOW-07 ← Workflow 로그 모달 표시
+ *   TC-WF-EL-01   ← 구 TC-WORKFLOW-EL-01 (Event Listener 목록)
+ *   TC-WF-EL-02   ← 구 TC-WORKFLOW-EL-02 (Event Listener 생성·워크플로우 연결)
+ *   TC-WF-EL-03   ← Event Listener 이름 중복 검사
+ *   TC-WF-EL-04   ← Event Listener 상세 수정
+ *   TC-WF-EL-05   ← Event Listener 삭제
+ *   TC-WF-EL-06   ← 구 TC-WORKFLOW-EL-05 (GET Trigger URL로 워크플로우 실행)
+ *   TC-WF-EL-07   ← 구 TC-WORKFLOW-EL-06 (POST Trigger URL로 워크플로우 실행)
+ */
+import type { TCEntry } from '../types';
+
+export const WORKFLOW_TC_REGISTRY: TCEntry[] = [
+
+  // ── WF-FLOW ──────────────────────────────────────────────────────────────
+  {
+    id: 'TC-WF-FLOW-01',
+    domain: 'workflow', feature: 'WF-FLOW',
+    title: 'Workflow Engine(Jenkins) 등록 및 연동 확인',
+    status: 'ready', channel: 'ui',
+  },
+  {
+    id: 'TC-WF-FLOW-02',
+    domain: 'workflow', feature: 'WF-FLOW',
+    title: 'Workflow 목록 조회',
+    status: 'ready', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/workflow/TC-WORKFLOW-01-list-workflows.spec.ts',
+  },
+  {
+    id: 'TC-WF-FLOW-03',
+    domain: 'workflow', feature: 'WF-FLOW',
+    title: '신규 Workflow 생성 (정의)',
+    status: 'ready', channel: 'api+ui',
+    variants: [
+      { key: 'api', channel: 'api', specFile: 'mc-web-console/specs/workflow/TC-WORKFLOW-02-create-workflow.spec.ts' },
+      { key: 'ui',  channel: 'ui',  specFile: 'mc-web-console/specs/workflow/TC-WF-FLOW-02-신규-workflow-생성-a-인프라-배포-sw-설치.spec.ts' },
+    ],
+  },
+  {
+    id: 'TC-WF-FLOW-04',
+    domain: 'workflow', feature: 'WF-FLOW',
+    title: 'Workflow 상세 수정',
+    status: 'ready', channel: 'ui',
+  },
+  {
+    id: 'TC-WF-FLOW-05',
+    domain: 'workflow', feature: 'WF-FLOW',
+    title: 'Workflow 삭제',
+    status: 'ready', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/workflow/TC-WORKFLOW-04-delete-workflow.spec.ts',
+  },
+  {
+    id: 'TC-WF-FLOW-06',
+    domain: 'workflow', feature: 'WF-FLOW',
+    title: 'Workflow 실행 (RUN) — 콘솔 RUN 버튼',
+    status: 'ready', channel: 'api+ui',
+    specFile: 'mc-web-console/specs/workflow/TC-WORKFLOW-03-run-workflow.spec.ts',
+  },
+  {
+    id: 'TC-WF-FLOW-07',
+    domain: 'workflow', feature: 'WF-FLOW',
+    title: 'Workflow 로그 모달 표시',
+    status: 'ready', channel: 'ui',
+  },
+
+  // ── WF-EL (Event Listener) ────────────────────────────────────────────────
+  {
+    id: 'TC-WF-EL-01',
+    domain: 'workflow', feature: 'WF-EL',
+    title: 'Event Listener 목록 조회',
+    status: 'ready', channel: 'ui',
+  },
+  {
+    id: 'TC-WF-EL-02',
+    domain: 'workflow', feature: 'WF-EL',
+    title: '신규 Event Listener 생성',
+    status: 'ready', channel: 'ui',
+  },
+  {
+    id: 'TC-WF-EL-03',
+    domain: 'workflow', feature: 'WF-EL',
+    title: 'Event Listener 이름 중복 검사',
+    status: 'ready', channel: 'ui',
+  },
+  {
+    id: 'TC-WF-EL-04',
+    domain: 'workflow', feature: 'WF-EL',
+    title: 'Event Listener 상세 수정',
+    status: 'ready', channel: 'ui',
+  },
+  {
+    id: 'TC-WF-EL-05',
+    domain: 'workflow', feature: 'WF-EL',
+    title: 'Event Listener 삭제',
+    status: 'ready', channel: 'ui',
+  },
+  {
+    id: 'TC-WF-EL-06',
+    domain: 'workflow', feature: 'WF-EL',
+    title: 'Event Listener를 통한 Workflow 실행 (GET)',
+    status: 'ready', channel: 'ui',
+  },
+  {
+    id: 'TC-WF-EL-07',
+    domain: 'workflow', feature: 'WF-EL',
+    title: 'Event Listener를 통한 Workflow 실행 (POST)',
+    status: 'ready', channel: 'ui',
+  },
+];

--- a/e2e/registry/tc/workload.registry.ts
+++ b/e2e/registry/tc/workload.registry.ts
@@ -1,0 +1,17 @@
+/**
+ * deploy/registry/tc/workload.registry.ts
+ * WORKLOAD 도메인 TC 전체 목록 (3개)
+ *
+ * Feature 코드:
+ *   INFRA-K8S    — PMK K8s KubeConfig 관련
+ *   WORKLOAD-MCI — MCI 터미널·파일 전송
+ *
+ * 주의: TC 이름은 INFRA-K8S / WORKLOAD-MCI 이지만 폴더는 mc-web-console/specs/workload/ 이다.
+ */
+import type { TCEntry } from '../types';
+
+export const WORKLOAD_TC_REGISTRY: TCEntry[] = [
+  { id: 'TC-INFRA-K8S-07',      domain: 'workload', feature: 'INFRA-K8S',    title: 'PMK KubeConfig 클립보드 복사', status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/workload/TC-INFRA-K8S-07-pmk-kubeconfig-copy.spec.ts' },
+  { id: 'TC-WORKLOAD-MCI-01',   domain: 'workload', feature: 'WORKLOAD-MCI', title: 'MCI 터미널 접속·명령 실행',    status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/workload/TC-WORKLOAD-MCI-01-mci-terminal.spec.ts' },
+  { id: 'TC-WORKLOAD-MCI-02',   domain: 'workload', feature: 'WORKLOAD-MCI', title: 'MCI 파일 전송',                status: 'ready', channel: 'ui', specFile: 'mc-web-console/specs/workload/TC-WORKLOAD-MCI-02-mci-file-transfer.spec.ts' },
+];

--- a/e2e/registry/types.ts
+++ b/e2e/registry/types.ts
@@ -1,0 +1,128 @@
+/**
+ * deploy/registry/types.ts
+ *
+ * TC 레지스트리 및 시나리오 레지스트리에서 사용하는 공통 타입 정의.
+ *
+ * 사용처:
+ *   - deploy/registry/tc/*.registry.ts   — 도메인별 TC 목록
+ *   - deploy/registry/scenario/          — 시나리오 목록
+ *   - deploy/registry/index.ts           — 전체 조회 유틸
+ */
+
+// ── TC 상태 ─────────────────────────────────────────────────────────────────
+/** ready    : 구현 완료, 실행 가능
+ *  wip      : 작업 중 (구현 진행 중) — 실행 시 FAIL
+ *  todo     : 구현 예정 (spec 파일 없음) — 실행 시 FAIL
+ *  deprecated: 더 이상 사용하지 않음
+ */
+export type TCStatus = 'ready' | 'wip' | 'todo' | 'deprecated';
+
+// ── TC 채널 ─────────────────────────────────────────────────────────────────
+/** api    : API(request) 테스트만
+ *  ui     : 브라우저(page) 테스트만
+ *  api+ui : 같은 TC 파일에 API + UI 테스트 모두 포함
+ */
+export type TCChannel = 'api' | 'ui' | 'api+ui';
+
+// ── Variant ─────────────────────────────────────────────────────────────────
+export type VariantKey = string;
+
+/** 같은 TC ID이지만 variant별로 spec 파일이 다른 경우 */
+export interface TCVariantFile {
+  key: VariantKey;      // 'helm' | 'docker' | 'aws' | 'ui' | 'api' …
+  specFile: string;     // repo root 기준 상대 경로
+  channel?: TCChannel;  // variant마다 채널이 다를 경우 override
+}
+
+// ── TC 엔트리 ────────────────────────────────────────────────────────────────
+export interface TCEntry {
+  /** TC 식별자 — 파일명의 TC-{DOMAIN}-{FEATURE}-{NN} 부분 */
+  id: string;
+  /** 도메인 폴더명 (iam, infra, sw, data, obs, csp, cost, workflow, workload) */
+  domain: string;
+  /** 기능 코드 (AUTH, MCI, APP-REP …) */
+  feature: string;
+  /** 한 줄 설명 */
+  title: string;
+  /** 구현 상태 */
+  status: TCStatus;
+  /** 테스트 채널 */
+  channel: TCChannel;
+  /**
+   * variant 없는 TC — 단일 spec 파일 경로
+   * variants 있는 TC — 이 필드 대신 variants[] 사용
+   */
+  specFile?: string;
+  /**
+   * 같은 TC ID가 여러 variant 파일로 나뉜 경우
+   * 예: TC-APP-REP-02 → api / ui:helm / ui:docker
+   */
+  variants?: TCVariantFile[];
+  /** wip/todo 이유 및 이슈 트래커 번호 */
+  note?: {
+    reason: string;
+    issue?: string;   // 예: 'ISSUE-009'
+  };
+  /** 검색·필터용 태그 (선택) */
+  tags?: string[];
+}
+
+// ── 시나리오 상태 ────────────────────────────────────────────────────────────
+/** ready   : 전체 스텝 실행 가능
+ *  partial : 일부 스텝만 ready (나머지 wip/todo — 실행 시 FAIL)
+ *  wip     : 작업 중
+ *  todo    : 구현 예정
+ *  deprecated: 더 이상 사용하지 않음
+ */
+export type ScenarioStatus = 'ready' | 'partial' | 'wip' | 'todo' | 'deprecated';
+
+// ── 시나리오 스텝 ────────────────────────────────────────────────────────────
+export interface ScenarioStep {
+  /** 실행 순서 (1부터 시작) */
+  order: number;
+  /** 호출할 TC ID */
+  tcId: string;
+  /** TC의 어떤 variant를 사용할지 (미지정 = base) */
+  variant?: VariantKey;
+  /** 이 스텝에서 실행할 채널 (미지정 = TC 기본값) */
+  channel?: TCChannel;
+  /** 스텝 구현 상태 */
+  status: TCStatus;
+  /** 사람이 읽을 수 있는 스텝 설명 */
+  description: string;
+  /** wip/todo 이유 */
+  note?: {
+    reason: string;
+    issue?: string;
+  };
+  /** 이 스텝이 RuntimeStore에 저장하는 key 목록 (문서화·검증용) */
+  outputParams?: string[];
+}
+
+// ── 시나리오 엔트리 ──────────────────────────────────────────────────────────
+export interface ScenarioEntry {
+  /** 시나리오 식별자 — 예: 'C4-service-create-infra' */
+  id: string;
+  /** 시나리오 코드 분류 — 예: 'C2', 'C4', 'WF' */
+  code: string;
+  /** 한 줄 제목 */
+  title: string;
+  /** 시나리오 목적·범위 설명 */
+  description: string;
+  /** 전체 시나리오 상태 */
+  status: ScenarioStatus;
+  /** 이 시나리오를 수행하는 페르소나 (선택) */
+  actor?: string;
+  /** spec 파일 경로 (선택 — 없으면 TC를 직접 순서대로 호출) */
+  specFile?: string;
+  /** 순서가 있는 스텝 목록 */
+  steps: ScenarioStep[];
+  /** 시나리오 시작 시 RuntimeStore에 사전 주입할 값 (TC의 getOrDefault 기본값 override) */
+  initialStore?: Record<string, unknown>;
+  /**
+   * 시나리오 시작 전 RuntimeStore에 반드시 있어야 하는 key 목록.
+   * 없으면 beforeAll에서 즉시 FAIL (fail-fast).
+   * 이전 시나리오가 생성한 값 또는 PW_<KEY>=<값> 환경변수로 제공.
+   */
+  requiredInputs?: string[];
+}

--- a/e2e/scenarios/C10-cleanup/C10-01-wf-infra-delete.spec.ts
+++ b/e2e/scenarios/C10-cleanup/C10-01-wf-infra-delete.spec.ts
@@ -1,0 +1,21 @@
+/**
+ * deploy/scenarios/C10-cleanup/C10-01-wf-infra-delete.spec.ts
+ * [C10] 워크플로우로 인프라 삭제
+ *
+ * C4 완료 후 별도 실행 — 워크플로우를 통해 MCI 인프라를 자동으로 삭제한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-WF-FLOW-03     인프라 삭제 워크플로우 정의
+ *   Step 2. TC-WF-FLOW-06     워크플로우 실행
+ *   Step 3. TC-INFRA-DEPLOY-01    MCI 삭제 확인
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C10-cleanup/C10-01-wf-infra-delete.spec.ts \
+ *     --config deploy/playwright.config.ts --project=session-e-cleanup
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C10-01-wf-infra-delete');

--- a/e2e/scenarios/C10-cleanup/C10-02-wf-k8s-delete.spec.ts
+++ b/e2e/scenarios/C10-cleanup/C10-02-wf-k8s-delete.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * deploy/scenarios/C10-cleanup/C10-02-wf-k8s-delete.spec.ts
+ * [C10] 워크플로우로 K8s 삭제
+ *
+ * C4 완료 후 별도 실행 — K8s 생성 워크플로우와 쌍인 삭제 워크플로우를 실행하여
+ * K8s 클러스터를 자동 삭제한다.
+ *
+ * 워크플로우 쌍:
+ *   생성: k8s-mariadb-backup-import-data-init
+ *   삭제: k8s-mariadb-data-init-cleanup  ← 실행 대상
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-WF-FLOW-03              K8s 삭제 워크플로우 존재 확인
+ *   Step 2. TC-WF-FLOW-06              K8s 삭제 워크플로우 실행 (k8s-mariadb-data-init-cleanup)
+ *   Step 3. TC-INFRA-K8S-08 [tencent]  K8s 클러스터 삭제 완료 확인
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C10-cleanup/C10-02-wf-k8s-delete.spec.ts \
+ *     --config deploy/playwright.config.ts --project=session-e-cleanup
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C10-02-wf-k8s-delete');

--- a/e2e/scenarios/C10-cleanup/C10-03-mci-per-csp-delete.spec.ts
+++ b/e2e/scenarios/C10-cleanup/C10-03-mci-per-csp-delete.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * deploy/scenarios/C10-cleanup/C10-03-mci-per-csp-delete.spec.ts
+ * [C10] CSP별 MCI 삭제 (자동화)
+ *
+ * C4 완료 후 별도 실행 — C4-02-mci-per-csp 가 생성한 CSP별 MCI(mci1~mci7)를 순서대로 삭제한다.
+ * 이미 없는 MCI는 경고 후 건너뛴다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-INFRA-LC-02 [aws]       mci1 삭제
+ *   Step 2. TC-INFRA-LC-02 [azure]     mci2 삭제
+ *   Step 3. TC-INFRA-LC-02 [gcp]       mci3 삭제
+ *   Step 4. TC-INFRA-LC-02 [ali]       mci4 삭제
+ *   Step 5. TC-INFRA-LC-02 [ibm]       mci5 삭제
+ *   Step 6. TC-INFRA-LC-02 [nhn]       mci6 삭제
+ *   Step 7. TC-INFRA-LC-02 [tencent]   mci7 삭제
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C10-cleanup/C10-03-mci-per-csp-delete.spec.ts \
+ *     --config deploy/playwright.config.ts --project=session-e-cleanup
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C10-03-mci-per-csp-delete');

--- a/e2e/scenarios/C10-cleanup/C10-04-mci-multi-csp-delete.spec.ts
+++ b/e2e/scenarios/C10-cleanup/C10-04-mci-multi-csp-delete.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * deploy/scenarios/C10-cleanup/C10-04-mci-multi-csp-delete.spec.ts
+ * [C10] Multi-CSP MCI 삭제
+ *
+ * C4 완료 후 별도 실행 — C4-03-mci-multi-csp 가 생성한 단일 Multi-CSP MCI(mci-multi)를 삭제한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-INFRA-LC-02 [multi-csp]   mci-multi 삭제
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C10-cleanup/C10-04-mci-multi-csp-delete.spec.ts \
+ *     --config deploy/playwright.config.ts --project=session-e-cleanup
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C10-04-mci-multi-csp-delete');

--- a/e2e/scenarios/C10-cleanup/C10-05-mci-cleanup.spec.ts
+++ b/e2e/scenarios/C10-cleanup/C10-05-mci-cleanup.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/scenarios/C10-cleanup/C10-05-mci-cleanup.spec.ts
+ * [C10] mc* MCI 일괄 삭제 (case 분류)
+ *
+ * C4 완료 후 별도 실행 — 이름이 mc로 시작하는 모든 MCI를
+ * Total Servers 수(0/1/2+)로 case 분류하여 일괄 삭제한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-INFRA-LC-03    mc* MCI 스캔 → case1/2/3 분류 → 전체 삭제
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C10-cleanup/C10-05-mci-cleanup.spec.ts \
+ *     --config deploy/playwright.config.ts --project=session-e-cleanup
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C10-05-mci-cleanup');

--- a/e2e/scenarios/C10-cleanup/C10-06-k8s-per-csp-delete.spec.ts
+++ b/e2e/scenarios/C10-cleanup/C10-06-k8s-per-csp-delete.spec.ts
@@ -1,0 +1,21 @@
+/**
+ * deploy/scenarios/C10-cleanup/C10-06-k8s-per-csp-delete.spec.ts
+ * [C10] CSP별 K8s 클러스터(PMK) 삭제
+ *
+ * C4 완료 후 별도 실행 — C4-08-k8s-per-csp 가 생성한 K8s 클러스터를 순서대로 삭제한다.
+ * 이미 없는 클러스터는 경고 후 건너뛴다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-INFRA-K8S-08 [tencent]  pmk1 삭제
+ *   Step 2. TC-INFRA-K8S-08 [ncp]      pmk2 삭제
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C10-cleanup/C10-06-k8s-per-csp-delete.spec.ts \
+ *     --config deploy/playwright.config.ts --project=session-e-cleanup
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C10-06-k8s-per-csp-delete');

--- a/e2e/scenarios/C2-admin-setup/C2-01-onboarding-mc-iam-manager-user-create.spec.ts
+++ b/e2e/scenarios/C2-admin-setup/C2-01-onboarding-mc-iam-manager-user-create.spec.ts
@@ -1,0 +1,24 @@
+/**
+ * deploy/scenarios/C2-01-onboarding-mc-iam-manager-user-create.spec.ts
+ * [C2] IAM 온보딩 — 사용자 추가·역할·그룹 할당
+ *
+ * 신규 사용자 생성부터 역할 배정, 그룹 할당, 워크스페이스 접근 확인까지
+ * 플랫폼 관리자가 수행하는 전체 온보딩 흐름을 검증한다.
+ *
+ * actor:  플랫폼 관리자
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-IAM-UG-03    신규 사용자 생성
+ *   Step 2. TC-IAM-UG-08    그룹 생성
+ *   Step 3. TC-IAM-UG-11    그룹에 사용자 배정
+ *   Step 4. TC-IAM-RBAC-06         사용자에 플랫폼 역할 부여
+ *   Step 5. TC-IAM-WS-05    워크스페이스에 사용자 배정
+ *   Step 6. TC-IAM-AUTH-01         신규 사용자로 로그인 확인
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C2-01-onboarding-mc-iam-manager-user-create.spec.ts
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C2-01-onboarding-mc-iam-manager-user-create');

--- a/e2e/scenarios/C2-admin-setup/C2-02-onboarding-mc-iam-manager-role-assign.spec.ts
+++ b/e2e/scenarios/C2-admin-setup/C2-02-onboarding-mc-iam-manager-role-assign.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/scenarios/C2-02-onboarding-mc-iam-manager-role-assign.spec.ts
+ * [C2] 관리자 계정 생성·역할 할당·MCI 연동
+ *
+ * 관리자 사용자를 생성하고 역할을 부여한 뒤 MCI 목록에 접근 가능한지 확인한다.
+ *
+ * actor:  플랫폼 관리자
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-IAM-UG-03    관리자 사용자 생성
+ *   Step 2. TC-IAM-RBAC-06         플랫폼 역할 부여
+ *   Step 3. TC-INFRA-DEPLOY-01        MCI 목록 접근 확인
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C2-02-onboarding-mc-iam-manager-role-assign.spec.ts
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C2-02-onboarding-mc-iam-manager-role-assign');

--- a/e2e/scenarios/C2-admin-setup/C2-03-onboarding-mc-iam-manager-signup-approval.spec.ts
+++ b/e2e/scenarios/C2-admin-setup/C2-03-onboarding-mc-iam-manager-signup-approval.spec.ts
@@ -1,0 +1,21 @@
+/**
+ * deploy/scenarios/C2-03-onboarding-mc-iam-manager-signup-approval.spec.ts
+ * [C2] 가입 신청 승인 — 관리자 승인 화면 API·UI 검증
+ *
+ * 사용자가 회원가입을 신청하고 관리자가 API 또는 UI로 승인한 후
+ * 해당 사용자의 로그인이 가능해지는 흐름을 검증한다.
+ *
+ * actor:  플랫폼 관리자
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-IAM-AUTH-05              사용자 회원가입 신청
+ *   Step 2. TC-IAM-USER-LIFECYCLE-01    관리자 API 승인 후 로그인
+ *   Step 3. TC-IAM-USER-LIFECYCLE-02    관리자 UI 승인 후 로그인
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C2-03-onboarding-mc-iam-manager-signup-approval.spec.ts
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C2-03-onboarding-mc-iam-manager-signup-approval');

--- a/e2e/scenarios/C2-admin-setup/C2-04-onboarding-mc-iam-manager-workspace-mgmt.spec.ts
+++ b/e2e/scenarios/C2-admin-setup/C2-04-onboarding-mc-iam-manager-workspace-mgmt.spec.ts
@@ -1,0 +1,25 @@
+/**
+ * deploy/scenarios/C2-04-onboarding-mc-iam-manager-workspace-mgmt.spec.ts
+ * [C2] Workspace 관리 UI 전체 검증
+ *
+ * 워크스페이스 목록 조회·생성·수정·삭제, Projects 탭 관리,
+ * 대시보드 카운트 및 테이블 정렬·다중선택 UX를 검증한다.
+ *
+ * actor:  플랫폼 관리자
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-IAM-WS-01    워크스페이스 목록 조회
+ *   Step 2. TC-IAM-WS-02    워크스페이스 생성
+ *   Step 3. TC-IAM-WS-08    대시보드 카운트 확인
+ *   Step 4. TC-IAM-WS-10    추가 모달 UI 확인
+ *   Step 5. TC-IAM-WS-13    Projects 탭 관리
+ *   Step 6. TC-IAM-WS-14    테이블 정렬·다중선택
+ *   Step 7. TC-IAM-WS-04    워크스페이스 삭제
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C2-04-onboarding-mc-iam-manager-workspace-mgmt.spec.ts
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C2-04-onboarding-mc-iam-manager-workspace-mgmt');

--- a/e2e/scenarios/C3-svc-wf/C3-01-wf-define.spec.ts
+++ b/e2e/scenarios/C3-svc-wf/C3-01-wf-define.spec.ts
@@ -1,0 +1,16 @@
+/**
+ * deploy/scenarios/C3-svc-wf/C3-01-wf-define.spec.ts
+ * [C3-01] WF 등록 (서비스 생성용·삭제용)
+ *
+ * 서비스 생성 및 삭제용 Workflow를 각각 정의하고 등록한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-WF-FLOW-03 (variant:create)  서비스 생성용 Workflow 등록
+ *   Step 2. TC-WF-FLOW-03 (variant:delete)  서비스 삭제용 Workflow 등록
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C3-01-wf-define');

--- a/e2e/scenarios/C3-svc-wf/C3-02-wf-modify.spec.ts
+++ b/e2e/scenarios/C3-svc-wf/C3-02-wf-modify.spec.ts
@@ -1,0 +1,16 @@
+/**
+ * deploy/scenarios/C3-svc-wf/C3-02-wf-modify.spec.ts
+ * [C3-02] WF 조회·수정
+ *
+ * 등록된 Workflow 목록을 조회하고 상세 내용을 수정한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-WF-FLOW-02  Workflow 목록 조회
+ *   Step 2. TC-WF-FLOW-04  Workflow 상세 수정
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C3-02-wf-modify');

--- a/e2e/scenarios/C3-svc-wf/C3-03-wf-run-infra.spec.ts
+++ b/e2e/scenarios/C3-svc-wf/C3-03-wf-run-infra.spec.ts
@@ -1,0 +1,16 @@
+/**
+ * deploy/scenarios/C3-svc-wf/C3-03-wf-run-infra.spec.ts
+ * [C3-03] WF 실행 — 인프라 배포
+ *
+ * 정의된 인프라 생성 Workflow를 RUN 버튼으로 실행하고 로그를 확인한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-WF-FLOW-06  인프라 배포 Workflow 실행 (RUN)
+ *   Step 2. TC-WF-FLOW-07  Workflow 로그 모달 확인
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C3-03-wf-run-infra');

--- a/e2e/scenarios/C3-svc-wf/C3-04-wf-run-infra-app.spec.ts
+++ b/e2e/scenarios/C3-svc-wf/C3-04-wf-run-infra-app.spec.ts
@@ -1,0 +1,16 @@
+/**
+ * deploy/scenarios/C3-svc-wf/C3-04-wf-run-infra-app.spec.ts
+ * [C3-04] WF 실행 — 인프라 + Application 통합 배포
+ *
+ * 인프라와 애플리케이션을 함께 배포하는 Workflow를 실행하고 로그를 확인한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-WF-FLOW-06 (variant:infra-app)  인프라+App 통합 배포 Workflow 실행 (RUN)
+ *   Step 2. TC-WF-FLOW-07                       Workflow 로그 모달 확인
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C3-04-wf-run-infra-app');

--- a/e2e/scenarios/C3-svc-wf/C3-05-wf-run-k8s.spec.ts
+++ b/e2e/scenarios/C3-svc-wf/C3-05-wf-run-k8s.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/scenarios/C3-svc-wf/C3-05-wf-run-k8s.spec.ts
+ * [C3-05] WF 실행 — K8s 배포
+ *
+ * K8s 클러스터를 배포하는 Workflow를 실행한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: wip
+ *
+ * 스텝:
+ *   Step 1. TC-WF-FLOW-06 (variant:k8s)  K8s 배포 Workflow 실행 (RUN)  [wip]
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C3-05-wf-run-k8s');

--- a/e2e/scenarios/C3-svc-wf/C3-06-wf-el-register.spec.ts
+++ b/e2e/scenarios/C3-svc-wf/C3-06-wf-el-register.spec.ts
@@ -1,0 +1,16 @@
+/**
+ * deploy/scenarios/C3-svc-wf/C3-06-wf-el-register.spec.ts
+ * [C3-06] Event Listener 등록 (WF 연결)
+ *
+ * Workflow와 연결된 Event Listener를 생성하고 이름 중복을 검사한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-WF-EL-02  Event Listener 생성 (Workflow 연결)
+ *   Step 2. TC-WF-EL-03  Event Listener 이름 중복 검사
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C3-06-wf-el-register');

--- a/e2e/scenarios/C3-svc-wf/C3-07-wf-el-run.spec.ts
+++ b/e2e/scenarios/C3-svc-wf/C3-07-wf-el-run.spec.ts
@@ -1,0 +1,16 @@
+/**
+ * deploy/scenarios/C3-svc-wf/C3-07-wf-el-run.spec.ts
+ * [C3-07] Event Listener로 WF 실행 (GET / POST)
+ *
+ * Event Listener를 통해 외부에서 Workflow를 GET/POST 방식으로 실행한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-WF-EL-06  Event Listener GET Trigger로 Workflow 실행
+ *   Step 2. TC-WF-EL-07  Event Listener POST Trigger로 Workflow 실행
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C3-07-wf-el-run');

--- a/e2e/scenarios/C4-svc-direct/C4-01-mci-multi-csp-cluster.spec.ts
+++ b/e2e/scenarios/C4-svc-direct/C4-01-mci-multi-csp-cluster.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C4-svc-direct/C4-01-mci-multi-csp-cluster.spec.ts
+ * [C4-01] MCI 배포 — Multi-CSP 통합 + Clustering SubGroup
+ *
+ * 여러 CSP의 VM을 1개 MCI에 통합 생성하고,
+ * Clustering용 NodeGroup에 N개 VM을 Expert 모드로 추가한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-INFRA-DEPLOY-05 (variant:multi)    Multi-CSP VM → 1개 MCI 생성
+ *   Step 2. TC-INFRA-DEPLOY-07 (variant:cluster)  Clustering NodeGroup N개 VM 추가 (Expert)
+ *   Step 3. TC-INFRA-DEPLOY-01                    모든 VM Running 상태 확인
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C4-01-mci-multi-csp-cluster');

--- a/e2e/scenarios/C4-svc-direct/C4-02-k8s-deploy.spec.ts
+++ b/e2e/scenarios/C4-svc-direct/C4-02-k8s-deploy.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * deploy/scenarios/C4-svc-direct/C4-02-k8s-deploy.spec.ts
+ * [C4-02] K8s 배포 — CSP별 공용 spec
+ *
+ * 9개 CSP K8s 클러스터 배포 시나리오가 이 파일을 공유한다.
+ * 실행 시 SCENARIO_ID 환경변수로 대상 시나리오를 선택한다.
+ *
+ *   C4-02-k8s-aws      (todo)   AWS    — Dynamic
+ *   C4-02-k8s-azure    (todo)   Azure  — Dynamic
+ *   C4-02-k8s-gcp      (todo)   GCP    — Dynamic
+ *   C4-02-k8s-ali      (todo)   Alibaba — Dynamic
+ *   C4-02-k8s-ibm      (wip)    IBM    — Expert
+ *   C4-02-k8s-nhn      (todo)   NHN    — Dynamic
+ *   C4-02-k8s-tencent  (ready)  Tencent — Dynamic
+ *   C4-02-k8s-ncp      (ready)  NCP    — Dynamic
+ *
+ * 스텝 (CSP별 variant 적용):
+ *   Step 1. TC-INFRA-K8S-03 or K8S-04  K8s 클러스터 배포 (Dynamic or Expert)
+ *   Step 2. TC-INFRA-K8S-05             KubeConfig 획득
+ *
+ * 실행 예:
+ *   SCENARIO_ID=C4-02-k8s-tencent npx playwright test C4-02-k8s-deploy.spec.ts
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario(process.env.SCENARIO_ID ?? 'C4-02-k8s-aws');

--- a/e2e/scenarios/C4-svc-direct/C4-03-sw-repo-create.spec.ts
+++ b/e2e/scenarios/C4-svc-direct/C4-03-sw-repo-create.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/scenarios/C4-svc-direct/C4-03-sw-repo-create.spec.ts
+ * [C4-03] SW Repository 생성
+ *
+ * 애플리케이션 검색·배포를 위한 SW Repository를 신규 생성한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-APP-REP-02  SW Repository 신규 생성
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C4-03-sw-repo-create');

--- a/e2e/scenarios/C4-svc-direct/C4-04-app-catalog-register.spec.ts
+++ b/e2e/scenarios/C4-svc-direct/C4-04-app-catalog-register.spec.ts
@@ -1,0 +1,17 @@
+/**
+ * deploy/scenarios/C4-svc-direct/C4-04-app-catalog-register.spec.ts
+ * [C4-04] SW 검색 → Catalog 등록
+ *
+ * 외부(DockerHub)에서 애플리케이션을 검색·Upload하고 SW Catalog에 등록한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-APP-CAT-03  외부 검색 결과 표시 (DockerHub)
+ *   Step 2. TC-APP-CAT-04  DockerHub 이미지 → Repository Upload
+ *   Step 3. TC-APP-CAT-05  Catalog 신규 등록 (VM 타겟)
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C4-04-app-catalog-register');

--- a/e2e/scenarios/C4-svc-direct/C4-05-app-deploy-standalone.spec.ts
+++ b/e2e/scenarios/C4-svc-direct/C4-05-app-deploy-standalone.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C4-svc-direct/C4-05-app-deploy-standalone.spec.ts
+ * [C4-05] SW Standalone 배포 (Infra VM 단일)
+ *
+ * MCI의 단일 VM에 애플리케이션을 Standalone 방식으로 배포한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C4-03, C4-04 완료 후 Catalog에 VM 타겟 앱이 등록되어 있어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-APP-DEP-01  VM 단일 Standalone 배포
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C4-05-app-deploy-standalone');

--- a/e2e/scenarios/C4-svc-direct/C4-06-app-deploy-clustering.spec.ts
+++ b/e2e/scenarios/C4-svc-direct/C4-06-app-deploy-clustering.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * deploy/scenarios/C4-svc-direct/C4-06-app-deploy-clustering.spec.ts
+ * [C4-06] SW Clustering 배포 (NodeGroup N개 VM)
+ *
+ * C4-01에서 생성한 Clustering NodeGroup(N개 VM)에 애플리케이션을 Clustering 방식으로 배포한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C4-01에서 Clustering NodeGroup이 생성되어 있어야 한다.
+ *   - C4-04 완료 후 Catalog에 VM 타겟 앱이 등록되어 있어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-APP-DEP-02  NodeGroup Clustering 배포
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C4-06-app-deploy-clustering');

--- a/e2e/scenarios/C4-svc-direct/C4-07-infra-app-verify.spec.ts
+++ b/e2e/scenarios/C4-svc-direct/C4-07-infra-app-verify.spec.ts
@@ -1,0 +1,16 @@
+/**
+ * deploy/scenarios/C4-svc-direct/C4-07-infra-app-verify.spec.ts
+ * [C4-07] Infra Application 상태 확인
+ *
+ * Infra(MCI VM)에 배포된 애플리케이션의 상태 목록을 조회하고 상세 정보를 확인한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-APP-APPS-01  Apps Status 목록 조회 (Infra)
+ *   Step 2. TC-APP-APPS-02  Apps Status 상세 팝업 확인 (Infra)
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C4-07-infra-app-verify');

--- a/e2e/scenarios/C4-svc-direct/C4-08-app-deploy-k8s-helm.spec.ts
+++ b/e2e/scenarios/C4-svc-direct/C4-08-app-deploy-k8s-helm.spec.ts
@@ -1,0 +1,17 @@
+/**
+ * deploy/scenarios/C4-svc-direct/C4-08-app-deploy-k8s-helm.spec.ts
+ * [C4-08] SW K8s Helm 배포
+ *
+ * K8s 클러스터에 Catalog(K8s 타겟)를 등록하고 Helm으로 애플리케이션을 배포한다.
+ * C4-02-k8s-* 각 환경에 대해 Playwright projects로 반복 실행된다.
+ *
+ * actor:  SRE 엔지니어
+ * status: todo
+ *
+ * 스텝:
+ *   Step 1. TC-APP-REP-03  SW Catalog 등록 (K8s 타겟)  [todo]
+ *   Step 2. TC-APP-DEP-03  SW K8s 배포 (Helm)          [todo]
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C4-08-app-deploy-k8s-helm');

--- a/e2e/scenarios/C4-svc-direct/C4-09-k8s-app-verify.spec.ts
+++ b/e2e/scenarios/C4-svc-direct/C4-09-k8s-app-verify.spec.ts
@@ -1,0 +1,17 @@
+/**
+ * deploy/scenarios/C4-svc-direct/C4-09-k8s-app-verify.spec.ts
+ * [C4-09] K8s Application 상태 확인
+ *
+ * K8s 클러스터에 배포된 애플리케이션의 상태 목록을 조회하고 상세 정보를 확인한다.
+ * C4-02-k8s-* 각 환경에 대해 Playwright projects로 반복 실행된다.
+ *
+ * actor:  SRE 엔지니어
+ * status: todo
+ *
+ * 스텝:
+ *   Step 1. TC-APP-APPS-01  Apps Status 목록 조회 (K8s)      [todo]
+ *   Step 2. TC-APP-APPS-02  Apps Status 상세 팝업 확인 (K8s)  [todo]
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C4-09-k8s-app-verify');

--- a/e2e/scenarios/C5-svc-mgmt1/C5-01-infra-scaleout.spec.ts
+++ b/e2e/scenarios/C5-svc-mgmt1/C5-01-infra-scaleout.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * deploy/scenarios/C5-svc-mgmt1/C5-01-infra-scaleout.spec.ts
+ * [C5-01] Infra Scale Out — CSP별 NodeGroup 2개 추가
+ *
+ * mci01의 각 CSP subgroup에 nodegroup을 2개씩 추가하여 수평 확장한다.
+ * (8 CSP × 2 = 16 subgroup 추가)
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step  1. TC-INFRA-DEPLOY-07 (variant:ng1a)  ng1a (AWS) subgroup 추가
+ *   Step  2. TC-INFRA-DEPLOY-07 (variant:ng1b)  ng1b (AWS) subgroup 추가
+ *   Step  3. TC-INFRA-DEPLOY-07 (variant:ng2a)  ng2a (Azure) subgroup 추가
+ *   Step  4. TC-INFRA-DEPLOY-07 (variant:ng2b)  ng2b (Azure) subgroup 추가
+ *   Step  5. TC-INFRA-DEPLOY-07 (variant:ng3a)  ng3a (Alibaba) subgroup 추가
+ *   Step  6. TC-INFRA-DEPLOY-07 (variant:ng3b)  ng3b (Alibaba) subgroup 추가
+ *   Step  7. TC-INFRA-DEPLOY-07 (variant:ng4a)  ng4a (GCP) subgroup 추가
+ *   Step  8. TC-INFRA-DEPLOY-07 (variant:ng4b)  ng4b (GCP) subgroup 추가
+ *   Step  9. TC-INFRA-DEPLOY-07 (variant:ng5a)  ng5a (NCP) subgroup 추가
+ *   Step 10. TC-INFRA-DEPLOY-07 (variant:ng5b)  ng5b (NCP) subgroup 추가
+ *   Step 11. TC-INFRA-DEPLOY-07 (variant:ng6a)  ng6a (NHN) subgroup 추가
+ *   Step 12. TC-INFRA-DEPLOY-07 (variant:ng6b)  ng6b (NHN) subgroup 추가
+ *   Step 13. TC-INFRA-DEPLOY-07 (variant:ng7a)  ng7a (Tencent) subgroup 추가
+ *   Step 14. TC-INFRA-DEPLOY-07 (variant:ng7b)  ng7b (Tencent) subgroup 추가
+ *   Step 15. TC-INFRA-DEPLOY-07 (variant:ng8a)  ng8a (IBM) subgroup 추가
+ *   Step 16. TC-INFRA-DEPLOY-07 (variant:ng8b)  ng8b (IBM) subgroup 추가
+ *   Step 17. TC-INFRA-DEPLOY-01                  전체 VM Running 상태 확인
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C5-01-infra-scaleout');

--- a/e2e/scenarios/C5-svc-mgmt1/C5-04-app-ops-verify.spec.ts
+++ b/e2e/scenarios/C5-svc-mgmt1/C5-04-app-ops-verify.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * deploy/scenarios/C5-svc-mgmt1/C5-04-app-ops-verify.spec.ts
+ * [C5-04] 애플리케이션 운영 액션
+ *
+ * 배포된 애플리케이션의 상태 목록 갱신·상세 조회 후
+ * 운영 액션(Restart / Stop / Uninstall)을 수행한다.
+ * Rating 제출은 C5-05에서 별도 처리한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-APP-APPS-01  배포 상태 목록 갱신·Refresh
+ *   Step 2. TC-APP-APPS-02  배포 상세 조회
+ *   Step 3. TC-APP-APPS-03  운영 액션 (Restart / Stop / Uninstall)
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C5-04-app-ops-verify');

--- a/e2e/scenarios/C5-svc-mgmt1/C5-05-app-rating.spec.ts
+++ b/e2e/scenarios/C5-svc-mgmt1/C5-05-app-rating.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/scenarios/C5-svc-mgmt1/C5-05-app-rating.spec.ts
+ * [C5-05] 애플리케이션 Rating 제출
+ *
+ * 사용한 애플리케이션에 대한 Rating(별점)을 제출한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-APP-APPS-04  Rating 제출
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C5-05-app-rating');

--- a/e2e/scenarios/C6-monitoring/C6-01-obs-agent.spec.ts
+++ b/e2e/scenarios/C6-monitoring/C6-01-obs-agent.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * deploy/scenarios/C6-01-obs-agent.spec.ts
+ * [C6-01] OBS Agent 관리
+ *
+ * 운영 중인 MCI에 모니터링 Agent를 설치·확인·플러그인 등록 후 제거한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-OBS-AGENT-01  등록 가능 Node 조회(Config)
+ *   Step 2. TC-OBS-AGENT-02  Agent 설치                 ← mciId 필수
+ *   Step 3. TC-OBS-AGENT-03  Agent 설치 상태 폴링       [todo]
+ *   Step 4. TC-OBS-AGENT-04  모니터링 플러그인(item) 등록 [todo]
+ *   Step 5. TC-OBS-AGENT-05  Agent 제거                 [todo]
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C6-01-obs-agent');

--- a/e2e/scenarios/C6-monitoring/C6-02-obs-metric.spec.ts
+++ b/e2e/scenarios/C6-monitoring/C6-02-obs-metric.spec.ts
@@ -1,0 +1,19 @@
+/**
+ * deploy/scenarios/C6-02-obs-metric.spec.ts
+ * [C6-02] OBS Metric 조회
+ *
+ * InfluxDB Agent 메트릭, CSP API 메트릭(cb-spider), K8s 노드 메트릭,
+ * Infra/NS 오버뷰를 순서대로 확인한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: partial (Step 1 ready / Step 2~4 todo — API discovery 필요)
+ *
+ * 스텝:
+ *   Step 1. TC-OBS-METRIC-01  Agent 시계열 메트릭(InfluxDB)  ← mciId 필수
+ *   Step 2. TC-OBS-METRIC-02  CSP API 메트릭(cb-spider)      [todo]
+ *   Step 3. TC-OBS-METRIC-03  K8s Cluster 노드 메트릭         [todo]
+ *   Step 4. TC-OBS-METRIC-04  Infra / NS 레벨 오버뷰          [todo]
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C6-02-obs-metric');

--- a/e2e/scenarios/C6-monitoring/C6-03-obs-insight.spec.ts
+++ b/e2e/scenarios/C6-monitoring/C6-03-obs-insight.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C6-03-obs-insight.spec.ts
+ * [C6-03] OBS Insight 분석
+ *
+ * Anomaly Detection 설정 → History 조회 → Prediction(예측) → LLM 서버 오류 분석
+ *
+ * actor:  SRE 엔지니어
+ * status: partial (Step 1 ready / Step 2~4 todo — API discovery 필요)
+ *
+ * 스텝:
+ *   Step 1. TC-OBS-INSIGHT-01  Anomaly Detection 설정     ← mciId 필수
+ *   Step 2. TC-OBS-INSIGHT-02  Anomaly History 조회        [todo]
+ *   Step 3. TC-OBS-INSIGHT-03  Prediction(예측)            [todo]
+ *   Step 4. TC-OBS-INSIGHT-04  Server Error Analysis(LLM)  [todo]
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C6-03-obs-insight');

--- a/e2e/scenarios/C6-monitoring/C6-04-obs-log.spec.ts
+++ b/e2e/scenarios/C6-monitoring/C6-04-obs-log.spec.ts
@@ -1,0 +1,16 @@
+/**
+ * deploy/scenarios/C6-04-obs-log.spec.ts
+ * [C6-04] OBS Log 조회
+ *
+ * Loki 라벨 목록을 조회하고 LogQL로 키워드 검색을 수행한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: partial (Step 1 ready / Step 2 todo — LogQL API discovery 필요)
+ *
+ * 스텝:
+ *   Step 1. TC-OBS-LOG-01  라벨 조회             ← mciId 필수
+ *   Step 2. TC-OBS-LOG-02  키워드 검색(LogQL)    [todo]
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C6-04-obs-log');

--- a/e2e/scenarios/C6-monitoring/C6-05-obs-trace.spec.ts
+++ b/e2e/scenarios/C6-monitoring/C6-05-obs-trace.spec.ts
@@ -1,0 +1,17 @@
+/**
+ * deploy/scenarios/C6-05-obs-trace.spec.ts
+ * [C6-05] OBS Trace 조회
+ *
+ * Grafana Tempo에서 Trace를 검색하고 상세 Call Sequence와 iframe 임베드를 확인한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: partial (Step 1 ready / Step 2~3 todo — Jaeger/Tempo 미설치 시 skip)
+ *
+ * 스텝:
+ *   Step 1. TC-OBS-TRACE-01  Trace 검색(Tempo)          [Jaeger 미설치 시 FAIL]
+ *   Step 2. TC-OBS-TRACE-02  Trace 상세 / Call Sequence  [todo]
+ *   Step 3. TC-OBS-TRACE-03  Trace iframe 임베드          [todo]
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C6-05-obs-trace');

--- a/e2e/scenarios/C6-monitoring/C6-06-obs-trigger.spec.ts
+++ b/e2e/scenarios/C6-monitoring/C6-06-obs-trigger.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/scenarios/C6-06-obs-trigger.spec.ts
+ * [C6-06] OBS Trigger 관리
+ *
+ * Trigger Policy 생성/목록/삭제, 타겟 연결, 알림 채널 설정,
+ * History 조회, 임계값 수정 전체 흐름.
+ *
+ * actor:  SRE 엔지니어
+ * status: todo (전체 — OBS Trigger API discovery 필요)
+ *
+ * 스텝:
+ *   Step 1. TC-OBS-TRIG-01  Trigger Policy 생성/목록/삭제  [todo]
+ *   Step 2. TC-OBS-TRIG-02  정책 ↔ Node/Infra 타겟 연결    [todo]
+ *   Step 3. TC-OBS-TRIG-03  알림 채널 설정                  [todo]
+ *   Step 4. TC-OBS-TRIG-04  Trigger / Notification History  [todo]
+ *   Step 5. TC-OBS-TRIG-05  정책 수정(임계값 등)             [todo]
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C6-06-obs-trigger');

--- a/e2e/scenarios/C6-monitoring/C6-08-obs-agent-pmk.spec.ts
+++ b/e2e/scenarios/C6-monitoring/C6-08-obs-agent-pmk.spec.ts
@@ -1,0 +1,21 @@
+/**
+ * deploy/scenarios/C6-monitoring/C6-08-obs-agent-pmk.spec.ts
+ * [C6-08] OBS Agent 관리 — PMK K8s
+ *
+ * PMK K8s 클러스터에 모니터링 Agent를 설치·상태확인·제거한다.
+ * MCI VM 대상인 C6-01과 분리된 K8s 전용 시나리오.
+ *
+ * actor:  SRE 엔지니어
+ * status: todo
+ *
+ * 전제조건:
+ *   - C4-02-k8s-* 시나리오로 K8s 클러스터가 배포되어 있어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-OBS-AGENT-01 (variant:pmk)  PMK K8s Node 조회 (Config)  [todo]
+ *   Step 2. TC-OBS-AGENT-02 (variant:pmk)  PMK K8s Agent 설치           [todo]
+ *   Step 3. TC-OBS-AGENT-03 (variant:pmk)  PMK K8s Agent 설치 상태 폴링 [todo]
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C6-08-obs-agent-pmk');

--- a/e2e/scenarios/C7-svc-mgmt2/C7-01-mci-lifecycle.spec.ts
+++ b/e2e/scenarios/C7-svc-mgmt2/C7-01-mci-lifecycle.spec.ts
@@ -1,0 +1,21 @@
+/**
+ * deploy/scenarios/C7-svc-mgmt2/C7-01-mci-lifecycle.spec.ts
+ * [C7-01] 운영 중 MCI 관리 (인프라 라이프사이클)
+ *
+ * 운영 중인 MCI 인프라의 suspend·reboot·resume 라이프사이클을 관리한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C5 시나리오로 mciId가 생성되어 store에 저장되어 있어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-INFRA-LC-01a  MCI suspend (Running→Stopped)
+ *   Step 2. TC-INFRA-LC-01c  MCI reboot  (Stopped→Running)
+ *   Step 3. TC-INFRA-LC-01a  MCI suspend (Running→Stopped)
+ *   Step 4. TC-INFRA-LC-01b  MCI resume  (Stopped→Running)
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C7-01-mci-lifecycle');

--- a/e2e/scenarios/C7-svc-mgmt2/C7-02-mci-resume.spec.ts
+++ b/e2e/scenarios/C7-svc-mgmt2/C7-02-mci-resume.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C7-svc-mgmt2/C7-02-mci-resume.spec.ts
+ * [C7-02] MCI Resume
+ *
+ * suspend 상태의 MCI를 resume하여 Running으로 복구한다.
+ * C7-01 실행 후 MCI가 Stopped 상태일 때 단독으로 실행하는 복구 시나리오.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-INFRA-DEPLOY-02  MCI 상태 확인
+ *   Step 2. TC-INFRA-LC-01b     MCI resume (Stopped→Running)
+ *   Step 3. TC-INFRA-DEPLOY-01  Running 상태 확인
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C7-02-mci-resume');

--- a/e2e/scenarios/C7-svc-mgmt2/C7-03-k8s-cluster-manage.spec.ts
+++ b/e2e/scenarios/C7-svc-mgmt2/C7-03-k8s-cluster-manage.spec.ts
@@ -1,0 +1,22 @@
+/**
+ * deploy/scenarios/C7-svc-mgmt2/C7-03-k8s-cluster-manage.spec.ts
+ * [C7-03] K8s 클러스터 운영 관리
+ *
+ * K8s 클러스터·NodeGroup 목록/상세 조회, KubeConfig 획득,
+ * Helm 앱 배포, NodeGroup 크기 변경을 수행한다.
+ *
+ * actor:  SRE 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C5 시나리오로 K8s 클러스터가 배포되어 있어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-INFRA-K8S-01  K8s 클러스터·NodeGroup 목록/상세 조회
+ *   Step 2. TC-INFRA-K8S-05  KubeConfig 획득 (kubectl 접속 정보)
+ *   Step 3. TC-APP-DEP-03    K8s Helm 앱 배포
+ *   Step 4. TC-INFRA-K8S-06  K8s NodeGroup 크기 변경
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C7-03-k8s-cluster-manage');

--- a/e2e/scenarios/C8-data/C8-01-objstore-generate.spec.ts
+++ b/e2e/scenarios/C8-data/C8-01-objstore-generate.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/scenarios/C8-data/C8-01-objstore-generate.spec.ts
+ * [C8-01] Object Storage 생성
+ *
+ * Object Storage 버킷을 생성하고 초기 샘플 데이터를 준비한다.
+ *
+ * actor:  DBA / 인프라 엔지니어
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-DATA-OS-01  Object Storage 생성 (Generate)
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C8-01-objstore-generate');

--- a/e2e/scenarios/C8-data/C8-02-objstore-migrate.spec.ts
+++ b/e2e/scenarios/C8-data/C8-02-objstore-migrate.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C8-data/C8-02-objstore-migrate.spec.ts
+ * [C8-02] Object Storage Migration
+ *
+ * Object Storage 데이터를 다른 버킷으로 마이그레이션한다.
+ *
+ * actor:  DBA / 인프라 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C8-01에서 원본 버킷과 샘플 데이터가 생성되어 있어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-DATA-OS-02  Object Storage 마이그레이션
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C8-02-objstore-migrate');

--- a/e2e/scenarios/C8-data/C8-03-objstore-backup.spec.ts
+++ b/e2e/scenarios/C8-data/C8-03-objstore-backup.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C8-data/C8-03-objstore-backup.spec.ts
+ * [C8-03] Object Storage Backup
+ *
+ * Object Storage 버킷을 백업한다.
+ *
+ * actor:  DBA / 인프라 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C8-01에서 원본 버킷과 샘플 데이터가 생성되어 있어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-DATA-OS-03  Object Storage 백업
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C8-03-objstore-backup');

--- a/e2e/scenarios/C8-data/C8-04-objstore-restore.spec.ts
+++ b/e2e/scenarios/C8-data/C8-04-objstore-restore.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C8-data/C8-04-objstore-restore.spec.ts
+ * [C8-04] Object Storage Restore
+ *
+ * Object Storage 백업에서 데이터를 복원한다.
+ *
+ * actor:  DBA / 인프라 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C8-03에서 백업이 완료되어 있어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-DATA-OS-04  Object Storage 복원
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C8-04-objstore-restore');

--- a/e2e/scenarios/C8-data/C8-05-rdb-generate.spec.ts
+++ b/e2e/scenarios/C8-data/C8-05-rdb-generate.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C8-data/C8-05-rdb-generate.spec.ts
+ * [C8-05] RDBMS 테스트 데이터 생성
+ *
+ * RDBMS 인스턴스에 테스트 데이터를 생성(Generate)한다.
+ *
+ * actor:  DBA / 인프라 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C1 MC-DATA-MANAGER-INIT에서 RDBMS 인스턴스가 가동 중이어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-DATA-RDB-01  RDBMS 데이터 생성 (Generate)
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C8-05-rdb-generate');

--- a/e2e/scenarios/C8-data/C8-06-rdb-migration.spec.ts
+++ b/e2e/scenarios/C8-data/C8-06-rdb-migration.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C8-data/C8-06-rdb-migration.spec.ts
+ * [C8-06] RDBMS Migration
+ *
+ * RDBMS 데이터를 다른 인스턴스로 마이그레이션한다.
+ *
+ * actor:  DBA / 인프라 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C8-05에서 테스트 데이터가 생성되어 있어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-DATA-RDB-02  RDBMS 마이그레이션
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C8-06-rdb-migration');

--- a/e2e/scenarios/C8-data/C8-07-rdb-backup.spec.ts
+++ b/e2e/scenarios/C8-data/C8-07-rdb-backup.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C8-data/C8-07-rdb-backup.spec.ts
+ * [C8-07] RDBMS Backup
+ *
+ * RDBMS 데이터를 백업한다.
+ *
+ * actor:  DBA / 인프라 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C8-05에서 테스트 데이터가 생성되어 있어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-DATA-RDB-03  RDBMS 백업
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C8-07-rdb-backup');

--- a/e2e/scenarios/C8-data/C8-08-rdb-restore.spec.ts
+++ b/e2e/scenarios/C8-data/C8-08-rdb-restore.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C8-data/C8-08-rdb-restore.spec.ts
+ * [C8-08] RDBMS Restore
+ *
+ * RDBMS 백업에서 데이터를 복원한다.
+ *
+ * actor:  DBA / 인프라 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C8-07에서 백업이 완료되어 있어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-DATA-RDB-04  RDBMS 복원
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C8-08-rdb-restore');

--- a/e2e/scenarios/C8-data/C8-09-nrdb-generate.spec.ts
+++ b/e2e/scenarios/C8-data/C8-09-nrdb-generate.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C8-data/C8-09-nrdb-generate.spec.ts
+ * [C8-09] NRDBMS 테스트 데이터 생성
+ *
+ * NRDBMS 인스턴스에 테스트 데이터를 생성(Generate)한다.
+ *
+ * actor:  DBA / 인프라 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C1 MC-DATA-MANAGER-INIT에서 NRDBMS 인스턴스가 가동 중이어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-DATA-NRDB-01  NRDBMS 데이터 생성 (Generate)
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C8-09-nrdb-generate');

--- a/e2e/scenarios/C8-data/C8-10-nrdb-migration.spec.ts
+++ b/e2e/scenarios/C8-data/C8-10-nrdb-migration.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C8-data/C8-10-nrdb-migration.spec.ts
+ * [C8-10] NRDBMS Migration
+ *
+ * NRDBMS 데이터를 다른 인스턴스로 마이그레이션한다.
+ *
+ * actor:  DBA / 인프라 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C8-09에서 테스트 데이터가 생성되어 있어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-DATA-NRDB-02  NRDBMS 마이그레이션
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C8-10-nrdb-migration');

--- a/e2e/scenarios/C8-data/C8-11-nrdb-backup.spec.ts
+++ b/e2e/scenarios/C8-data/C8-11-nrdb-backup.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C8-data/C8-11-nrdb-backup.spec.ts
+ * [C8-11] NRDBMS Backup
+ *
+ * NRDBMS 데이터를 백업한다.
+ *
+ * actor:  DBA / 인프라 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C8-09에서 테스트 데이터가 생성되어 있어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-DATA-NRDB-03  NRDBMS 백업
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C8-11-nrdb-backup');

--- a/e2e/scenarios/C8-data/C8-12-nrdb-restore.spec.ts
+++ b/e2e/scenarios/C8-data/C8-12-nrdb-restore.spec.ts
@@ -1,0 +1,18 @@
+/**
+ * deploy/scenarios/C8-data/C8-12-nrdb-restore.spec.ts
+ * [C8-12] NRDBMS Restore
+ *
+ * NRDBMS 백업에서 데이터를 복원한다.
+ *
+ * actor:  DBA / 인프라 엔지니어
+ * status: ready
+ *
+ * 전제조건:
+ *   - C8-11에서 백업이 완료되어 있어야 한다.
+ *
+ * 스텝:
+ *   Step 1. TC-DATA-NRDB-04  NRDBMS 복원
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C8-12-nrdb-restore');

--- a/e2e/scenarios/C9-cost/C9-01-cost-analysis.spec.ts
+++ b/e2e/scenarios/C9-cost/C9-01-cost-analysis.spec.ts
@@ -1,0 +1,23 @@
+/**
+ * deploy/scenarios/C9-01-cost-analysis.spec.ts
+ * [C9] 클라우드 비용 확인
+ *
+ * Cost Analysis API로 당월 청구·Top5 비용을 조회하고
+ * Cost Analysis iframe 화면이 정상 로드되는지 확인한다.
+ * 실행 중인 MCI가 없어도 독립적으로 동작한다.
+ *
+ * actor:  과금 관리자
+ * status: ready
+ *
+ * 스텝:
+ *   Step 1. TC-COSTOPT-BILL-01     API 호스트 조회
+ *   Step 2. TC-COSTOPT-BILL-02     당월 청구 조회
+ *   Step 3. TC-COSTOPT-BILL-03     Top5 청구 조회
+ *   Step 4. TC-COSTOPT-IFRAME-01   Cost Analysis iframe 확인
+ *
+ * 실행:
+ *   npx playwright test deploy/scenarios/C9-01-cost-analysis.spec.ts
+ */
+import { bootstrapScenario } from '../shared/createScenarioSuite';
+
+bootstrapScenario('C9-01-cost-analysis');

--- a/e2e/scenarios/shared/createScenarioSuite.ts
+++ b/e2e/scenarios/shared/createScenarioSuite.ts
@@ -1,0 +1,166 @@
+/**
+ * deploy/scenarios/shared/createScenarioSuite.ts
+ * 레지스트리 기반 시나리오 spec 부트스트랩 — C4/C8 커스텀 spec 제외 공통 진입점
+ */
+import * as fs   from 'fs';
+import * as path from 'path';
+import { test, type TestInfo } from '@playwright/test';
+import { requireScenario } from '../../registry';
+import { ScenarioRuntimeStore } from '../../params/runtime/store';
+import { loadDiscovered, saveDiscovered } from '../../params/runtime/discovered';
+import { runScenarioStep } from './runScenarioStep';
+import type { ScenarioStep } from '../../registry/types';
+
+const OUT_DIR = process.env.RUN_OUTPUT_DIR
+  ?? path.resolve(__dirname, '../../../deploy_result');
+
+const RESULT_DIR = OUT_DIR;
+
+type StepRecord = {
+  order:       number;
+  tcId:        string;
+  variant?:    string;
+  description: string;
+  result:      'pass' | 'fail' | 'timeout' | 'skip';
+};
+
+export function bootstrapScenario(scenarioId: string): void {
+  const entry     = requireScenario(scenarioId);
+  const runtimeId = process.env.SCENARIO_ID ?? scenarioId;
+  const scenarioResultDir = path.join(OUT_DIR, runtimeId);
+
+  const store      = new ScenarioRuntimeStore(runtimeId, scenarioResultDir);
+  const stepRecords: StepRecord[] = [];
+  let currentStep: ScenarioStep | null = null;
+
+  test.describe(`${entry.code}: ${entry.title}`, () => {
+    test.describe.configure({ mode: 'serial' });
+    test.use({ storageState: { cookies: [], origins: [] } });
+
+    test.beforeAll(() => {
+      // 1. store 초기화
+      store.reset();
+
+      // 2. 이전 실행 발견값 로드 (Layer 2.5) — 이미 있는 값은 덮지 않음
+      const discovered = loadDiscovered(OUT_DIR, runtimeId);
+      for (const [k, v] of Object.entries(discovered)) {
+        if (store.get(k) === undefined) store.set(k, v);
+      }
+
+      // 3. 레지스트리 initialStore 주입 (discovered보다 우선)
+      if (entry.initialStore) {
+        store.setAll(entry.initialStore);
+      }
+
+      // 4. requiredInputs 유효성 검사 — fail-fast
+      if (entry.requiredInputs?.length) {
+        const missing = entry.requiredInputs.filter(k => store.get(k) === undefined);
+        if (missing.length > 0) {
+          throw new Error(
+            `[${scenarioId}] 필수 입력 파라미터 없음: ${missing.join(', ')}\n` +
+            `  → PW_${missing[0]}=<값> 환경변수 또는 이전 시나리오 실행으로 제공하세요.`,
+          );
+        }
+      }
+
+      console.log(`\n${'='.repeat(60)}`);
+      console.log(`[${scenarioId}] 시나리오 시작 (runtime: ${runtimeId})`);
+      console.log(`  actor: ${entry.actor}`);
+      console.log(`  status: ${entry.status}`);
+      if (entry.requiredInputs?.length) {
+        console.log(`  requiredInputs: ${entry.requiredInputs.join(', ')} ✓`);
+      }
+      console.log('='.repeat(60));
+    });
+
+    test.afterEach(async ({}, testInfo: TestInfo) => {
+      const m = testInfo.title.match(/^Step (\d+)/);
+      if (!m) return;
+      const order = parseInt(m[1], 10);
+      const step  = steps.find(s => s.order === order);
+      if (!step) return;
+
+      let result: StepRecord['result'];
+      if (testInfo.status === 'skipped') {
+        result = 'skip';
+      } else {
+        result = testInfo.status === 'passed'   ? 'pass'
+               : testInfo.status === 'timedOut' ? 'timeout'
+               : 'fail';
+      }
+
+      stepRecords.push({
+        order,
+        tcId:        step.tcId,
+        variant:     step.variant,
+        description: step.description,
+        result,
+      });
+
+      // 실패 시 체크포인트 저장 — 재연에 필요한 정보 보존
+      if ((result === 'fail' || result === 'timeout') && currentStep) {
+        store.checkpoint(
+          { order: currentStep.order, tcId: currentStep.tcId },
+          new Error(testInfo.error?.message ?? '알 수 없는 오류'),
+        );
+        console.log(`[${scenarioId}] 체크포인트 저장: Step${currentStep.order} ${currentStep.tcId}`);
+      }
+    });
+
+    test.afterAll(() => {
+      console.log(`\n${'='.repeat(60)}`);
+      console.log(`[${scenarioId}] 시나리오 종료 — 런타임 파라미터:`);
+      store.dump(`${scenarioId} RuntimeStore`);
+      console.log('='.repeat(60));
+
+      // 발견된 params 영속 저장 — 다음 실행 시 Layer 2.5로 재사용
+      try {
+        saveDiscovered(OUT_DIR, runtimeId, store.snapshot());
+        console.log(`[${scenarioId}] discovered.json 저장 완료`);
+      } catch (e) {
+        console.error(`[${scenarioId}] discovered.json 저장 실패:`, e);
+      }
+
+      // ── deploy_result 기록 ──────────────────────────────────────────────
+      try {
+        fs.mkdirSync(RESULT_DIR, { recursive: true });
+        const ts       = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+        const filename = `${scenarioId}-${ts}.json`;
+        const overall  = stepRecords.some(r => r.result === 'fail' || r.result === 'timeout')
+          ? 'fail' : 'pass';
+        const record = {
+          scenarioId,
+          overall,
+          timestamp: new Date().toISOString(),
+          store:     store.snapshot(),
+          steps:     stepRecords,
+        };
+        fs.writeFileSync(path.join(RESULT_DIR, filename), JSON.stringify(record, null, 2));
+        // latest 링크 (덮어쓰기)
+        fs.writeFileSync(path.join(RESULT_DIR, `${scenarioId}-latest.json`), JSON.stringify(record, null, 2));
+        console.log(`[${scenarioId}] deploy_result/${filename} 저장 완료 (overall=${overall})`);
+      } catch (e) {
+        console.error(`[${scenarioId}] deploy_result 저장 실패:`, e);
+      }
+    });
+
+    const steps = [...entry.steps].sort((a, b) => a.order - b.order);
+    for (const step of steps) {
+      test(`Step ${step.order} — ${step.tcId}: ${step.description}`, async ({ page, request }) => {
+        test.setTimeout(5 * 60_000);
+        currentStep = step;
+        try {
+          await runScenarioStep({
+            page,
+            request,
+            store,
+            scenarioId: runtimeId,
+            step,
+          });
+        } finally {
+          currentStep = null;
+        }
+      });
+    }
+  });
+}

--- a/e2e/scenarios/shared/runScenarioStep.ts
+++ b/e2e/scenarios/shared/runScenarioStep.ts
@@ -1,0 +1,4813 @@
+/**
+ * deploy/scenarios/shared/runScenarioStep.ts
+ * 레지스트리 스텝(TC ID)별 브라우저 UI 실행 — API 직접 호출 없음
+ */
+import { test, expect, type Page, type Locator, type APIRequestContext } from '@playwright/test';
+import * as fs   from 'fs';
+import * as os   from 'os';
+import * as path from 'path';
+import { PAGES } from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { gotoSwIframeTab } from '../../shared/sw-iframe.helper';
+import { ScenarioContext } from '../../params/runtime/context';
+import { ScenarioRuntimeStore } from '../../params/runtime/store';
+import type { ScenarioStep } from '../../registry/types';
+
+const DEFAULT_NS = 'default';
+
+export interface StepRunContext {
+  page: Page;
+  request: APIRequestContext; // reserved — not used directly
+  store: ScenarioRuntimeStore;
+  scenarioId: string;
+  step: ScenarioStep;
+}
+
+function warn(tag: string, msg: string) {
+  console.warn(`[${tag}] ${msg}`);
+}
+
+function failStep(tag: string, reason: string): never {
+  throw new Error(`[${tag}] ${reason}`);
+}
+
+// deploy_result_table.md 에 spec/image 결과를 기록
+function recordDeployResult(opts: {
+  provider: string; region: string; spec: string; image: string;
+  result: 'success' | 'fail'; reason?: string;
+}): void {
+  try {
+    const tableFile = path.resolve('deploy_result', 'deploy_result_table.md');
+    const now  = new Date().toISOString().slice(0, 16).replace('T', ' ');
+    const icon = opts.result === 'success' ? '✅' : '❌';
+    const row  = `| ${opts.provider} | ${opts.region} | ${opts.spec} | ${opts.image || '-'} | ${icon} ${opts.result} | ${opts.reason || '-'} | ${now} |`;
+    const SECTION = '## CSP별 MCI spec/image 기록';
+    const header  = `\n\n${SECTION}\n\n| provider | region | spec | image | 결과 | 사유 | 기록 시각 |\n|---------|--------|------|-------|------|------|----------|\n`;
+    let content = fs.existsSync(tableFile) ? fs.readFileSync(tableFile, 'utf-8') : '';
+    content += content.includes(SECTION) ? row + '\n' : header + row + '\n';
+    fs.writeFileSync(tableFile, content, 'utf-8');
+  } catch { /* 기록 실패 무시 */ }
+}
+
+// ── 공통 헬퍼 ──────────────────────────────────────────────────────────────
+
+async function selectWorkspaceProject(page: Page, tag: string): Promise<void> {
+  try {
+    await page.waitForFunction(() => {
+      const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+      return sel && Array.from(sel.options).some(o => o.text.includes('ws01') || o.value.includes('ws01'));
+    }, { timeout: 15_000 });
+    const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+    await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+
+    await page.waitForFunction(() => {
+      const sel = document.querySelector('#select-current-project') as HTMLSelectElement;
+      return sel && Array.from(sel.options).some(o => o.text.toLowerCase().includes('default'));
+    }, { timeout: 15_000 });
+    const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+    await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    console.log(`[${tag}] ws01/default 선택`);
+  } catch (e) {
+    warn(tag, `ws01/default 선택 실패 — ${(e as Error).message?.slice(0, 60)}`);
+  }
+}
+
+async function dismissWorkspaceModal(page: Page): Promise<void> {
+  try {
+    await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 3_000 });
+    await page.click('#commonDefaultModal-confirm-btn');
+    await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 5_000 });
+  } catch { /* 모달 없음 */ }
+}
+
+// workspace/project 선택 후 팝업이 남아있으면 dismiss, 최종 선택값 확인
+async function ensureWorkspaceProjectSelected(page: Page, tag: string): Promise<void> {
+  await selectWorkspaceProject(page, tag);
+  await page.waitForTimeout(500);
+
+  // 1) 선택 요구 팝업(commonDefaultModal) 처리
+  await dismissWorkspaceModal(page);
+  await page.waitForTimeout(500);
+
+  // 2) 일반 모달/얼럿("워크스페이스를 선택해주세요" 계열) 처리
+  const genericModal = page.locator('[role="dialog"], .modal.show').first();
+  const isGenericVisible = await genericModal.isVisible({ timeout: 2_000 }).catch(() => false);
+  if (isGenericVisible) {
+    const confirmBtn = genericModal.locator('button').filter({ hasText: /ok|confirm|확인|닫기/i }).first();
+    if (await confirmBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await confirmBtn.click();
+      await page.waitForTimeout(500);
+    }
+  }
+
+  // 3) 현재 선택값 검증
+  const wsSelected = await page.locator('#select-current-workspace').inputValue().catch(() => '');
+  const projSelected = await page.locator('#select-current-project').inputValue().catch(() => '');
+  console.log(`[${tag}] workspace 선택값="${wsSelected}", project 선택값="${projSelected}"`);
+
+  const wsOk   = wsSelected.toLowerCase().includes('ws01') || wsSelected !== '';
+  const projOk = projSelected.toLowerCase().includes('default') || projSelected !== '';
+
+  if (!wsOk || !projOk) {
+    // 재시도: selectWorkspaceProject 다시 호출
+    console.log(`[${tag}] workspace/project 미선택 → 재시도`);
+    await selectWorkspaceProject(page, tag);
+    await page.waitForTimeout(800);
+    await dismissWorkspaceModal(page);
+  }
+
+  await page.waitForTimeout(1_000);
+}
+
+// ── MCI spec/image 모달 헬퍼 ───────────────────────────────────────────────
+
+async function selectSpecForConnection(page: Page, tag: string, connectionName: string, targetSpecId: string): Promise<boolean> {
+  const specModal = page.locator('#spec-search').first();
+  const provider     = targetSpecId.split('+')[0].toLowerCase();
+  const cspSpecName  = targetSpecId.split('+').pop() ?? '';
+  const preferredConn = connectionName.toLowerCase(); // e.g. "tencent-ap-seoul"
+
+  console.log(`[${tag}] Spec 검색: targetSpecId="${targetSpecId}" conn="${connectionName}"`);
+
+  // Bootstrap 모달 애니메이션 완료 대기
+  await page.waitForTimeout(600);
+
+  // ① 지역 선택 — "Seoul" (위치 기반 우선순위 정렬)
+  await page.evaluate(() => {
+    const sel = document.getElementById('assistRecommendSpecConnectionName') as HTMLSelectElement | null;
+    if (sel) { sel.value = 'seoul'; sel.dispatchEvent(new Event('change')); }
+    // showRecommendSpecSetting('seoul')이 위도/경도를 설정
+    type ModMap = Record<string, Record<string, (v: string) => void>>;
+    const rec = (window as unknown as { webconsolejs?: ModMap }).webconsolejs;
+    rec?.['partials/operation/manage/serverrecommendation']?.['showRecommendSpecSetting']?.('seoul');
+  }).catch(() => {});
+  await page.waitForTimeout(200);
+
+  // ② provider checkbox 설정
+  await page.evaluate((prov: string) => {
+    const allCb  = document.getElementById('spec-provider-all') as HTMLInputElement | null;
+    const provCb = document.getElementById(`spec-provider-${prov}`) as HTMLInputElement | null;
+    if (allCb)  allCb.checked  = false;
+    if (provCb) provCb.checked = true;
+  }, provider).catch(() => {});
+
+  // ③ 검색 버튼 클릭
+  await specModal.locator('a[onclick*="getRecommendVmInfo"]').click();
+  try {
+    await specModal.locator('#spec-table .tabulator-row:not(.tabulator-placeholder)').first()
+      .waitFor({ timeout: 30_000 });
+  } catch {
+    warn(tag, 'Spec 목록 로드 실패');
+    await specModal.locator('[data-bs-dismiss="modal"]').first().click().catch(() => {});
+    return false;
+  }
+
+  // 페이지 크기 최대화 — Tabulator API + select 양방향 시도
+  await page.evaluate(() => {
+    const table = (window as unknown as { recommendTable?: { setPageSize: (n: number) => void } }).recommendTable;
+    if (table) { try { table.setPageSize(9999); } catch { /* 무시 */ } }
+    const sel = document.querySelector('#spec-table .tabulator-page-size') as HTMLSelectElement | null;
+    if (sel) {
+      const max = Math.max(...Array.from(sel.options).map(o => Number(o.value) || 0));
+      if (max > 0 && sel.value !== String(max)) { sel.value = String(max); sel.dispatchEvent(new Event('change')); }
+    }
+  }).catch(() => {});
+  await page.waitForTimeout(800);
+
+  const specRows = specModal.locator('#spec-table .tabulator-row:not(.tabulator-placeholder)');
+  const rowCount  = await specRows.count();
+  console.log(`[${tag}] Spec 검색결과: ${rowCount}행 (찾는 spec: ${cspSpecName}, conn: ${connectionName})`);
+
+  // 디버그: 처음 5행 텍스트 출력
+  for (let _di = 0; _di < Math.min(5, rowCount); _di++) {
+    const _t = ((await specRows.nth(_di).textContent()) ?? '').replace(/\s+/g, ' ').trim();
+    console.log(`[${tag}] row[${_di}]: ${_t.slice(0, 120)}`);
+  }
+
+  // ④ connectionName에서 region 추출: "alibaba-ap-northeast-2" → "ap-northeast-2"
+  //    첫 번째 '-' 이후를 region으로 사용 (provider prefix 제거)
+  const dashIdx    = preferredConn.indexOf('-');
+  const regionPart = dashIdx >= 0 ? preferredConn.slice(dashIdx + 1) : preferredConn;
+
+  const findRowByRegion = async (region: string): Promise<number> => {
+    for (let i = 0; i < rowCount; i++) {
+      const text = ((await specRows.nth(i).textContent()) ?? '').toLowerCase();
+      if (text.includes(region.toLowerCase()) && text.includes(cspSpecName.toLowerCase())) return i;
+    }
+    return -1;
+  };
+
+  // ⑤ Spec 행 선택 — commonSpec 미지정 시 vCPU 1→2→4 우선순위, 지정 시 region+spec명 매칭
+  let idx = -1;
+
+  if (!cspSpecName) {
+    // vCPU 1→2→4 자동 선택 (commonSpec 미지정)
+    idx = await page.evaluate(() => {
+      const t = (window as unknown as { recommendTable?: { getData: () => Array<Record<string, unknown>> } }).recommendTable;
+      if (!t) return 0;
+      const rows = t.getData();
+      for (const vcpu of [1, 2, 4]) {
+        const found = rows.findIndex(r => Number(r['vCPU']) === vcpu);
+        if (found >= 0) return found;
+      }
+      return 0;
+    }).catch(() => 0);
+    console.log(`[${tag}] vCPU 자동 선택 (1→2→4 우선순위): row ${idx}`);
+  } else {
+    // spec 이름 지정 → region + spec 이름 텍스트 매칭
+    idx = await findRowByRegion(regionPart);
+    if (idx >= 0) {
+      console.log(`[${tag}] Spec 선택: region=${regionPart} / ${cspSpecName}`);
+    }
+  }
+
+  // ⑥ 미발견 처리 (spec명 지정 모드에서만 실패 처리)
+  if (idx < 0) {
+    warn(tag, `Spec 미발견: ${targetSpecId} (region=${regionPart})`);
+    recordDeployResult({ provider, region: regionPart, spec: cspSpecName, image: '', result: 'fail', reason: 'spec 미발견' });
+    await specModal.locator('[data-bs-dismiss="modal"]').first().click().catch(() => {});
+    return false;
+  }
+
+  await specRows.nth(idx).click();
+
+  await page.waitForTimeout(400);
+  await specModal.locator('button[onclick*="applySpecInfo"]').click();
+  await specModal.waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
+
+  // window.selectedSpecInfo 설정 확인 (callbackServerRecommendation는 async이므로 최대 2초 대기)
+  const specInfo = await page.waitForFunction(
+    () => (window as unknown as { selectedSpecInfo?: { provider?: string } }).selectedSpecInfo?.provider,
+    { timeout: 2_000 }
+  ).then(h => h.jsonValue() as Promise<string>).catch(() => '');
+  if (specInfo) {
+    console.log(`[${tag}] selectedSpecInfo.provider: ${specInfo}`);
+  } else {
+    warn(tag, 'selectedSpecInfo.provider 미설정 — 이미지 검색 provider 불확실');
+  }
+  return true;
+}
+
+async function selectImageForSpec(page: Page, tag: string, fixedImageId?: string, specProvider?: string, specRegion?: string): Promise<boolean> {
+  const imgModal = page.locator('#image-search').first();
+
+  // Ubuntu 22.04 OS 선택 시도 — fixedImageId 지정 시 OS 필터 스킵 (e.g. NCP Ubuntu 24.04)
+  if (!fixedImageId) {
+    try {
+      await imgModal.locator('[onclick*="toggleOSDropdown"]').click();
+      await page.waitForTimeout(300);
+      await imgModal.locator('a[onclick*="ubuntu 22.04"]').first().click();
+    } catch { /* OS dropdown 없으면 무시 */ }
+  }
+
+  // selectedSpecInfo에서 provider/region을 즉시 강제 설정
+  await page.evaluate(({ prov, reg }: { prov: string; reg: string }) => {
+    const info = (window as unknown as { selectedSpecInfo?: { provider?: string; regionName?: string; region?: string } }).selectedSpecInfo;
+    const p = document.getElementById('image-provider') as HTMLInputElement | null;
+    const r = document.getElementById('image-region')   as HTMLInputElement | null;
+    const provVal = info?.provider  || prov;
+    const regVal  = info?.regionName || info?.region || reg;
+    if (p && provVal) { p.value = provVal; p.dispatchEvent(new Event('change')); p.dispatchEvent(new Event('input')); }
+    if (r && regVal)  { r.value = regVal;  r.dispatchEvent(new Event('change')); r.dispatchEvent(new Event('input')); }
+  }, { prov: specProvider ?? '', reg: specRegion ?? '' }).catch(() => {});
+
+  // 검색: 1차(osType 포함) → 결과 없으면 osType 초기화 후 2차
+  let loaded = false;
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    if (attempt === 2) {
+      // 2차: osType 필터 초기화 (osType 미스매치 방어)
+      await page.evaluate(() => {
+        const el = document.getElementById('assist_os_type') as HTMLInputElement | null;
+        if (el) el.value = '';
+      }).catch(() => {});
+      warn(tag, 'Image 1차 조회 결과 없음 — osType 필터 제거 후 재검색');
+    }
+    // provider/region 재설정 (비동기 초기화 방어)
+    await page.evaluate(({ prov, reg }: { prov: string; reg: string }) => {
+      const p = document.getElementById('image-provider') as HTMLInputElement | null;
+      const r = document.getElementById('image-region')   as HTMLInputElement | null;
+      if (p && prov) p.value = prov;
+      if (r && reg)  r.value = reg;
+    }, { prov: specProvider ?? '', reg: specRegion ?? '' }).catch(() => {});
+    await imgModal.locator('a[onclick*="getRecommendImageInfo"]').click();
+    try {
+      await imgModal.locator('#image-table .tabulator-row:not(.tabulator-placeholder)').first().waitFor({ timeout: 30_000 });
+      loaded = true;
+      break;
+    } catch {
+      warn(tag, `Image 로드 실패 (${attempt}/2)`);
+    }
+  }
+
+  // fixedImageId 지정 시: 검색 실패 또는 행 미발견이면 ep_commonImageId 직접 설정
+  if (fixedImageId) {
+    let imageFoundInModal = false;
+    if (loaded) {
+      const targetRow = imgModal.locator('#image-table .tabulator-row').filter({ hasText: fixedImageId }).first();
+      if (await targetRow.count() > 0) {
+        await targetRow.click();
+        console.log(`[${tag}] Image 지정 선택: ${fixedImageId}`);
+        imageFoundInModal = true;
+        await page.waitForTimeout(500);
+        await imgModal.locator('button[onclick*="applyImageInfo"]').click();
+        await imgModal.waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
+      }
+    }
+    if (!imageFoundInModal) {
+      warn(tag, `Image ID(${fixedImageId}) 모달 미발견 — ep_commonImageId 직접 설정`);
+      // 모달 닫기
+      await imgModal.locator('[data-bs-dismiss="modal"]').first().click().catch(() => {});
+      await imgModal.waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
+      // ep_commonImageId 직접 설정 (expressDone_btn이 이 값을 읽음)
+      await page.evaluate((id: string) => {
+        const ep = document.getElementById('ep_commonImageId') as HTMLInputElement | null;
+        if (ep) ep.value = id;
+      }, fixedImageId).catch(() => {});
+      console.log(`[${tag}] Image 고정 설정(직접): ${fixedImageId}`);
+    }
+    const imageId = await page.locator('#ep_commonImageId').inputValue().catch(() => '');
+    if (!imageId) { warn(tag, 'Image ep_commonImageId 설정 실패'); return false; }
+    console.log(`[${tag}] Image 선택: ${imageId}`);
+    return true;
+  }
+
+  if (!loaded) {
+    warn(tag, 'Image 목록 로드 불가');
+    await imgModal.locator('[data-bs-dismiss="modal"]').first().click().catch(() => {});
+    return false;
+  }
+
+  // fixedImageId 미지정 시: non-pro 이미지 우선 선택
+  const allRows = imgModal.locator('#image-table .tabulator-row:not(.tabulator-placeholder)');
+  const rowCount = await allRows.count();
+  let imageClicked = false;
+  for (let i = 0; i < Math.min(rowCount, 30); i++) {
+    const row = allRows.nth(i);
+    const text = (await row.textContent()) ?? '';
+    if (!text.toLowerCase().includes('-pro-') && !text.toLowerCase().includes('ubuntu-pro')) {
+      await row.click();
+      imageClicked = true;
+      break;
+    }
+  }
+  if (!imageClicked) await allRows.first().click();
+
+  await page.waitForTimeout(500);
+  await imgModal.locator('button[onclick*="applyImageInfo"]').click();
+  await imgModal.waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
+
+  const imageId = await page.locator('#ep_commonImageId').inputValue().catch(() => '');
+  if (!imageId) { warn(tag, 'Image 미선택'); return false; }
+  console.log(`[${tag}] Image 선택: ${imageId}`);
+  return true;
+}
+
+// ── TC-INFRA-DEPLOY-05: MCI 생성 (UI) ────────────────────────────────────────
+
+async function runInfraDeploy05(ctx: StepRunContext, tag: string, variant?: string): Promise<void> {
+  const { page, store, scenarioId } = ctx;
+  const sc         = new ScenarioContext(scenarioId, 'TC-INFRA-DEPLOY-05', variant);
+  const nsId       = (sc.params.nsId    as string) ?? DEFAULT_NS;
+  const mciName    = (sc.params.mciName as string) ?? `deploy-${scenarioId}`;
+  const vmName     = (sc.params.vmName  as string) ?? `${mciName}-vm-0`;
+  const specId     = (sc.params.commonSpec    as string) ?? '';
+  const connName   = (sc.params.connectionName as string) ?? 'aws-ap-northeast-2';
+  const fixedImgId = (sc.params.imageId as string | undefined);
+
+  const ok = await loginAndGoto(page, PAGES.operations.mciWorkloads, tag);
+  if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+
+  await dismissWorkspaceModal(page);
+  await selectWorkspaceProject(page, tag);
+
+  await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 15_000 });
+  await page.waitForTimeout(1_500);
+
+  // mcilist-table 페이지 크기를 최대로 확장 — 8개 이상의 MCI가 있을 때 페이지네이션으로 탈락하지 않도록
+  await page.evaluate(() => {
+    const sel = document.querySelector('#mcilist-table .tabulator-page-size') as HTMLSelectElement | null;
+    if (!sel) return;
+    const max = Math.max(...Array.from(sel.options).map(o => Number(o.value) || 0));
+    if (max > 0 && sel.value !== String(max)) {
+      sel.value = String(max);
+      sel.dispatchEvent(new Event('change'));
+    }
+  }).catch(() => {});
+  await page.waitForTimeout(500);
+
+  // 이미 존재하면 재사용 — Name 셀 exact match (mci17-dryrun 등 부분 매칭 방지)
+  const existRow = page.locator('#mcilist-table .tabulator-row').filter({
+    has: page.locator('.tabulator-cell').filter({ hasText: new RegExp(`^\\s*${mciName}\\s*$`) }),
+  });
+  if (await existRow.count().catch(() => 0) > 0) {
+    await existRow.first().click({ force: true });
+    await page.waitForTimeout(500);
+    const mciId = await page.evaluate(() => (window as unknown as { currentMciId?: string }).currentMciId ?? '') as string;
+    const id = mciId || mciName;
+    if (variant) { store.set(`mciId_${variant}`, id); store.set(`mciName_${variant}`, mciName); }
+    store.set('mciId', id); store.set('mciName', mciName); store.set('nsId', nsId);
+    console.log(`[${tag}] MCI 재사용: ${mciName} (${id})`);
+    return;
+  }
+
+  // Add Mci 버튼
+  const addBtn = page.locator('#page-header-btn-list a', { hasText: 'Add Mci' });
+  try {
+    await addBtn.waitFor({ state: 'visible', timeout: 10_000 });
+    await addBtn.click();
+    await page.locator('#mcicreate').waitFor({ state: 'visible', timeout: 5_000 });
+  } catch {
+    throw new Error(`[${tag}] Add Mci 버튼 없음`);
+  }
+
+  await page.fill('#mci_name', mciName);
+  await page.fill('#mci_desc', `${scenarioId} deploy scenario`);
+
+  // + SubGroup
+  await page.click('#mci_plusVmIcon');
+  await page.locator('#server_configuration').waitFor({ state: 'visible', timeout: 5_000 });
+  await page.fill('#ep_name', vmName);
+
+  // Spec 검색 모달
+  await page.click('#server_configuration [data-bs-target="#spec-search"]');
+  await page.locator('#spec-search').first().waitFor({ state: 'visible', timeout: 5_000 });
+  const specOk = await selectSpecForConnection(page, tag, connName, specId);
+  if (!specOk) { throw new Error(`[${tag}] Spec(${specId}) 선택 실패 — MCI 미생성`); }
+
+  // Image 검색 모달
+  const specProviderPart = specId.split('+')[0] ?? '';
+  const specRegionPart   = specId.split('+')[1] ?? '';
+  let selectedImageId = '';
+  try {
+    await page.click('#server_configuration [onclick*="validateAndOpenImageModal"]');
+    await page.locator('#image-search').first().waitFor({ state: 'visible', timeout: 5_000 });
+    const imgOk = await selectImageForSpec(page, tag, fixedImgId, specProviderPart, specRegionPart);
+    if (imgOk) {
+      selectedImageId = await page.locator('#ep_commonImageId').inputValue().catch(() => '');
+    } else {
+      recordDeployResult({ provider: specProviderPart, region: specRegionPart, spec: specId, image: '', result: 'fail', reason: 'image 선택 실패' });
+    }
+  } catch { warn(tag, 'Image 모달 열기 실패 — 진행 계속'); }
+
+  // Done
+  await page.click('button[onclick*="expressDone_btn"]');
+  await page.waitForTimeout(1_000);
+
+  // expressDone_btn 이후 Express_Server_Config_Arr 상태 확인
+  const configArr = await page.evaluate(() => {
+    const g = window as unknown as Record<string, unknown>;
+    const arr = g['Express_Server_Config_Arr'];
+    return Array.isArray(arr) ? arr : null;
+  }).catch(() => null);
+  console.log(`[${tag}] Express_Server_Config_Arr:`, JSON.stringify(configArr));
+
+  // PostInfraDynamicReview 모킹 (리뷰 결과 고정 — 인프라 프로비저닝 사전 검증 우회용 mock)
+  await page.route('**/PostInfraDynamicReview', async route => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        responseData: {
+          overallStatus: 'Ready', overallMessage: 'deploy-scenario bypass review',
+          creationViable: true, infraName: mciName, nodeReviews: [], vmReviews: [], resourceSummary: {},
+        },
+        status: { code: 200, message: 'OK' },
+      }),
+    });
+  });
+
+  // PostInfraDynamic 요청/응답 인터셉트 (디버깅용 — 실제 요청은 통과시킴)
+  await page.route('**/PostInfraDynamic', async route => {
+    const reqBody = route.request().postData() || '';
+    console.log(`[${tag}] PostInfraDynamic req: ${reqBody.slice(0, 300)}`);
+    try {
+      const response = await route.fetch();
+      const respText = await response.text().catch(() => '');
+      console.log(`[${tag}] PostInfraDynamic res(${response.status()}): ${respText.slice(0, 300)}`);
+      await route.fulfill({ response });
+    } catch {
+      // page/context가 이미 닫힌 경우 — route를 중단하지 않고 무시
+    }
+  });
+
+  page.on('dialog', async dialog => { await dialog.accept(); });
+
+  const navPromise = page.waitForNavigation({ waitUntil: 'networkidle', timeout: 60_000 }).catch(() => null);
+  try {
+    await page.click('button[onclick*="deployMci"]');
+  } catch {
+    throw new Error(`[${tag}] Deploy 버튼 없음`);
+  }
+  await navPromise;
+
+  // 배포 후 목록 복귀 → MCI 표시 확인 (creating / running / failed 모두 유효)
+  // 최대 6회 reload 재시도 (~60s). 미표시 시 배포 실패로 처리한다.
+  let mciFoundId = '';
+  for (let attempt = 0; attempt <= 5; attempt++) {
+    await dismissWorkspaceModal(page);
+    await selectWorkspaceProject(page, tag);
+    await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+    await page.waitForTimeout(2_000);
+
+    // 테이블 페이지 크기를 최대로 늘려 전체 행 검색 가능하게 함 (기본 5행 페이지네이션 우회)
+    await page.evaluate(() => {
+      const sel = document.querySelector('#mcilist-table .tabulator-page-size') as HTMLSelectElement | null;
+      if (!sel) return;
+      const max = Math.max(...Array.from(sel.options).map(o => Number(o.value) || 0));
+      if (max > 0 && sel.value !== String(max)) {
+        sel.value = String(max);
+        sel.dispatchEvent(new Event('change'));
+      }
+    }).catch(() => {});
+    await page.waitForTimeout(800);
+
+    const row = page.locator('#mcilist-table .tabulator-row').filter({
+      has: page.locator('.tabulator-cell').filter({ hasText: new RegExp(`^\\s*${mciName}\\s*$`) }),
+    });
+    if (await row.count().catch(() => 0) > 0) {
+      await row.first().click();
+      await page.waitForTimeout(500);
+      const mciId = await page.evaluate(() => (window as unknown as { currentMciId?: string }).currentMciId ?? '') as string;
+      mciFoundId = mciId || mciName;
+      break;
+    }
+    console.log(`[${tag}] MCI ${mciName} 미표시 (attempt ${attempt + 1}/6) — 재시도`);
+    if (attempt < 5) {
+      await page.reload({ waitUntil: 'networkidle', timeout: 30_000 }).catch(() => {});
+    }
+  }
+
+  if (!mciFoundId) {
+    recordDeployResult({ provider: specProviderPart, region: specRegionPart, spec: specId, image: selectedImageId, result: 'fail', reason: `MCI ${mciName} 배포 실패` });
+    throw new Error(`[${tag}] MCI ${mciName} 배포 후 목록 미표시 — 배포 실패 (6회 재시도 후)`);
+  }
+  if (variant) { store.set(`mciId_${variant}`, mciFoundId); store.set(`mciName_${variant}`, mciName); }
+  store.set('mciId', mciFoundId); store.set('mciName', mciName); store.set('nsId', nsId);
+  console.log(`[${tag}] MCI 생성: ${mciName} (${mciFoundId})`);
+  recordDeployResult({ provider: specProviderPart, region: specRegionPart, spec: specId, image: selectedImageId, result: 'success' });
+}
+
+// ── TC-INFRA-DEPLOY-01/02: MCI 목록/상태 확인 (UI) ───────────────────────────
+
+async function runInfraDeployList(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page } = ctx;
+  const ok = await loginAndGoto(page, PAGES.operations.mciWorkloads, tag);
+  if (!ok) return;
+  await dismissWorkspaceModal(page);
+  await selectWorkspaceProject(page, tag);
+  await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+  const rowCount = await page.locator('#mcilist-table .tabulator-row').count().catch(() => 0);
+  console.log(`[${tag}] MCI 목록 로드 완료 (행 수: ${rowCount})`);
+}
+
+// ── MCI 목록 페이지 크기 최대화 ──────────────────────────────────────────────
+async function expandMciListPageSize(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const sel = document.querySelector('#mcilist-table .tabulator-page-size') as HTMLSelectElement | null;
+    if (!sel) return;
+    const max = Math.max(...Array.from(sel.options).map(o => Number(o.value) || 0));
+    if (max > 0 && sel.value !== String(max)) { sel.value = String(max); sel.dispatchEvent(new Event('change')); }
+  }).catch(() => {});
+  await page.waitForTimeout(800);
+}
+
+// ── MCI 행에서 ID 추출 ────────────────────────────────────────────────────────
+async function getMciIdFromRow(page: Page, row: Locator, tag: string): Promise<string> {
+  await row.click().catch(() => {});
+  await page.waitForTimeout(300);
+  const fromJs = await page.evaluate(() =>
+    (window as unknown as { currentMciId?: string }).currentMciId ?? ''
+  ).catch(() => '') as string;
+  if (fromJs) return fromJs;
+  // fallback: id 셀
+  const idCell = row.locator('[tabulator-field="id"]');
+  return ((await idCell.textContent().catch(() => '')) ?? '').trim();
+}
+
+// ── MCI ID 화면 자동 발견 헬퍼 ──────────────────────────────────────────────
+// requiredStatus: 원하는 상태 포함 문자열 (예: 'running', 'stopped')
+// 미지정 시 첫 번째 MCI 선택
+async function discoverMciIdFromUi(page: Page, tag: string, requiredStatus?: string): Promise<string> {
+  await expandMciListPageSize(page);
+
+  const rows = page.locator('#mcilist-table .tabulator-row:not(.tabulator-placeholder)');
+  const count = await rows.count().catch(() => 0);
+  if (count === 0) return '';
+
+  if (!requiredStatus) {
+    // 상태 무관: 첫 번째 행
+    const id = await getMciIdFromRow(page, rows.first(), tag);
+    if (id) console.log(`[${tag}] UI에서 MCI 자동 선택: ${id}`);
+    return id;
+  }
+
+  // 원하는 상태인 MCI 탐색
+  for (let i = 0; i < count; i++) {
+    const row    = rows.nth(i);
+    const status = ((await row.locator('[tabulator-field="status"]').textContent().catch(() => '')) ?? '').trim().toLowerCase();
+    if (status.includes(requiredStatus.toLowerCase())) {
+      const id = await getMciIdFromRow(page, row, tag);
+      if (id) {
+        console.log(`[${tag}] UI에서 MCI 자동 선택 (상태: ${status}): ${id}`);
+        return id;
+      }
+    }
+  }
+  console.warn(`[${tag}] 상태 '${requiredStatus}'인 MCI 없음 — 목록 ${count}행 확인`);
+  return '';
+}
+
+// ── TC-INFRA-LC-01 헬퍼: MCI 상태 읽기 / 안정화 대기 / Refresh 폴링 ──────
+
+async function readMciStatus(mciRow: Locator): Promise<string> {
+  return ((await mciRow.locator('[tabulator-field="status"]').textContent().catch(() => '')) ?? '').trim();
+}
+
+// Starting.../Stopping... 상태가 끝날 때까지 page.reload()로 대기
+// timeoutMs: 최대 대기 (기본 2분). 초과 시 null 반환 (throw 대신)
+async function waitForStableMciStatus(
+  page: Page, mciRow: Locator, mciId: string, tag: string, timeoutMs = 2 * 60_000,
+): Promise<string | null> {
+  // 초기 상태 확인 — 이미 안정적이면 즉시 반환
+  const initialStatus = await readMciStatus(mciRow);
+  const initialLower  = initialStatus.toLowerCase().replace(/\./g, '').trim();
+  if (initialStatus && !initialLower.includes('starting') && !initialLower.includes('stopping')) {
+    return initialStatus;
+  }
+
+  // 불안정 상태: page.reload()로 폴링 (Refresh 버튼은 업데이트 안 됨)
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 20_000 });
+    await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 15_000 });
+    await page.waitForTimeout(1_000);
+    const freshRow  = page.locator('#mcilist-table .tabulator-row').filter({ hasText: mciId }).first();
+    const status    = await readMciStatus(freshRow);
+    const lower     = status.toLowerCase().replace(/\./g, '').trim();
+    if (status && !lower.includes('starting') && !lower.includes('stopping')) return status;
+    console.log(`[${tag}] 안정화 대기 (${status})…`);
+    await page.waitForTimeout(4_000);
+  }
+
+  // 타임아웃 — 최종 상태 반환 (null 반환 = 선택 불가 신호)
+  await page.reload({ waitUntil: 'domcontentloaded', timeout: 20_000 }).catch(() => {});
+  await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+  const freshRow    = page.locator('#mcilist-table .tabulator-row').filter({ hasText: mciId }).first();
+  const finalStatus = await readMciStatus(freshRow);
+  console.warn(`[${tag}] MCI '${mciId}' 안정화 타임아웃 — 현재: ${finalStatus}`);
+  return null;
+}
+
+// 최종 상태를 page.reload()로 폴링 (최대 timeoutMs)
+// Refresh 버튼 클릭은 상태 업데이트가 되지 않아 page.reload() 사용
+async function pollMciStatusWithRefresh(
+  page: Page, mciId: string, finalContains: string, tag: string, timeoutMs = 5 * 60_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 20_000 });
+    await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 15_000 });
+    await page.waitForTimeout(1_000);
+    const mciRow  = page.locator('#mcilist-table .tabulator-row').filter({ hasText: mciId }).first();
+    const status  = await readMciStatus(mciRow);
+    console.log(`[${tag}] 최종 상태 대기 (현재: ${status}, 목표: ${finalContains})`);
+    if (status.toLowerCase().includes(finalContains.toLowerCase())) return;
+    await page.waitForTimeout(4_000);
+  }
+  throw new Error(`[${tag}] 최종 상태 '${finalContains}' 대기 타임아웃`);
+}
+
+// ── TC-INFRA-LC-01a/b/c: suspend / reboot / resume (UI) ─────────────────
+//
+//   사전 조건:  a(suspend)=Running,  b(resume)=Stopped,  c(reboot)=Stopped
+//   사후 확인:  a→Stopped,           b→Running,           c→Running
+//
+//   방안 A 시나리오 순서 (C5-01):
+//     Step 1: LC-01a suspend  (Running→Stopped)
+//     Step 2: LC-01c reboot   (Stopped→Running)
+//     Step 3: LC-01a suspend  (Running→Stopped)
+//     Step 4: LC-01b resume   (Stopped→Running)
+//
+async function runInfraLc01(ctx: StepRunContext, tag: string, action: 'suspend' | 'resume' | 'reboot'): Promise<void> {
+  // Cloud VM 상태 전환은 최대 8~10분 걸릴 수 있음 — 기본 5분 타임아웃 연장
+  test.setTimeout(12 * 60_000);
+
+  const { page, store } = ctx;
+  let mciId = (process.env.MCI_ID ?? '') || store.getOrDefault<string>('mciId', '');
+
+  const ok = await loginAndGoto(page, PAGES.operations.mciWorkloads, tag);
+  if (!ok) throw new Error(`[${tag}] 로그인 실패`);
+
+  await dismissWorkspaceModal(page);
+  await selectWorkspaceProject(page, tag);
+
+  await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 15_000 });
+  await page.waitForTimeout(1_500);
+
+  // 사전 조건 상태 (suspend=running, resume/reboot=stopped)
+  const requiredPre = action === 'suspend' ? 'running' : 'stopped';
+
+  // MCI_ID 환경변수로 명시된 경우 해당 MCI만 사용 (fallback 없음)
+  const mciIdFixed = !!(process.env.MCI_ID ?? '').trim();
+
+  await expandMciListPageSize(page);
+
+  let mciRow: Locator | null = null;
+  let currentStatus: string  = '';
+
+  if (mciId) {
+    const candidate = page.locator('#mcilist-table .tabulator-row').filter({ hasText: mciId }).first();
+    if (await candidate.count().catch(() => 0) > 0) {
+      const stable = await waitForStableMciStatus(page, candidate, mciId, tag, 2 * 60_000);
+      if (stable && stable.toLowerCase().includes(requiredPre)) {
+        mciRow       = candidate;
+        currentStatus = stable;
+      } else if (mciIdFixed) {
+        throw new Error(
+          `[${tag}] MCI_ID='${mciId}' 는 ${action} 사전조건 미충족 — 현재: "${stable ?? 'timeout'}", 필요: ${requiredPre}`
+        );
+      } else {
+        console.warn(`[${tag}] '${mciId}' 상태 '${stable ?? 'timeout'}' — 다른 MCI 탐색`);
+      }
+    } else if (mciIdFixed) {
+      throw new Error(`[${tag}] MCI_ID='${mciId}' 가 목록에 없음`);
+    } else {
+      console.warn(`[${tag}] '${mciId}' 목록에 없음 — 다른 MCI 탐색`);
+    }
+  }
+
+  // fallback: MCI_ID 미지정일 때만 목록에서 requiredPre 상태인 MCI 탐색
+  if (!mciRow) {
+    const foundId = await discoverMciIdFromUi(page, tag, requiredPre);
+    if (!foundId) {
+      throw new Error(`[${tag}] ${action} 가능한 MCI 없음 — 상태 '${requiredPre}'인 MCI가 목록에 없음`);
+    }
+    mciId = foundId;
+    store.set('mciId', mciId);
+    const candidate = page.locator('#mcilist-table .tabulator-row').filter({ hasText: mciId }).first();
+    const stable = await waitForStableMciStatus(page, candidate, mciId, tag, 2 * 60_000);
+    if (!stable || !stable.toLowerCase().includes(requiredPre)) {
+      throw new Error(`[${tag}] ${action} 가능한 MCI '${mciId}' 상태 확인 실패 — ${stable ?? 'timeout'}`);
+    }
+    mciRow       = candidate;
+    currentStatus = stable;
+  }
+
+  console.log(`[${tag}] MCI '${mciId}' 현재 상태: ${currentStatus}`);
+
+  // 중간 선택값 기록 — param-history 누적에 활용
+  store.set('lcAction',       action);
+  store.set('lcStatusBefore', currentStatus);
+
+  // 3. MCI 행 클릭 → MCI Info 패널 표시 = 선택 완료
+  //    사용자가 행을 클릭하면 하단에 MCI Info 패널이 표시되고 액션 버튼이 활성화됨
+  await mciRow.click();
+  // MCI Info 패널이 나타날 때까지 대기 (선택 확인)
+  await page.locator(`text=MCI Info [ ${mciId} ]`).waitFor({ state: 'visible', timeout: 5_000 }).catch(() => {
+    // 텍스트 기반 확인 실패해도 계속 진행
+    console.warn(`[${tag}] MCI Info 패널 미확인 — 진행 계속`);
+  });
+  await page.waitForTimeout(300);
+
+  // 4. "List of MCI" 헤더 오른쪽 꺽쇠 드롭다운 클릭
+  //    a.btn-action ❌ → .btn-action[data-bs-toggle="dropdown"] ✅ (탐색으로 확인된 셀렉터)
+  const dropdownBtn = page.locator('.btn-action[data-bs-toggle="dropdown"]:has(svg.icon-tabler-chevron-down)').first();
+  await dropdownBtn.waitFor({ state: 'visible', timeout: 5_000 });
+  await dropdownBtn.click();
+  await page.waitForTimeout(300);
+
+  // 5. 드롭다운 아이템 클릭 (onclick 속성으로 구분)
+  const actionKeyMap: Record<string, string> = { suspend: 'MciSuspend', resume: 'MciResume', reboot: 'MciReboot' };
+  const actionKey  = actionKeyMap[action];
+  const actionItem = page.locator(`.dropdown-menu.show .dropdown-item[onclick*="${actionKey}"]`);
+  await actionItem.waitFor({ state: 'visible', timeout: 3_000 });
+  await actionItem.click();
+
+  // 6. 확인 모달
+  await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 5_000 });
+
+  // Validation 모달("Please select an MCI") 감지 — 선택이 안 된 경우 즉시 실패
+  const modalBody = await page.locator('#commonDefaultModal .modal-body').textContent().catch(() => '');
+  if ((modalBody ?? '').toLowerCase().includes('select an mci')) {
+    throw new Error(`[${tag}] MCI 선택 실패 — UI에서 MCI 체크가 인식되지 않음 (모달: "${modalBody?.trim()}")`);
+  }
+
+  await page.locator('#commonDefaultModal-confirm-btn').click();
+  await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 30_000 });
+  console.log(`[${tag}] MCI ${action} 요청 완료`);
+
+  // 7. 최종 상태 page.reload() 폴링으로 확인
+  const finalStatus = action === 'suspend' ? 'stopped' : 'running';
+  await pollMciStatusWithRefresh(page, mciId, finalStatus, tag, 5 * 60_000);
+  store.set('lcStatusAfter', finalStatus);
+  console.log(`[${tag}] MCI ${action} 검증 완료 → ${finalStatus}`);
+}
+
+// ── TC-INFRA-LC-02: MCI 삭제 (UI) ────────────────────────────────────────
+
+async function runInfraLc02(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store, scenarioId } = ctx;
+  const variant = ctx.step.variant;
+  // 우선순위: env MCI_ID > TC params(variant 포함) > runtime store
+  const sc      = new ScenarioContext(scenarioId, 'TC-INFRA-LC-02', variant);
+  const paramId = (sc.params.mciId as string) ?? '';
+  const mciId   = (process.env.MCI_ID ?? '') || paramId || store.getOrDefault<string>('mciId', '');
+  if (!mciId) {
+    failStep(tag, 'mciId 없음 — MCI 삭제 불가 (C3/C4 먼저 실행, 또는 MCI_ID=<id> 환경변수 주입)');
+  }
+
+  const ok = await loginAndGoto(page, PAGES.operations.mciWorkloads, tag);
+  if (!ok) { warn(tag, '삭제 건너뜀 — 로그인 실패'); return; }
+
+  await dismissWorkspaceModal(page);
+  await selectWorkspaceProject(page, tag);
+  await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 15_000 });
+  await page.waitForTimeout(1_500);
+
+  // 페이지 크기 최대로 확장 — mci11 이후 MCI가 페이지네이션으로 누락되지 않도록
+  await page.evaluate(() => {
+    const sel = document.querySelector('#mcilist-table .tabulator-page-size') as HTMLSelectElement | null;
+    if (!sel) return;
+    const max = Math.max(...Array.from(sel.options).map(o => Number(o.value) || 0));
+    if (max > 0 && sel.value !== String(max)) { sel.value = String(max); sel.dispatchEvent(new Event('change')); }
+  }).catch(() => {});
+  await page.waitForTimeout(500);
+
+  // 잔여 모달 닫기 (이전 step의 삭제 완료 모달 등)
+  await dismissWorkspaceModal(page);
+
+  const mciRow = page.locator('#mcilist-table .tabulator-row').filter({ hasText: mciId }).first();
+  if (await mciRow.count().catch(() => 0) === 0) {
+    warn(tag, `삭제 — MCI ${mciId} 목록에 없음`);
+    return;
+  }
+  await mciRow.click({ force: true });
+  await page.waitForTimeout(500);
+
+  try {
+    await page.locator('a.btn-action:has(svg.icon-tabler-chevron-down)').first().click();
+    await page.locator('a.dropdown-item[onclick*="MciDelete"]').waitFor({ state: 'visible', timeout: 3_000 });
+    await page.locator('a.dropdown-item[onclick*="MciDelete"]').first().click();
+    await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 5_000 });
+    await page.click('#commonDefaultModal-confirm-btn');
+    await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 10_000 });
+    console.log(`[${tag}] MCI 삭제 요청 완료`);
+  } catch (e) {
+    warn(tag, `MCI 삭제 버튼 클릭 실패 — ${(e as Error).message?.slice(0, 80)}`);
+  }
+}
+
+// ── TC-INFRA-LC-03: mc* MCI 일괄 삭제 (case 분류) ────────────────────────
+
+interface MciInfo { name: string; totalServers: number; }
+
+async function runInfraLc03(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+
+  const ok = await loginAndGoto(page, PAGES.operations.mciWorkloads, tag);
+  if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+
+  await dismissWorkspaceModal(page);
+  await selectWorkspaceProject(page, tag);
+  // 워크스페이스 변경 후 추가 modal 대기·닫기
+  await page.waitForTimeout(1_500);
+  await dismissWorkspaceModal(page);
+
+  // ── 테이블 스캔: mc*로 시작하는 MCI 수집 ──────────────────────────
+  const expandTable = async () => {
+    await page.evaluate(() => {
+      const sel = document.querySelector('#mcilist-table .tabulator-page-size') as HTMLSelectElement | null;
+      if (!sel) return;
+      const max = Math.max(...Array.from(sel.options).map(o => Number(o.value) || 0));
+      if (max > 0 && sel.value !== String(max)) { sel.value = String(max); sel.dispatchEvent(new Event('change')); }
+    }).catch(() => {});
+    await page.waitForTimeout(800);
+  };
+
+  const scanMcMcis = async (): Promise<MciInfo[]> => {
+    await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+    await page.waitForTimeout(1_500);
+    await expandTable();
+    return (await page.evaluate(() => {
+      const headerEls = Array.from(document.querySelectorAll('#mcilist-table .tabulator-col'));
+      const colTitle  = (el: Element) =>
+        (el.querySelector('.tabulator-col-title') as HTMLElement)?.innerText?.trim() ?? '';
+      const nameIdx  = headerEls.findIndex(h => colTitle(h) === 'Name');
+      const totalIdx = headerEls.findIndex(h => colTitle(h) === 'Total Servers');
+      return Array.from(
+        document.querySelectorAll('#mcilist-table .tabulator-row:not(.tabulator-placeholder)')
+      ).map(row => {
+        const cells = Array.from(row.querySelectorAll('.tabulator-cell'));
+        const name  = (cells[nameIdx]  as HTMLElement)?.innerText?.trim() || '';
+        const total = parseInt((cells[totalIdx] as HTMLElement)?.innerText?.trim() || '0', 10) || 0;
+        return { name, totalServers: total };
+      }).filter((r: { name: string; totalServers: number }) => r.name.startsWith('mc'));
+    })) as unknown as MciInfo[];
+  };
+
+  const mcMcis = await scanMcMcis();
+  const case1  = mcMcis.filter(m => m.totalServers === 0);
+  const case2  = mcMcis.filter(m => m.totalServers === 1);
+  const case3  = mcMcis.filter(m => m.totalServers >= 2);
+
+  console.log(`[${tag}] === mc* MCI 스캔 결과 ===`);
+  console.log(`[${tag}] case1 (nodegroup 없음,  0개): ${case1.length === 0 ? 'SKIP' : case1.map(m => `${m.name}(${m.totalServers})`).join(', ')}`);
+  console.log(`[${tag}] case2 (nodegroup 1개,  1 VM): ${case2.length === 0 ? 'SKIP' : case2.map(m => `${m.name}(${m.totalServers})`).join(', ')}`);
+  console.log(`[${tag}] case3 (nodegroup 2개+, ≥2VM): ${case3.length === 0 ? 'SKIP' : case3.map(m => `${m.name}(${m.totalServers})`).join(', ')}`);
+  console.log(`[${tag}] 총 삭제 대상: ${mcMcis.length}개`);
+
+  if (mcMcis.length === 0) {
+    console.log(`[${tag}] mc*로 시작하는 MCI 없음 — SKIP`);
+    return;
+  }
+
+  // ── 삭제 루프 ──────────────────────────────────────────────────
+  let deleted = 0;
+  for (const mci of mcMcis) {
+    const caseLabel = mci.totalServers === 0 ? 'case1' : mci.totalServers === 1 ? 'case2' : 'case3';
+    console.log(`[${tag}] [${caseLabel}] 삭제 시작: ${mci.name} (Total Servers: ${mci.totalServers})`);
+
+    await dismissWorkspaceModal(page);
+    await expandTable();
+    const row = page.locator('#mcilist-table .tabulator-row').filter({ hasText: mci.name }).first();
+    if (await row.count().catch(() => 0) === 0) {
+      warn(tag, `${mci.name} 행 없음 — skip`); continue;
+    }
+    await row.click();
+    await page.waitForTimeout(500);
+
+    try {
+      await page.locator('a.btn-action:has(svg.icon-tabler-chevron-down)').first().click();
+      await page.locator('a.dropdown-item[onclick*="MciDelete"]').first().waitFor({ state: 'visible', timeout: 3_000 });
+      await page.locator('a.dropdown-item[onclick*="MciDelete"]').first().click();
+      await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 5_000 });
+      await page.click('#commonDefaultModal-confirm-btn');
+      await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 10_000 });
+      console.log(`[${tag}] 삭제 요청 완료: ${mci.name}`);
+      deleted++;
+      await page.waitForTimeout(1_500);
+    } catch (e) {
+      warn(tag, `${mci.name} 삭제 실패 — ${(e as Error).message?.slice(0, 80)}`);
+    }
+  }
+
+  console.log(`[${tag}] 삭제 완료: ${deleted}/${mcMcis.length}`);
+}
+
+// ── TC-INFRA-K8S-08: K8s 클러스터(PMK) 삭제 (UI) ─────────────────────────
+
+async function runK8sDelete(ctx: StepRunContext, tag: string, variant?: string): Promise<void> {
+  const { page, store, scenarioId } = ctx;
+  const sc          = new ScenarioContext(scenarioId, 'TC-INFRA-K8S-08', variant);
+  const clusterName = (sc.params.clusterName as string) ?? `pmk-${variant ?? 'default'}`;
+
+  const ok = await loginAndGoto(page, PAGES.operations.pmkWorkloads, tag);
+  if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+
+  await dismissWorkspaceModal(page);
+  await selectWorkspaceProject(page, tag);
+  await page.locator('#pmklist-table, #k8slist-table, table').first()
+    .waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+  await page.waitForTimeout(1_500);
+
+  // 테이블 페이지 크기를 최대로 늘려 전체 행 검색 (기본 5행 페이지네이션 우회)
+  await page.evaluate(() => {
+    const sel = document.querySelector('#pmklist-table .tabulator-page-size, #k8slist-table .tabulator-page-size') as HTMLSelectElement | null;
+    if (!sel) return;
+    const max = Math.max(...Array.from(sel.options).map(o => Number(o.value) || 0));
+    if (max > 0 && sel.value !== String(max)) { sel.value = String(max); sel.dispatchEvent(new Event('change')); }
+  }).catch(() => {});
+  await page.waitForTimeout(800);
+
+  const clusterRow = page.locator('#pmklist-table .tabulator-row, #k8slist-table .tabulator-row')
+    .filter({ hasText: clusterName }).first();
+  if (await clusterRow.count().catch(() => 0) === 0) {
+    throw new Error(`[${tag}] 클러스터 ${clusterName} 목록에 없음`);
+  }
+  await clusterRow.click();
+  await page.waitForTimeout(500);
+
+  try {
+    const dropdownBtn = page.locator('a.btn-action:has(svg.icon-tabler-chevron-down)').first();
+    const hasDropdown = await dropdownBtn.isVisible({ timeout: 2_000 }).catch(() => false);
+    if (hasDropdown) {
+      await dropdownBtn.click();
+      // onclick 속성에 'PmkDelete' 포함 (텍스트는 'Delete')
+      const deleteItem = page.locator('a.dropdown-item[onclick*="PmkDelete"]').first();
+      await deleteItem.waitFor({ state: 'visible', timeout: 3_000 });
+      await deleteItem.click();
+    } else {
+      await page.locator('a[onclick*="PmkDelete"], button[onclick*="PmkDelete"]').first().click();
+    }
+    await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 5_000 });
+    await page.click('#commonDefaultModal-confirm-btn');
+    await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 10_000 });
+    console.log(`[${tag}] PMK 클러스터 삭제 요청 완료: ${clusterName}`);
+  } catch (e) {
+    warn(tag, `클러스터 삭제 버튼 클릭 실패 — ${(e as Error).message?.slice(0, 80)}`);
+  }
+}
+
+// ── TC-INFRA-K8S-03: K8s 클러스터 생성 (UI) ───────────────────────────────
+
+async function runK8sCreate(ctx: StepRunContext, tag: string, variant?: string): Promise<void> {
+  const { page, store, scenarioId } = ctx;
+  const sc          = new ScenarioContext(scenarioId, 'TC-INFRA-K8S-03', variant);
+  const nsId        = (sc.params.nsId         as string) ?? DEFAULT_NS;
+  const clusterName = (sc.params.clusterName  as string) ?? `pmk-${variant ?? 'default'}`;
+  const ngName      = (sc.params.nodeGroupName as string) ?? `png-${variant ?? 'default'}`;
+  const connName    = (sc.params.connectionName as string) ?? '';
+  const specId      = (sc.params.commonSpec   as string) ?? (sc.params.specId as string) ?? '';
+
+  const ok = await loginAndGoto(page, PAGES.operations.pmkWorkloads, tag);
+  if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+
+  await dismissWorkspaceModal(page);
+  await selectWorkspaceProject(page, tag);
+
+  // 목록 로드 대기
+  await page.locator('#pmklist-table, #k8slist-table, table').first().waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+  await page.waitForTimeout(1_500);
+
+  // 이미 존재 확인
+  const listTable = page.locator('#pmklist-table, #k8slist-table').first();
+  const existRow = listTable.locator('.tabulator-row').filter({ hasText: clusterName });
+  if (await existRow.count().catch(() => 0) > 0) {
+    await existRow.first().click();
+    await page.waitForTimeout(500);
+    const k8sId = await page.evaluate(() =>
+      (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentPmkId ??
+      (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentK8sId ?? ''
+    ) as string;
+    const id = k8sId || clusterName;
+    if (variant) { store.set(`k8sId_${variant}`, id); store.set(`k8sName_${variant}`, clusterName); }
+    store.set('k8sId', id); store.set('k8sName', clusterName); store.set('nsId', nsId);
+    console.log(`[${tag}] K8s 재사용: ${clusterName} (${id})`);
+    return;
+  }
+
+  // Add Cluster 버튼
+  const addBtn = page.locator('#page-header-btn-list a[href="#createcluster"], #page-header-btn-list a', { hasText: /Add.*Cluster|Add.*PMK/i }).first();
+  try {
+    await addBtn.waitFor({ state: 'visible', timeout: 10_000 });
+    await addBtn.click();
+    await page.locator('#createcluster').waitFor({ state: 'visible', timeout: 5_000 });
+  } catch {
+    throw new Error(`[${tag}] Add Cluster 버튼 없음`);
+  }
+
+  // 폼 입력
+  await page.fill('#cluster_name_dynamic', clusterName).catch(() => {});
+  await page.fill('#cluster_desc_dynamic', `${scenarioId} deploy scenario`).catch(() => {});
+  await page.fill('#nodegroup_name_dynamic', ngName).catch(() => {});
+
+  // Connection 선택
+  if (connName) {
+    try {
+      await page.waitForFunction((conn: string) => {
+        const sel = document.querySelector('#cluster_cloudconnection_dynamic') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.value.toLowerCase().includes(conn.toLowerCase()) || o.text.toLowerCase().includes(conn.toLowerCase()));
+      }, connName, { timeout: 10_000 });
+      const connOpt = await page.locator('#cluster_cloudconnection_dynamic option').filter({ hasText: new RegExp(connName, 'i') }).first().getAttribute('value');
+      await page.locator('#cluster_cloudconnection_dynamic').selectOption(connOpt ?? connName);
+      await page.waitForTimeout(1_000);
+    } catch {
+      warn(tag, `Connection ${connName} 선택 실패`);
+    }
+  }
+
+  // Spec 검색 모달
+  try {
+    const specBtn = page.locator('[data-bs-target="#spec-search-pmk"], [onclick*="spec-search-pmk"]').first();
+    await specBtn.waitFor({ state: 'visible', timeout: 5_000 });
+    await specBtn.click();
+    await page.locator('#spec-search-pmk').waitFor({ state: 'visible', timeout: 5_000 });
+
+    // Spec 검색
+    await page.locator('#spec-search-pmk a[onclick*="getRecommendVmInfoPmk"], #spec-search-pmk a[onclick*="getRecommendVmInfo"]').first().click();
+    await page.locator('#spec-search-pmk .tabulator-row:not(.tabulator-placeholder)').first().waitFor({ timeout: 30_000 });
+
+    // specId로 행 선택 — vCPU 2→4 우선순위 자동 선택 (specId 미지정 또는 미발견 시)
+    const cspSpecName = specId.split('+').pop() ?? '';
+    await page.evaluate(
+      ({ specName }: { specName: string }) => {
+        const table = (window as unknown as { recommendTablePmk?: {
+          getData: () => Array<Record<string, unknown>>;
+          deselectRow: () => void;
+          getRows: () => Array<{ select: () => void }>;
+        } }).recommendTablePmk;
+        if (!table) return;
+        const rows = table.getData();
+        let idx = -1;
+        if (specName) {
+          idx = rows.findIndex(r =>
+            ((r['cspSpecName'] as string) ?? '').toLowerCase().includes(specName.toLowerCase())
+          );
+        }
+        // vCPU 2→4 우선순위 자동 선택 (specName 미지정 또는 미발견)
+        if (idx < 0) {
+          for (const vcpu of [2, 4]) {
+            const found = rows.findIndex(r => Number(r['vCPU']) === vcpu);
+            if (found >= 0) { idx = found; break; }
+          }
+        }
+        if (idx < 0) idx = 0;
+        table.deselectRow();
+        table.getRows()[idx]?.select();
+      },
+      { specName: cspSpecName },
+    );
+    await page.waitForTimeout(400);
+    await page.locator('#spec-search-pmk button[onclick*="applySpecInfo"]').click();
+    await page.locator('#spec-search-pmk').waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
+  } catch (e) {
+    warn(tag, `PMK Spec 선택 실패 — ${(e as Error).message?.slice(0, 60)}`);
+  }
+
+  // Deploy
+  page.on('dialog', async dialog => { await dialog.accept(); });
+  try {
+    await page.locator('button[onclick*="deployPmkDynamic"], button', { hasText: /deploy/i }).first().click();
+  } catch {
+    throw new Error(`[${tag}] PMK Deploy 버튼 없음`);
+  }
+
+  await page.waitForNavigation({ waitUntil: 'networkidle', timeout: 60_000 }).catch(() => null);
+
+  // 목록 복귀 후 ID 추출
+  await dismissWorkspaceModal(page);
+  await selectWorkspaceProject(page, tag);
+  await page.locator('#pmklist-table, #k8slist-table').first().waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+  await page.waitForTimeout(2_000);
+
+  const newRow = page.locator('#pmklist-table .tabulator-row, #k8slist-table .tabulator-row').filter({ hasText: clusterName }).first();
+  if (await newRow.count().catch(() => 0) > 0) {
+    await newRow.click();
+    await page.waitForTimeout(500);
+    const k8sId = await page.evaluate(() =>
+      (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentPmkId ??
+      (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentK8sId ?? ''
+    ) as string;
+    const id = k8sId || clusterName;
+    if (variant) { store.set(`k8sId_${variant}`, id); store.set(`k8sName_${variant}`, clusterName); }
+    store.set('k8sId', id); store.set('k8sName', clusterName); store.set('nsId', nsId);
+    console.log(`[${tag}] K8s 생성: ${clusterName} (${id})`);
+  } else {
+    throw new Error(`[${tag}] K8s ${clusterName} 목록 미표시`);
+  }
+}
+
+// ── TC-INFRA-DEPLOY-07: 기존 MCI에 SubGroup 추가 (Expert 모드) ──────────────
+
+async function runInfraDeploy07(ctx: StepRunContext, tag: string, variant?: string): Promise<void> {
+  const { page, store, scenarioId } = ctx;
+  const sc           = new ScenarioContext(scenarioId, 'TC-INFRA-DEPLOY-07', variant);
+  const subGroupName = (sc.params.subGroupName as string) ?? `sg-${variant ?? 'exp1'}`;
+  const provider     = (sc.params.provider     as string) ?? 'aws';
+  const region       = (sc.params.region       as string) ?? 'ap-northeast-2';
+  const connName     = (sc.params.connectionName as string) ?? 'aws-ap-northeast-2';
+  const specId       = (sc.params.commonSpec   as string) ?? '';
+  const subGroupSize = (sc.params.subGroupSize as string) ?? '1';
+  const fixedImgId   = (sc.params.imageId as string | undefined);
+
+  // store에서 mciName 가져오기 (이전 DEPLOY-05 OUT)
+  let targetMciName = (sc.params.mciName as string) ?? '';
+  if (!targetMciName) {
+    try { targetMciName = store.require<string>('mciName'); } catch { targetMciName = 'mci11'; }
+  }
+
+  const ok = await loginAndGoto(page, PAGES.operations.mciWorkloads, tag);
+  if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+
+  await dismissWorkspaceModal(page);
+  await selectWorkspaceProject(page, tag);
+
+  await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+  await page.waitForTimeout(1_500);
+
+  // 대상 MCI 행 선택
+  const mciRow = page.locator('#mcilist-table .tabulator-row').filter({
+    has: page.locator('.tabulator-cell').filter({ hasText: new RegExp(`^\\s*${targetMciName}\\s*$`) }),
+  }).first();
+  if (await mciRow.count().catch(() => 0) === 0) {
+    throw new Error(`[${tag}] MCI ${targetMciName} 목록에 없음`);
+  }
+  await mciRow.click();
+  await page.waitForTimeout(1_000);
+
+  // Add Server 버튼
+  const addServerBtn = page.locator(
+    'button[onclick*="addServer"], button[onclick*="addSubGroup"], ' +
+    'a[onclick*="addServer"], a[onclick*="addSubGroup"], ' +
+    'button:has-text("Add Server"), a:has-text("Add Server")'
+  ).first();
+  try {
+    await addServerBtn.waitFor({ state: 'visible', timeout: 10_000 });
+    await addServerBtn.click();
+    await page.waitForTimeout(800);
+  } catch {
+    throw new Error(`[${tag}] Add Server 버튼 없음`);
+  }
+
+  // Deployment Algorithm → Expert 선택
+  try {
+    const algoSel = page.locator('#mci_deploy_algorithm, [id*="deploy_algorithm"]').first();
+    await algoSel.waitFor({ state: 'visible', timeout: 5_000 });
+    await algoSel.selectOption('expert');
+    await page.waitForTimeout(800);
+  } catch (e) {
+    throw new Error(`[${tag}] Deployment Algorithm 선택 실패 — ${(e as Error).message?.slice(0, 60)}`);
+  }
+
+  // + VM 버튼
+  try {
+    const addVmBtn = page.locator(
+      'button[onclick*="addVm"], button[onclick*="addVM"], ' +
+      'button:has-text("+ VM"), button:has-text("+VM"), a:has-text("+ VM")'
+    ).first();
+    await addVmBtn.waitFor({ state: 'visible', timeout: 5_000 });
+    await addVmBtn.click();
+    await page.waitForTimeout(800);
+  } catch (e) {
+    throw new Error(`[${tag}] + VM 버튼 없음 — ${(e as Error).message?.slice(0, 60)}`);
+  }
+
+  await page.fill('[id*="subgroup_name"], [id*="sg_name"], [name*="subGroupName"]', subGroupName).catch(() => {});
+
+  // Provider 선택
+  try {
+    const provSel = page.locator('[id*="vm_provider"], [id*="expert"][id*="provider"]').first();
+    if (await provSel.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      const provOpt = await provSel.locator('option').filter({ hasText: new RegExp(provider, 'i') }).first().getAttribute('value');
+      await provSel.selectOption(provOpt ?? provider);
+      await page.waitForTimeout(800);
+    }
+  } catch { console.warn(`[${tag}] Provider 선택 실패`); }
+
+  // Region 선택
+  try {
+    const regionSel = page.locator('[id*="vm_region"], [id*="expert"][id*="region"]').first();
+    if (await regionSel.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await page.waitForFunction((reg: string) => {
+        const sel = document.querySelector('[id*="vm_region"], [id*="expert"][id*="region"]') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.value.toLowerCase().includes(reg.toLowerCase()) || o.text.toLowerCase().includes(reg.toLowerCase()));
+      }, region, { timeout: 8_000 }).catch(() => {});
+      const regionOpt = await regionSel.locator('option').filter({ hasText: new RegExp(region, 'i') }).first().getAttribute('value');
+      await regionSel.selectOption(regionOpt ?? region).catch(() => {});
+      await page.waitForTimeout(800);
+    }
+  } catch { console.warn(`[${tag}] Region 선택 실패`); }
+
+  // Connection 선택
+  if (connName) {
+    try {
+      const connSel = page.locator('[id*="vm_connection"], [id*="expert"][id*="connection"]').first();
+      if (await connSel.isVisible({ timeout: 5_000 }).catch(() => false)) {
+        await page.waitForFunction((conn: string) => {
+          const sel = document.querySelector('[id*="vm_connection"], [id*="expert"][id*="connection"]') as HTMLSelectElement;
+          return sel && Array.from(sel.options).some(o => o.value.toLowerCase().includes(conn.toLowerCase()) || o.text.toLowerCase().includes(conn.toLowerCase()));
+        }, connName, { timeout: 8_000 }).catch(() => {});
+        const connOpt = await connSel.locator('option').filter({ hasText: new RegExp(connName, 'i') }).first().getAttribute('value');
+        await connSel.selectOption(connOpt ?? connName).catch(() => {});
+        await page.waitForTimeout(800);
+      }
+    } catch { console.warn(`[${tag}] Connection 선택 실패`); }
+  }
+
+  // Spec 검색 모달 — vCPU 1→2→4 우선순위
+  try {
+    const specBtn = page.locator('[data-bs-target*="spec-search"], [onclick*="spec-search"]').first();
+    if (await specBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await specBtn.click();
+      await page.locator('[id*="spec-search"]').first().waitFor({ state: 'visible', timeout: 5_000 });
+      await page.locator('[id*="spec-search"] a[onclick*="getRecommend"]').first().click();
+      await page.locator('[id*="spec-search"] .tabulator-row:not(.tabulator-placeholder)').first().waitFor({ timeout: 30_000 });
+
+      const cspSpecName = specId.split('+').pop() ?? '';
+      await page.evaluate(
+        ({ specName }: { specName: string }) => {
+          const t = (window as unknown as { recommendTable?: { getData: () => Array<Record<string, unknown>>; deselectRow: () => void; getRows: () => Array<{ select: () => void }> } }).recommendTable;
+          if (!t) return;
+          const rows = t.getData();
+          let idx = -1;
+          if (specName) {
+            idx = rows.findIndex(r => ((r['cspSpecName'] as string) ?? '').toLowerCase().includes(specName.toLowerCase()));
+          }
+          if (idx < 0) {
+            for (const vcpu of [1, 2, 4]) {
+              const found = rows.findIndex(r => Number(r['vCPU']) === vcpu);
+              if (found >= 0) { idx = found; break; }
+            }
+          }
+          if (idx < 0) idx = 0;
+          t.deselectRow();
+          t.getRows()[idx]?.select();
+        },
+        { specName: cspSpecName },
+      );
+      await page.waitForTimeout(400);
+      await page.locator('[id*="spec-search"] button[onclick*="applySpec"]').first().click();
+      await page.locator('[id*="spec-search"]').first().waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
+    }
+  } catch (e) {
+    console.warn(`[${tag}] Spec 선택 실패 — ${(e as Error).message?.slice(0, 60)}`);
+  }
+
+  // Image (fixedImgId 지정 시)
+  if (fixedImgId) {
+    try {
+      const imgBtn = page.locator('[onclick*="validateAndOpenImageModal"], [data-bs-target*="image-search"]').first();
+      if (await imgBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+        await imgBtn.click();
+        await page.locator('#image-search').first().waitFor({ state: 'visible', timeout: 5_000 });
+        await selectImageForSpec(page, tag, fixedImgId);
+      }
+    } catch { console.warn(`[${tag}] Image 모달 처리 실패`); }
+  }
+
+  await page.fill('[id*="subgroup_size"], [name*="subGroupSize"]', subGroupSize).catch(() => {});
+
+  // Deploy
+  page.on('dialog', async d => { await d.accept(); });
+  try {
+    const deployBtn = page.locator(
+      'button[onclick*="deployAddServer"], button[onclick*="addSubGroup"], button[onclick*="deploySubGroup"], button',
+      { hasText: /deploy/i }
+    ).first();
+    await deployBtn.waitFor({ state: 'visible', timeout: 5_000 });
+    await deployBtn.click();
+  } catch {
+    throw new Error(`[${tag}] Deploy 버튼 없음`);
+  }
+
+  await page.waitForTimeout(3_000);
+  store.set('subGroupId',   subGroupName);
+  store.set('subGroupName', subGroupName);
+  console.log(`[${tag}] Add Server Expert 완료: mci=${targetMciName}, subGroup=${subGroupName}`);
+}
+
+// ── TC-INFRA-K8S-04: PMK 클러스터 생성 (Expert 모드) ──────────────────────
+
+async function runK8sCreateExpert(ctx: StepRunContext, tag: string, variant?: string): Promise<void> {
+  const { page, store, scenarioId } = ctx;
+  const sc          = new ScenarioContext(scenarioId, 'TC-INFRA-K8S-04', variant);
+  const nsId        = (sc.params.nsId         as string) ?? DEFAULT_NS;
+  const clusterName = (sc.params.clusterName  as string) ?? `k8s-${variant ?? 'exp1'}`;
+  const ngName      = (sc.params.nodeGroupName as string) ?? `png-${variant ?? 'exp1'}`;
+  const provider    = (sc.params.provider     as string) ?? 'ibm';
+  const region      = (sc.params.region       as string) ?? 'jp-tok';
+  const connName    = (sc.params.connectionName as string) ?? '';
+  const specId      = (sc.params.commonSpec   as string) ?? '';
+
+  const ok = await loginAndGoto(page, PAGES.operations.pmkWorkloads, tag);
+  if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+
+  await dismissWorkspaceModal(page);
+  await selectWorkspaceProject(page, tag);
+
+  await page.locator('#pmklist-table, #k8slist-table, table').first().waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+  await page.waitForTimeout(1_500);
+
+  // 이미 존재 확인
+  const listTable = page.locator('#pmklist-table, #k8slist-table').first();
+  const existRow  = listTable.locator('.tabulator-row').filter({ hasText: clusterName });
+  if (await existRow.count().catch(() => 0) > 0) {
+    await existRow.first().click();
+    await page.waitForTimeout(500);
+    const k8sId = await page.evaluate(() =>
+      (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentPmkId ??
+      (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentK8sId ?? ''
+    ) as string;
+    const id = k8sId || clusterName;
+    if (variant) { store.set(`k8sId_${variant}`, id); store.set(`k8sName_${variant}`, clusterName); }
+    store.set('k8sId', id); store.set('k8sName', clusterName); store.set('nsId', nsId);
+    console.log(`[${tag}] K8s 재사용 (Expert): ${clusterName} (${id})`);
+    return;
+  }
+
+  // Add Cluster 버튼
+  const addBtn = page.locator('#page-header-btn-list a[href="#createcluster"], #page-header-btn-list a', {
+    hasText: /Add.*Cluster|Add.*PMK/i,
+  }).first();
+  try {
+    await addBtn.waitFor({ state: 'visible', timeout: 10_000 });
+    await addBtn.click();
+    await page.locator('#createcluster').waitFor({ state: 'visible', timeout: 5_000 });
+  } catch {
+    throw new Error(`[${tag}] Add Cluster 버튼 없음`);
+  }
+
+  // Expert 모드 전환
+  try {
+    const expertBtn = page.locator(
+      'button[onclick*="toggleExpert"], a[onclick*="toggleExpert"], button:has-text("Expert"), a:has-text("Expert Creation")'
+    ).first();
+    await expertBtn.waitFor({ state: 'visible', timeout: 5_000 });
+    await expertBtn.click();
+    await page.locator('#create_expert').waitFor({ state: 'visible', timeout: 5_000 });
+    console.log(`[${tag}] Expert 모드 전환 완료`);
+  } catch (e) {
+    throw new Error(`[${tag}] Expert 모드 전환 실패 — ${(e as Error).message?.slice(0, 80)}`);
+  }
+
+  await page.fill('#cluster_name_expert, [id*="cluster"][id*="name"][id*="expert"]', clusterName).catch(() => {});
+  await page.fill('#nodegroup_name_expert, [id*="nodegroup"][id*="name"][id*="expert"]', ngName).catch(() => {});
+
+  // Provider 선택
+  try {
+    const provSel = page.locator('#cluster_provider_expert, [id*="expert"][id*="provider"]').first();
+    await provSel.waitFor({ state: 'visible', timeout: 5_000 });
+    const provOpt = await provSel.locator('option').filter({ hasText: new RegExp(provider, 'i') }).first().getAttribute('value');
+    await provSel.selectOption(provOpt ?? provider);
+    await page.waitForTimeout(800);
+  } catch { console.warn(`[${tag}] Provider 선택 실패`); }
+
+  // Region 선택
+  try {
+    const regionSel = page.locator('#cluster_region_expert, [id*="expert"][id*="region"]').first();
+    await regionSel.waitFor({ state: 'visible', timeout: 8_000 });
+    await page.waitForFunction((reg: string) => {
+      const sel = document.querySelector('#cluster_region_expert, [id*="expert"][id*="region"]') as HTMLSelectElement;
+      return sel && Array.from(sel.options).some(o => o.value.toLowerCase().includes(reg.toLowerCase()) || o.text.toLowerCase().includes(reg.toLowerCase()));
+    }, region, { timeout: 10_000 }).catch(() => {});
+    const regionOpt = await regionSel.locator('option').filter({ hasText: new RegExp(region, 'i') }).first().getAttribute('value');
+    await regionSel.selectOption(regionOpt ?? region);
+    await page.waitForTimeout(800);
+  } catch { console.warn(`[${tag}] Region 선택 실패`); }
+
+  // Connection 선택
+  if (connName) {
+    try {
+      await page.waitForFunction((conn: string) => {
+        const sel = document.querySelector('#cluster_cloudconnection_expert, [id*="expert"][id*="connection"]') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.value.toLowerCase().includes(conn.toLowerCase()) || o.text.toLowerCase().includes(conn.toLowerCase()));
+      }, connName, { timeout: 10_000 }).catch(() => {});
+      const connSel = page.locator('#cluster_cloudconnection_expert, [id*="expert"][id*="connection"]').first();
+      const connOpt = await connSel.locator('option').filter({ hasText: new RegExp(connName, 'i') }).first().getAttribute('value');
+      await connSel.selectOption(connOpt ?? connName);
+      await page.waitForTimeout(800);
+    } catch { console.warn(`[${tag}] Connection ${connName} 선택 실패`); }
+  }
+
+  // Spec 검색 모달 — vCPU 2→4 우선순위
+  try {
+    const specBtn = page.locator('#create_expert [data-bs-target*="spec-search-pmk"], #create_expert [onclick*="spec-search-pmk"]').first();
+    await specBtn.waitFor({ state: 'visible', timeout: 5_000 });
+    await specBtn.click();
+    await page.locator('#spec-search-pmk').waitFor({ state: 'visible', timeout: 5_000 });
+    await page.locator('#spec-search-pmk a[onclick*="getRecommendVmInfoPmk"], #spec-search-pmk a[onclick*="getRecommendVmInfo"]').first().click();
+    await page.locator('#spec-search-pmk .tabulator-row:not(.tabulator-placeholder)').first().waitFor({ timeout: 30_000 });
+
+    const cspSpecName = specId.split('+').pop() ?? '';
+    await page.evaluate(
+      ({ specName }: { specName: string }) => {
+        const t = (window as unknown as { recommendTablePmk?: { getData: () => Array<Record<string, unknown>>; deselectRow: () => void; getRows: () => Array<{ select: () => void }> } }).recommendTablePmk;
+        if (!t) return;
+        const rows = t.getData();
+        let idx = -1;
+        if (specName) {
+          idx = rows.findIndex(r => ((r['cspSpecName'] as string) ?? '').toLowerCase().includes(specName.toLowerCase()));
+        }
+        if (idx < 0) {
+          for (const vcpu of [2, 4]) {
+            const found = rows.findIndex(r => Number(r['vCPU']) === vcpu);
+            if (found >= 0) { idx = found; break; }
+          }
+        }
+        if (idx < 0) idx = 0;
+        t.deselectRow();
+        t.getRows()[idx]?.select();
+      },
+      { specName: cspSpecName },
+    );
+    await page.waitForTimeout(400);
+    await page.locator('#spec-search-pmk button[onclick*="applySpecInfo"]').click();
+    await page.locator('#spec-search-pmk').waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
+  } catch (e) {
+    console.warn(`[${tag}] PMK Spec 선택 실패 (Expert) — ${(e as Error).message?.slice(0, 60)}`);
+  }
+
+  // Deploy (Expert 폼)
+  page.on('dialog', async d => { await d.accept(); });
+  try {
+    const deployBtn = page.locator('#create_expert button[onclick*="deployPmk"], #create_expert button', { hasText: /deploy/i }).first();
+    await deployBtn.waitFor({ state: 'visible', timeout: 5_000 });
+    await deployBtn.click();
+  } catch {
+    try {
+      await page.locator('button[onclick*="deployPmkExpert"], button[onclick*="deployPmk"]').first().click();
+    } catch {
+      throw new Error(`[${tag}] PMK Deploy 버튼 없음 (Expert)`);
+    }
+  }
+
+  await page.waitForNavigation({ waitUntil: 'networkidle', timeout: 60_000 }).catch(() => null);
+  await dismissWorkspaceModal(page);
+  await selectWorkspaceProject(page, tag);
+  await page.locator('#pmklist-table, #k8slist-table').first().waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+  await page.waitForTimeout(2_000);
+
+  const newRow = page.locator('#pmklist-table .tabulator-row, #k8slist-table .tabulator-row').filter({ hasText: clusterName }).first();
+  if (await newRow.count().catch(() => 0) > 0) {
+    await newRow.click();
+    await page.waitForTimeout(500);
+    const k8sId = await page.evaluate(() =>
+      (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentPmkId ??
+      (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentK8sId ?? ''
+    ) as string;
+    const id = k8sId || clusterName;
+    if (variant) { store.set(`k8sId_${variant}`, id); store.set(`k8sName_${variant}`, clusterName); }
+    store.set('k8sId', id); store.set('k8sName', clusterName); store.set('nsId', nsId);
+    console.log(`[${tag}] K8s Expert 생성 완료: ${clusterName} (${id})`);
+  } else {
+    throw new Error(`[${tag}] K8s ${clusterName} 목록 미표시`);
+  }
+}
+
+// ── 메인 디스패처 ──────────────────────────────────────────────────────────
+
+export async function runScenarioStep(ctx: StepRunContext): Promise<void> {
+  const { page, store, scenarioId, step } = ctx;
+  const tag     = `${scenarioId}/Step${step.order}`;
+  const tcId    = step.tcId;
+  const variant = step.variant;
+
+  // ── IAM ──────────────────────────────────────────────────────────────────
+  if (tcId.startsWith('TC-IAM-AUTH-01')) {
+    const ok = await loginAndGoto(page, PAGES.operations.workspaces, tag);
+    expect(ok, `[${tag}] 로그인 또는 워크스페이스 화면 진입 실패`).toBeTruthy();
+    await expect(page).toHaveURL(/workspaces/);
+    return;
+  }
+  if (tcId.startsWith('TC-IAM-AUTH-05')) {
+    const ok = await loginAndGoto(page, PAGES.auth.signup, tag);
+    expect(ok, `[${tag}] 회원가입 화면 진입 실패`).toBeTruthy();
+    await expect(page).toHaveURL(/signup/);
+    return;
+  }
+  if (tcId.startsWith('TC-IAM-UG-03')) {
+    const ok = await loginAndGoto(page, PAGES.settings.users, tag);
+    expect(ok, `[${tag}] 사용자 목록 화면 진입 실패`).toBeTruthy();
+    await expect(page).toHaveURL(/users/);
+    return;
+  }
+  if (tcId.startsWith('TC-IAM-UG-08') || tcId.startsWith('TC-IAM-UG-11')) {
+    const ok = await loginAndGoto(page, PAGES.settings.groups, tag);
+    expect(ok, `[${tag}] 그룹 목록 화면 진입 실패`).toBeTruthy();
+    await expect(page).toHaveURL(/groups/);
+    return;
+  }
+  if (tcId.startsWith('TC-IAM-RBAC-06')) {
+    const ok = await loginAndGoto(page, PAGES.settings.roles, tag);
+    expect(ok, `[${tag}] 역할 목록 화면 진입 실패`).toBeTruthy();
+    await expect(page).toHaveURL(/roles/);
+    return;
+  }
+  if (tcId.startsWith('TC-IAM-WS-')) {
+    const ok = await loginAndGoto(page, PAGES.operations.workspaces, tag);
+    expect(ok, `[${tag}] 워크스페이스 화면 진입 실패`).toBeTruthy();
+    await expect(page).toHaveURL(/workspaces/);
+    return;
+  }
+  if (tcId.startsWith('TC-IAM-USER-LIFECYCLE-')) {
+    const ok = await loginAndGoto(page, PAGES.settings.approvals, tag);
+    expect(ok, `[${tag}] 승인 요청 화면 진입 실패`).toBeTruthy();
+    await expect(page).toHaveURL(/approvals/);
+    return;
+  }
+
+  // ── CSP ──────────────────────────────────────────────────────────────────
+  if (tcId.startsWith('TC-CSP-CREDENTIAL-03')) {
+    const ok = await loginAndGoto(page, PAGES.settings.credentials, tag);
+    expect(ok, `[${tag}] CSP 자격증명 화면 진입 실패`).toBeTruthy();
+    await expect(page).toHaveURL(/credentials/);
+    return;
+  }
+  if (tcId.startsWith('TC-CSP-CONNECTION-02')) {
+    const ok = await loginAndGoto(page, PAGES.settings.connections, tag);
+    expect(ok, `[${tag}] CSP 연결 화면 진입 실패`).toBeTruthy();
+    await expect(page).toHaveURL(/connections/);
+    return;
+  }
+
+  // ── INFRA ────────────────────────────────────────────────────────────────
+  if (tcId === 'TC-INFRA-DEPLOY-05') {
+    await runInfraDeploy05(ctx, tag, variant);
+    return;
+  }
+  if (tcId === 'TC-INFRA-DEPLOY-07') {
+    await runInfraDeploy07(ctx, tag, variant);
+    return;
+  }
+  if (tcId === 'TC-INFRA-DEPLOY-01') {
+    await runInfraDeployList(ctx, tag);
+    return;
+  }
+  if (tcId === 'TC-INFRA-DEPLOY-02') {
+    // mciId 없어도 목록 화면을 로드해 상태 확인 — 화면 조회 결과에서 선택
+    await runInfraDeployList(ctx, tag);
+    return;
+  }
+  if (tcId === 'TC-INFRA-LC-01' || tcId === 'TC-INFRA-LC-01a') {
+    // TC-INFRA-LC-01a: suspend (Running → Stopped)
+    await runInfraLc01(ctx, tag, 'suspend');
+    return;
+  }
+  if (tcId === 'TC-INFRA-LC-01b') {
+    // TC-INFRA-LC-01b: resume (Stopped → Running)
+    await runInfraLc01(ctx, tag, 'resume');
+    return;
+  }
+  if (tcId === 'TC-INFRA-LC-01c') {
+    // TC-INFRA-LC-01c: reboot (Stopped → Running)
+    await runInfraLc01(ctx, tag, 'reboot');
+    return;
+  }
+  if (tcId === 'TC-INFRA-LC-02') {
+    await runInfraLc02(ctx, tag);
+    return;
+  }
+  if (tcId === 'TC-INFRA-LC-03') {
+    await runInfraLc03(ctx, tag);
+    return;
+  }
+  if (tcId.startsWith('TC-INFRA-SSH-02')) {
+    const ok = await loginAndGoto(page, PAGES.settings.sshKeys, tag);
+    if (ok) console.log(`[${tag}] SSH Keys UI OK`);
+    return;
+  }
+  if (tcId === 'TC-INFRA-K8S-03') {
+    await runK8sCreate(ctx, tag, variant);
+    return;
+  }
+  if (tcId === 'TC-INFRA-K8S-04') {
+    await runK8sCreateExpert(ctx, tag, variant);
+    return;
+  }
+  if (tcId.startsWith('TC-INFRA-K8S-07')) {
+    const ok = await loginAndGoto(page, PAGES.operations.pmkWorkloads, tag);
+    if (ok) console.log(`[${tag}] PMK Workloads UI OK`);
+    return;
+  }
+  if (tcId === 'TC-INFRA-K8S-08') {
+    await runK8sDelete(ctx, tag, variant);
+    return;
+  }
+
+  // ── SW / APP ─────────────────────────────────────────────────────────────
+  if (tcId.startsWith('TC-APP-CAT-03')) {
+    await runAppCatSearch(ctx, tag);
+    return;
+  }
+  if (tcId.startsWith('TC-APP-CAT-04')) {
+    await runAppCatUpload(ctx, tag);
+    return;
+  }
+  if (tcId.startsWith('TC-APP-CAT-05') || tcId.startsWith('TC-SW-CATALOG-01')) {
+    await runAppCatRegist(ctx, tag);
+    return;
+  }
+  if (tcId.startsWith('TC-APP-DEP-01') || tcId.startsWith('TC-SW-CATALOG-02')) {
+    await runAppDeploy(ctx, tag, variant);
+    return;
+  }
+  if (tcId.startsWith('TC-APP-REP-')) {
+    throw new Error(`[${tag}] ${tcId}: Repository 등록 동작 미구현`);
+  }
+  if (tcId.startsWith('TC-APP-APPS-01')) {
+    await runAppApps01(ctx, tag);
+    return;
+  }
+  if (tcId.startsWith('TC-APP-APPS-02')) {
+    await runAppApps02(ctx, tag);
+    return;
+  }
+  if (tcId.startsWith('TC-APP-APPS-03') || tcId.startsWith('TC-APP-APPS-04')) {
+    throw new Error(`[${tag}] ${tcId}: 운영 액션 동작 미구현`);
+  }
+  if (tcId.startsWith('TC-SW-CATALOG-03')) {
+    failStep(tag, 'SW undeploy — API 미구현 (TODO)');
+  }
+
+  // ── OBS (C6-01~07): observability iframe 기반 테스트 ──────────────────────
+  // 외부 URL: /webconsole/operations/analytics/observability
+  // 내부 iframe: https://<host>:18081/embed/...
+  //   /embed/monitoring/{ns}  → MCI 개요 (Node/K8s 탭)
+  //   /embed/config/{ns}      → Monitor Setting (Agent 설치/상태 테이블)
+  //   /embed/log/{ns}         → 워크로드 상세 (Monitoring|Logs|Config|Insight|Alerts|Tracing 탭)
+  if (tcId.startsWith('TC-OBS-')) {
+    if (tcId === 'TC-OBS-AGENT-01') { await runObsAgent01(ctx, tag); return; }
+    if (tcId === 'TC-OBS-AGENT-02') { await runObsAgent02(ctx, tag); return; }
+    if (tcId === 'TC-OBS-AGENT-03') { await runObsAgent03(ctx, tag); return; }
+    if (tcId === 'TC-OBS-INSIGHT-01') { await runObsInsight01(ctx, tag); return; }
+    if (tcId === 'TC-OBS-INSIGHT-02') { await runObsInsight02(ctx, tag); return; }
+    if (tcId === 'TC-OBS-INSIGHT-03') { await runObsInsight03(ctx, tag); return; }
+    if (tcId === 'TC-OBS-INSIGHT-04') { await runObsInsight04(ctx, tag); return; }
+    if (tcId === 'TC-OBS-LOG-01') { await runObsLog01(ctx, tag); return; }
+    if (tcId === 'TC-OBS-LOG-02') { await runObsLog02(ctx, tag); return; }
+    if (tcId === 'TC-OBS-TRACE-01') { await runObsTrace01(ctx, tag); return; }
+    if (tcId === 'TC-OBS-TRACE-02') { await runObsTrace02(ctx, tag); return; }
+    if (tcId === 'TC-OBS-TRACE-03') { await runObsTrace03(ctx, tag); return; }
+    if (tcId === 'TC-OBS-TRIG-01')  { await runObsTrig01(ctx, tag); return; }
+    if (tcId === 'TC-OBS-TRIG-02')  { await runObsTrig02(ctx, tag); return; }
+    if (tcId === 'TC-OBS-TRIG-03')  { await runObsTrig03(ctx, tag); return; }
+    if (tcId === 'TC-OBS-TRIG-04')  { await runObsTrig04(ctx, tag); return; }
+    if (tcId === 'TC-OBS-TRIG-05')  { await runObsTrig05(ctx, tag); return; }
+    await runObsIframeGeneric(ctx, tag, tcId);
+    return;
+  }
+
+  // ── COST ─────────────────────────────────────────────────────────────────
+  if (tcId.startsWith('TC-COSTOPT-BILL-') || tcId === 'TC-COSTOPT-IFRAME-01') {
+    const ok = await loginAndGoto(page, PAGES.operations.costAnalysis, tag);
+    if (ok) console.log(`[${tag}] Cost Analysis UI OK`);
+    return;
+  }
+
+  // ── COST INIT: CUR 데이터 수집 설정 (TC-COSTOPT-INIT-01~04) ───────────
+  if (tcId === 'TC-COSTOPT-INIT-01' || tcId === 'TC-COSTOPT-INIT-02' ||
+      tcId === 'TC-COSTOPT-INIT-03' || tcId === 'TC-COSTOPT-INIT-04') {
+    const ok = await loginAndGoto(page, PAGES.operations.costAnalysis, tag);
+    if (!ok) throw new Error(`[${tag}] Cost Analysis 페이지 진입 실패`);
+    // TODO: CUR 설정 UI 탐색 후 구현 — 페이지 URL 확인 필요
+    // variant: aws | ncp | azure | gcp
+    console.log(`[${tag}] ${tcId} (variant=${variant ?? 'base'}) — CUR 설정 UI 구현 대기`);
+    throw new Error(`[${tag}] ${tcId} 미구현 — Cost Optimizer CUR 설정 UI 탐색 후 구현 필요`);
+  }
+
+  // ── COST INIT: 알림·LLM 채널 설정 (TC-COSTOPT-INIT-05~06) ───────────
+  if (tcId === 'TC-COSTOPT-INIT-05' || tcId === 'TC-COSTOPT-INIT-06') {
+    const ok = await loginAndGoto(page, PAGES.operations.costAnalysis, tag);
+    if (!ok) throw new Error(`[${tag}] Cost Analysis 페이지 진입 실패`);
+    // TODO: 알림/LLM 채널 설정 UI 탐색 후 구현 — 설정 페이지 URL 확인 필요
+    console.log(`[${tag}] ${tcId} — 채널 설정 UI 구현 대기`);
+    throw new Error(`[${tag}] ${tcId} 미구현 — 알림/LLM 채널 설정 UI 탐색 후 구현 필요`);
+  }
+
+  // ── COST OPER: 비용 수집 알람 수신 (TC-COSTOPT-OPER-01~02) ──────────
+  if (tcId === 'TC-COSTOPT-OPER-01' || tcId === 'TC-COSTOPT-OPER-02') {
+    const ok = await loginAndGoto(page, PAGES.operations.costAnalysis, tag);
+    if (!ok) throw new Error(`[${tag}] Cost Analysis 페이지 진입 실패`);
+    // TODO: 비용 수집 트리거 + 알람 수신 UI 탐색 후 구현
+    // OPER-02: variant='dump' 일 때 덤프 데이터 활용 경로
+    console.log(`[${tag}] ${tcId} (variant=${variant ?? 'base'}) — 비용 수집 알람 UI 구현 대기`);
+    throw new Error(`[${tag}] ${tcId} 미구현 — 비용 수집 알람 수신 UI 탐색 후 구현 필요`);
+  }
+
+  // ── COST OPER: ML/LLM 자원 추천 (TC-COSTOPT-OPER-03) ────────────────
+  if (tcId === 'TC-COSTOPT-OPER-03') {
+    const ok = await loginAndGoto(page, PAGES.operations.costAnalysis, tag);
+    if (!ok) throw new Error(`[${tag}] Cost Analysis 페이지 진입 실패`);
+    // TODO: 자원 추천 결과 UI 탐색 후 구현
+    console.log(`[${tag}] ${tcId} — ML/LLM 자원 추천 UI 구현 대기`);
+    throw new Error(`[${tag}] ${tcId} 미구현 — ML/LLM 자원 추천 UI 탐색 후 구현 필요`);
+  }
+
+  // ── WORKFLOW — 공통 헬퍼 ────────────────────────────────────────────────────
+
+  // iframe(mc-workflow-manager-fe) 탐색 공통 헬퍼
+  const _getWfIframe = async () => {
+    await selectWorkspaceProject(page, tag);
+    await page.waitForTimeout(3000);
+    return page.frames().find(f => f.url().includes('workflow') && !f.url().includes('webconsole'));
+  };
+
+  const _enterElTab = async (frame: import('@playwright/test').Frame) => {
+    const t = frame.locator('a, button, [role="tab"], .nav-link, li')
+      .filter({ hasText: /event.?listener|이벤트.?리스너/i }).first();
+    const ok = await t.waitFor({ state: 'visible', timeout: 10_000 }).then(() => true).catch(() => false);
+    if (ok) { await t.click(); await page.waitForTimeout(1000); }
+    return ok;
+  };
+
+  const _getElCallUrl = async (
+    frame: import('@playwright/test').Frame,
+    elRow: import('@playwright/test').Locator,
+  ): Promise<string> => {
+    const cell = elRow.locator('td, .tabulator-cell').filter({ hasText: /http/i }).first();
+    if (await cell.count() > 0) {
+      const txt = (await cell.textContent() ?? '').trim();
+      if (txt.startsWith('http')) return txt;
+    }
+    const detailBtn = elRow.locator('button, a').filter({ hasText: /detail|상세|보기/i }).first();
+    if (await detailBtn.count() > 0) {
+      await detailBtn.click();
+      await page.waitForTimeout(1000);
+      const urlEl = frame.locator('[class*="callUrl"], [class*="call-url"], input[readonly]').first();
+      if (await urlEl.count() > 0) {
+        return ((await urlEl.inputValue().catch(() => '')) || (await urlEl.textContent() ?? '')).trim();
+      }
+    }
+    return '';
+  };
+
+  // ── WORKFLOW — Event Listener (TC-WF-EL-01 ~ 07) ─────────────────────────
+
+  if (tcId === 'TC-WF-EL-01') {
+    // Event Listener 목록 조회 — iframe > EL 탭 진입 후 목록 영역 확인
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+    const f = await _getWfIframe();
+    if (!f) { throw new Error(`[${tag}] WF iframe 미발견`); }
+    if (!await _enterElTab(f)) { throw new Error(`[${tag}] EL 탭 미발견`); }
+    console.log(`[${tag}] Event Listener 탭 진입 완료`);
+    const listArea = f.locator('table, .tabulator, [class*="list"], [class*="empty"]').first();
+    const listVisible = await listArea.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false);
+    console.log(`[${tag}] Event Listener 목록 영역: ${listVisible ? '확인' : '미확인'}`);
+    return;
+  }
+
+  if (tcId === 'TC-WF-EL-02') {
+    // 신규 Event Listener 생성 — EL 탭 > 생성 폼 작성 (이름 + 연결 워크플로우) > 제출
+    const sc = new ScenarioContext(scenarioId, 'TC-WF-EL-02', variant);
+    const p  = sc.params;
+    const elName = (p.eventListenerName as string | undefined) ?? 'infra-create-el';
+    const wfName = (p.workflowName as string | undefined) ?? '';
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+    const f = await _getWfIframe();
+    if (!f) { throw new Error(`[${tag}] WF iframe 미발견`); }
+    if (!await _enterElTab(f)) { throw new Error(`[${tag}] EL 탭 미발견`); }
+
+    // 이미 존재하면 skip
+    if (await f.locator('tr, .tabulator-row, [class*="row"]').filter({ hasText: elName }).count() > 0) {
+      console.log(`[${tag}] EL '${elName}' 이미 존재`);
+      store.set('elName', elName); return;
+    }
+
+    const createBtn = f.locator('button').filter({ hasText: /create|등록|추가|새로\s*만들기|New/i }).first();
+    if (await createBtn.count() === 0) { throw new Error(`[${tag}] 생성 버튼 미발견`); }
+    await createBtn.click();
+    await page.waitForTimeout(1000);
+
+    const nameInput = f.locator('input[name*="name" i], input[placeholder*="name" i], input[id*="name" i]').first();
+    if (await nameInput.count() > 0) { await nameInput.fill(elName); console.log(`[${tag}] EL 이름: ${elName}`); }
+
+    if (wfName) {
+      const sel = f.locator('select').first();
+      if (await sel.count() > 0) {
+        await sel.selectOption({ label: wfName }).catch(() =>
+          sel.selectOption({ value: wfName }).catch(() => warn(tag, `WF '${wfName}' 선택 실패`)),
+        );
+        console.log(`[${tag}] 연결 워크플로우: ${wfName}`);
+      }
+    }
+
+    const submitBtn = f.locator('button[type="submit"], button').filter({ hasText: /submit|저장|확인|등록|OK/i }).last();
+    if (await submitBtn.count() === 0) { throw new Error(`[${tag}] 등록 버튼 미발견`); }
+    let createStatus = 0;
+    page.on('response', res => { if (res.url().includes('/eventlistener') && res.request().method() === 'POST') createStatus = res.status(); });
+    await submitBtn.click();
+    await page.waitForTimeout(2000);
+    if (createStatus > 0) console.log(`[${tag}] POST /eventlistener HTTP ${createStatus}`);
+    console.log(`[${tag}] EL '${elName}' 등록 요청 완료`);
+    store.set('elName', elName);
+    return;
+  }
+
+  if (tcId === 'TC-WF-EL-03') {
+    // Event Listener 이름 중복 검사 — 동일 이름으로 재생성 시도 후 오류 메시지 확인
+    const sc = new ScenarioContext(scenarioId, 'TC-WF-EL-03', variant);
+    const p  = sc.params;
+    const elName = (p.eventListenerName as string | undefined) ?? store.getOrDefault<string>('elName', 'infra-create-el');
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+    const f = await _getWfIframe();
+    if (!f) { throw new Error(`[${tag}] WF iframe 미발견`); }
+    if (!await _enterElTab(f)) { throw new Error(`[${tag}] EL 탭 미발견`); }
+
+    const createBtn = f.locator('button').filter({ hasText: /create|등록|추가|새로\s*만들기|New/i }).first();
+    if (await createBtn.count() === 0) { throw new Error(`[${tag}] 생성 버튼 미발견`); }
+    await createBtn.click();
+    await page.waitForTimeout(1000);
+
+    const nameInput = f.locator('input[name*="name" i], input[placeholder*="name" i], input[id*="name" i]').first();
+    if (await nameInput.count() > 0) { await nameInput.fill(elName); await nameInput.press('Tab'); }
+    await page.waitForTimeout(1000);
+
+    const errMsg = f.locator('[class*="error"], [class*="invalid"], .alert, .text-danger')
+      .filter({ hasText: /중복|duplicate|already|exist/i }).first();
+    const hasDupError = await errMsg.waitFor({ state: 'visible', timeout: 5_000 }).then(() => true).catch(() => false);
+    console.log(`[${tag}] 이름 중복 오류 메시지: ${hasDupError ? '확인' : '미확인'}`);
+
+    const cancelBtn = f.locator('button').filter({ hasText: /cancel|취소/i }).first();
+    if (await cancelBtn.count() > 0) await cancelBtn.click();
+    else await page.keyboard.press('Escape');
+    await page.waitForTimeout(500);
+    return;
+  }
+
+  if (tcId === 'TC-WF-EL-04') {
+    // Event Listener 상세 수정 — EL 행 > 수정 버튼 > 내용 변경 > 저장
+    const sc = new ScenarioContext(scenarioId, 'TC-WF-EL-04', variant);
+    const p  = sc.params;
+    const elName = (p.eventListenerName as string | undefined) ?? store.getOrDefault<string>('elName', '');
+    if (!elName) { throw new Error(`[${tag}] elName 없음`); }
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+    const f = await _getWfIframe();
+    if (!f) { throw new Error(`[${tag}] WF iframe 미발견`); }
+    if (!await _enterElTab(f)) { throw new Error(`[${tag}] EL 탭 미발견`); }
+
+    const elRow = f.locator('tr, .tabulator-row, [class*="row"]').filter({ hasText: elName }).first();
+    if (!await elRow.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false)) {
+      throw new Error(`[${tag}] EL '${elName}' 없음`);
+    }
+
+    const editBtn = elRow.locator('button, a').filter({ hasText: /edit|수정|편집/i }).first();
+    if (await editBtn.count() === 0) { throw new Error(`[${tag}] 수정 버튼 미발견`); }
+    await editBtn.click();
+    await page.waitForTimeout(1000);
+
+    const descInput = f.locator('input[name*="desc" i], textarea[name*="desc" i], input[placeholder*="desc" i]').first();
+    if (await descInput.count() > 0) {
+      const cur = await descInput.inputValue().catch(() => '');
+      await descInput.fill(cur ? `${cur} (수정)` : '수정된 설명');
+    }
+
+    let updateStatus = 0;
+    page.on('response', res => { if (res.url().includes('/eventlistener') && res.request().method() === 'PATCH') updateStatus = res.status(); });
+    const saveBtn = f.locator('button[type="submit"], button').filter({ hasText: /save|저장|확인|수정|OK/i }).last();
+    if (await saveBtn.count() > 0) { await saveBtn.click(); await page.waitForTimeout(2000); }
+    if (updateStatus > 0) console.log(`[${tag}] PATCH /eventlistener HTTP ${updateStatus}`);
+    console.log(`[${tag}] EL '${elName}' 수정 완료`);
+    return;
+  }
+
+  if (tcId === 'TC-WF-EL-05') {
+    // Event Listener 삭제 — EL 행 > 삭제 버튼 > 확인 다이얼로그
+    const sc = new ScenarioContext(scenarioId, 'TC-WF-EL-05', variant);
+    const p  = sc.params;
+    const elName = (p.eventListenerName as string | undefined) ?? store.getOrDefault<string>('elName', '');
+    if (!elName) { throw new Error(`[${tag}] elName 없음`); }
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+    const f = await _getWfIframe();
+    if (!f) { throw new Error(`[${tag}] WF iframe 미발견`); }
+    if (!await _enterElTab(f)) { throw new Error(`[${tag}] EL 탭 미발견`); }
+
+    const elRow = f.locator('tr, .tabulator-row, [class*="row"]').filter({ hasText: elName }).first();
+    if (await elRow.count() === 0) { console.log(`[${tag}] EL '${elName}' 없음 — 이미 삭제됨`); return; }
+
+    const delBtn = elRow.locator('button, a').filter({ hasText: /del|delete|삭제/i }).first();
+    if (await delBtn.count() === 0) { throw new Error(`[${tag}] 삭제 버튼 미발견`); }
+    await delBtn.click();
+    await page.waitForTimeout(500);
+    const confirmBtn = page.locator('.swal2-confirm, .modal.show button').filter({ hasText: /확인|OK|Yes|삭제/i }).first();
+    if (await confirmBtn.count() > 0) await confirmBtn.click();
+    await page.waitForTimeout(1500);
+    console.log(`[${tag}] EL '${elName}' 삭제 완료`);
+    return;
+  }
+
+  if (tcId === 'TC-WF-EL-06') {
+    // Event Listener GET Trigger — EL callUrl(GET)로 워크플로우 실행
+    const sc = new ScenarioContext(scenarioId, 'TC-WF-EL-06', variant);
+    const p  = sc.params;
+    const elName = (p.eventListenerName as string | undefined) ?? store.getOrDefault<string>('elName', '');
+    if (!elName) { throw new Error(`[${tag}] elName 없음`); }
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+    const f = await _getWfIframe();
+    if (!f) { throw new Error(`[${tag}] WF iframe 미발견`); }
+    await _enterElTab(f);
+
+    const elRow = f.locator('tr, .tabulator-row, [class*="row"]').filter({ hasText: elName }).first();
+    if (!await elRow.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false)) {
+      throw new Error(`[${tag}] EL '${elName}' 없음`);
+    }
+    const callUrl = await _getElCallUrl(f, elRow);
+    if (!callUrl || !callUrl.startsWith('http')) {
+      throw new Error(`[${tag}] callUrl 미발견`);
+    }
+    console.log(`[${tag}] EL callUrl (GET): ${callUrl}`);
+    const resp = await page.request.get(callUrl, { ignoreHTTPSErrors: true }).catch(() => null);
+    const httpStatus = resp?.status() ?? 0;
+    console.log(`[${tag}] GET trigger HTTP ${httpStatus}`);
+    if (httpStatus >= 200 && httpStatus < 300) {
+      console.log(`[${tag}] EL '${elName}' GET Trigger → 워크플로우 실행 완료`);
+    } else {
+      warn(tag, `GET trigger 응답 ${httpStatus}`);
+    }
+    return;
+  }
+
+  if (tcId === 'TC-WF-EL-07') {
+    // Event Listener POST Trigger — EL callUrl(POST)로 파라미터 포함 워크플로우 실행
+    const sc = new ScenarioContext(scenarioId, 'TC-WF-EL-07', variant);
+    const p  = sc.params;
+    const elName = (p.eventListenerName as string | undefined) ?? store.getOrDefault<string>('elName', '');
+    if (!elName) { throw new Error(`[${tag}] elName 없음`); }
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+    const f = await _getWfIframe();
+    if (!f) { throw new Error(`[${tag}] WF iframe 미발견`); }
+    await _enterElTab(f);
+
+    const elRow = f.locator('tr, .tabulator-row, [class*="row"]').filter({ hasText: elName }).first();
+    if (!await elRow.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false)) {
+      throw new Error(`[${tag}] EL '${elName}' 없음`);
+    }
+    const callUrl = await _getElCallUrl(f, elRow);
+    if (!callUrl || !callUrl.startsWith('http')) {
+      throw new Error(`[${tag}] callUrl 미발견`);
+    }
+    console.log(`[${tag}] EL callUrl (POST): ${callUrl}`);
+    const triggerBody = (p.triggerBody as Record<string, unknown> | undefined) ?? {};
+    const resp = await page.request.post(callUrl, { data: triggerBody, ignoreHTTPSErrors: true }).catch(() => null);
+    const httpStatus = resp?.status() ?? 0;
+    console.log(`[${tag}] POST trigger HTTP ${httpStatus}`);
+    if (httpStatus >= 200 && httpStatus < 300) {
+      console.log(`[${tag}] EL '${elName}' POST Trigger → 워크플로우 실행 완료`);
+    } else {
+      warn(tag, `POST trigger 응답 ${httpStatus}`);
+    }
+    return;
+  }
+
+  // ── WORKFLOW — Flow (TC-WF-FLOW-01 ~ 07) ─────────────────────────────────
+
+  if (tcId === 'TC-WF-FLOW-01') {
+    // Workflow Engine(Jenkins) 등록 및 연동 확인 — OSS 목록 조회 후 연결 상태 확인
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+    await page.waitForLoadState('networkidle');
+    // OSS/Engine 탭 진입 시도
+    const ossTab = page.locator('a, button, [role="tab"], .nav-link')
+      .filter({ hasText: /OSS|jenkins|engine|엔진/i }).first();
+    if (await ossTab.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false)) {
+      await ossTab.click();
+      await page.waitForTimeout(1000);
+      console.log(`[${tag}] OSS/Engine 탭 진입`);
+    } else {
+      console.log(`[${tag}] OSS 탭 미발견 — API 조회로 대체`);
+    }
+    const ossListResp = await page.request.get('/api/mc-workflow-manager/oss/list', { ignoreHTTPSErrors: true }).catch(() => null);
+    const ossStatus = ossListResp?.status() ?? 0;
+    console.log(`[${tag}] GET /oss/list HTTP ${ossStatus}`);
+    if (ossStatus >= 200 && ossStatus < 300) {
+      const body = await ossListResp!.json().catch(() => []);
+      const count = Array.isArray(body) ? body.length : (body?.data?.length ?? 0);
+      console.log(`[${tag}] 등록된 OSS(WF Engine) 수: ${count}`);
+      if (count === 0) warn(tag, 'OSS(Jenkins) 미등록 — Engine 설정 필요');
+    } else {
+      warn(tag, `OSS API 비정상 (HTTP ${ossStatus})`);
+    }
+    return;
+  }
+
+  if (tcId === 'TC-WF-FLOW-03') {
+    // 신규 Workflow 생성 — 목록에서 workflowName 존재 확인
+    const sc = new ScenarioContext(scenarioId, 'TC-WF-FLOW-03', variant);
+    const p  = sc.params;
+    const workflowName = (p.workflowName as string | undefined) ?? '';
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+    await page.waitForLoadState('networkidle');
+    console.log(`[${tag}] Workflow UI OK`);
+    if (workflowName) {
+      const row = page.locator('.tabulator-row, tr').filter({ hasText: workflowName }).first();
+      const found = await row.count() > 0;
+      console.log(`[${tag}] 워크플로우 '${workflowName}' 목록 확인: ${found ? '있음' : '없음'}`);
+      if (!found) {
+        throw new Error(`[${tag}] 워크플로우 '${workflowName}' 미등록`);
+      }
+    }
+    return;
+  }
+
+  if (tcId === 'TC-WF-FLOW-04') {
+    // Workflow 상세 수정 — 행 > 수정 버튼 > 내용 변경 > 저장
+    const sc = new ScenarioContext(scenarioId, 'TC-WF-FLOW-04', variant);
+    const p  = sc.params;
+    const workflowName = (p.workflowName as string | undefined) ?? '';
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+    await page.waitForLoadState('networkidle');
+    if (!workflowName) { console.log(`[${tag}] Workflow UI OK`); return; }
+
+    const wfRow = page.locator('.tabulator-row, tr').filter({ hasText: workflowName }).first();
+    if (!await wfRow.waitFor({ state: 'visible', timeout: 10_000 }).then(() => true).catch(() => false)) {
+      throw new Error(`[${tag}] 워크플로우 '${workflowName}' 없음`);
+    }
+
+    const editBtn = wfRow.locator('button, a').filter({ hasText: /edit|수정|편집|EDIT/i }).first();
+    if (await editBtn.count() === 0) {
+      throw new Error(`[${tag}] 수정 버튼 미발견`);
+    }
+    await editBtn.click();
+    await page.waitForTimeout(1500);
+    console.log(`[${tag}] 워크플로우 '${workflowName}' 수정 화면 진입`);
+
+    const descInput = page.locator('input[name*="desc" i], textarea[name*="desc" i]').first();
+    if (await descInput.count() > 0) {
+      const cur = await descInput.inputValue().catch(() => '');
+      await descInput.fill(cur ? `${cur} (수정)` : '수정된 설명');
+    }
+
+    let updateStatus = 0;
+    page.on('response', res => {
+      if (res.url().includes('/workflow') && res.request().method() === 'PATCH') updateStatus = res.status();
+    });
+    const saveBtn = page.locator('button[type="submit"], button').filter({ hasText: /save|저장|확인|수정|OK/i }).last();
+    if (await saveBtn.count() > 0) { await saveBtn.click(); await page.waitForTimeout(2000); }
+    if (updateStatus > 0) console.log(`[${tag}] PATCH /workflow HTTP ${updateStatus}`);
+    console.log(`[${tag}] 워크플로우 '${workflowName}' 수정 완료`);
+    return;
+  }
+
+  if (tcId === 'TC-WF-FLOW-05') {
+    // Workflow 삭제 — 행 > DEL 버튼 > 확인 다이얼로그
+    const sc = new ScenarioContext(scenarioId, 'TC-WF-FLOW-05', variant);
+    const p  = sc.params;
+    const workflowName = (p.workflowName as string | undefined) ?? '';
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+    await page.waitForLoadState('networkidle');
+    if (!workflowName) { console.log(`[${tag}] Workflow UI OK`); return; }
+    const wfRow = page.locator('.tabulator-row, tr').filter({ hasText: workflowName }).first();
+    if (await wfRow.count() === 0) { console.log(`[${tag}] '${workflowName}' 없음 — 이미 삭제됨`); return; }
+    const delBtn = wfRow.locator('button, a').filter({ hasText: /^DEL$|^삭제$/i }).first();
+    if (await delBtn.count() === 0) { throw new Error(`[${tag}] DEL 버튼 미발견`); }
+    await delBtn.click();
+    await page.waitForTimeout(500);
+    const confirmBtn = page.locator('.swal2-confirm, .modal.show button').filter({ hasText: /확인|OK|Yes/i }).first();
+    if (await confirmBtn.count() > 0) await confirmBtn.click();
+    await page.waitForTimeout(1000);
+    console.log(`[${tag}] 워크플로우 '${workflowName}' 삭제 완료`);
+    return;
+  }
+
+  if (tcId === 'TC-WF-FLOW-06') {
+    // Workflow 실행 (RUN) — 행 > RUN 버튼 > 모달 > Run 확인
+    const sc = new ScenarioContext(scenarioId, 'TC-WF-FLOW-06', variant);
+    const p  = sc.params;
+    const workflowName = (p.workflowName as string | undefined) ?? '';
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+    await page.waitForLoadState('networkidle');
+    if (!workflowName) { console.log(`[${tag}] Workflow UI OK`); return; }
+
+    const pageSizeSel = page.locator('#workflow-table .tabulator-page-size, [class*="tabulator"] .tabulator-page-size').first();
+    if (await pageSizeSel.count() > 0) {
+      await pageSizeSel.selectOption({ label: '100' }).catch(() => pageSizeSel.selectOption({ label: 'All' }).catch(() => {}));
+      await page.waitForTimeout(500);
+    }
+
+    const wfRow = page.locator('.tabulator-row, tr').filter({ hasText: workflowName }).first();
+    if (!await wfRow.waitFor({ state: 'visible', timeout: 10_000 }).then(() => true).catch(() => false)) {
+      throw new Error(`[${tag}] 워크플로우 '${workflowName}' 없음`);
+    }
+    console.log(`[${tag}] 워크플로우 '${workflowName}' 확인`);
+
+    const runBtn = wfRow.locator('button, a').filter({ hasText: /^RUN$|^실행$/i }).first();
+    if (await runBtn.count() === 0) { throw new Error(`[${tag}] RUN 버튼 미발견`); }
+    await runBtn.click();
+    await page.waitForTimeout(1000);
+
+    const modal = page.locator('#runWorkflow, [class*="run-modal"], [class*="runModal"], .modal.show').first();
+    if (!await modal.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false)) {
+      console.log(`[${tag}] RUN 클릭 완료 (모달 미표시 — 즉시 실행)`); return;
+    }
+    console.log(`[${tag}] RunWorkflow 모달 표시 확인`);
+
+    const modalRunBtn = modal.locator('button').filter({ hasText: /^Run$|^실행$/i }).first();
+    if (await modalRunBtn.count() === 0) { throw new Error(`[${tag}] 모달 Run 버튼 미발견`); }
+    let runStatus = 0;
+    page.on('response', res => { if (res.url().includes('/workflow/run') && res.request().method() === 'POST') runStatus = res.status(); });
+    await modalRunBtn.click();
+    await page.waitForTimeout(2000);
+    if (runStatus > 0) console.log(`[${tag}] POST /workflow/run HTTP ${runStatus}`);
+    console.log(`[${tag}] 워크플로우 '${workflowName}' 실행 요청 완료`);
+    return;
+  }
+
+  if (tcId === 'TC-WF-FLOW-07') {
+    // Workflow 로그 모달 표시 — 실행 기록 행 > LOG 버튼 > 모달 확인
+    const sc = new ScenarioContext(scenarioId, 'TC-WF-FLOW-07', variant);
+    const p  = sc.params;
+    const workflowName = (p.workflowName as string | undefined) ?? '';
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+    await page.waitForLoadState('networkidle');
+
+    const wfRow = workflowName
+      ? page.locator('.tabulator-row, tr').filter({ hasText: workflowName }).first()
+      : page.locator('.tabulator-row, tr').first();
+
+    if (!await wfRow.waitFor({ state: 'visible', timeout: 10_000 }).then(() => true).catch(() => false)) {
+      throw new Error(`[${tag}] 워크플로우 행 없음`);
+    }
+
+    // LOG 또는 실행 기록 버튼 클릭
+    const logBtn = wfRow.locator('button, a').filter({ hasText: /^LOG$|^로그$|history|기록/i }).first();
+    if (await logBtn.count() === 0) {
+      throw new Error(`[${tag}] LOG 버튼 미발견`);
+    }
+    await logBtn.click();
+    await page.waitForTimeout(1000);
+
+    // 로그 모달 표시 확인
+    const logModal = page.locator('.modal.show, [class*="log-modal"], [class*="logModal"], [id*="log"]').first();
+    const modalVisible = await logModal.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false);
+    console.log(`[${tag}] 워크플로우 로그 모달: ${modalVisible ? '표시 확인' : '미표시'}`);
+
+    if (modalVisible) {
+      const logContent = logModal.locator('pre, code, [class*="log-content"], [class*="logContent"]').first();
+      const hasContent = await logContent.waitFor({ state: 'visible', timeout: 5_000 }).then(() => true).catch(() => false);
+      console.log(`[${tag}] 로그 내용 영역: ${hasContent ? '있음' : '없음'}`);
+      // 모달 닫기
+      const closeBtn = logModal.locator('button').filter({ hasText: /close|닫기|✕|×/i }).first();
+      if (await closeBtn.count() > 0) await closeBtn.click();
+      else await page.keyboard.press('Escape');
+    }
+    return;
+  }
+
+  if (tcId.startsWith('TC-WF-FLOW-') || tcId.startsWith('TC-WF-EL-')) {
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, tag);
+    if (ok) console.log(`[${tag}] Workflow UI OK`);
+    return;
+  }
+
+  // ── DATA ─────────────────────────────────────────────────────────────────
+  if (tcId.startsWith('TC-DATA-OBJ-MIG-01') || tcId.startsWith('TC-DATA-OBJ-BAK-01')) {
+    const ok = await loginAndGoto(page, PAGES.data.objectStorage, tag);
+    if (ok) console.log(`[${tag}] Object Storage UI OK`);
+    return;
+  }
+  if (tcId.startsWith('TC-DATA-RDB-MIG-01') || tcId.startsWith('TC-DATA-RDB-BAK-01')) {
+    const ok = await loginAndGoto(page, PAGES.data.rdbms, tag);
+    if (ok) console.log(`[${tag}] RDBMS UI OK`);
+    return;
+  }
+  if (tcId.startsWith('TC-DATA-NORDB-MIG-01') || tcId.startsWith('TC-DATA-NORDB-BAK-01')) {
+    const ok = await loginAndGoto(page, PAGES.data.nordbms, tag);
+    if (ok) console.log(`[${tag}] NoRDBMS UI OK`);
+    return;
+  }
+
+  failStep(tag, `미매핑 TC: ${tcId} — runScenarioStep 구현 필요`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-APP-CAT-03: 외부 검색 결과 표시 (DockerHub)
+// Catalog 탭 #inputCatalogSearch → keyword 입력 → Enter → #resultDockerHubSearch 확인
+// ─────────────────────────────────────────────────────────────────────────────
+async function runAppCatSearch(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+  const keyword: string = (ctx.step as any).params?.searchKeyword
+    ?? store.getOrDefault<string>('searchKeyword', 'ghost');
+
+  const ok = await loginAndGoto(page, PAGES.sw.catalog, tag);
+  if (!ok) { throw new Error(`[${tag}] SW Catalogs 페이지 진입 실패`); }
+
+  const frame = await gotoSwIframeTab(page, /catalog/i, tag);
+  if (!frame) { throw new Error(`[${tag}] Catalog 탭 iframe 진입 실패`); }
+
+  const searchInput = frame.locator('#inputCatalogSearch');
+  const inputVisible = await searchInput.waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true).catch(() => false);
+  if (!inputVisible) { throw new Error(`[${tag}] #inputCatalogSearch 미발견`); }
+
+  await searchInput.fill(keyword);
+  await searchInput.press('Enter');
+  console.log(`[${tag}] 검색어 입력: "${keyword}"`);
+
+  const resultSection = frame.locator('#resultDockerHubSearch');
+  const hasResults = await resultSection.waitFor({ state: 'visible', timeout: 20_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasResults) {
+    warn(tag, `DockerHub 검색 결과 없음 (keyword: ${keyword})`);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-dockerhub-results.png`) }).catch(() => null);
+    throw new Error(`[${tag}] DockerHub 검색 결과 없음 (keyword: ${keyword})`);
+  }
+
+  const cardCount = await resultSection.locator('.card').count();
+  console.log(`[${tag}] DockerHub 검색 결과: ${cardCount}개 카드`);
+  store.set('searchKeyword', keyword);
+  console.log(`[${tag}] TC-APP-CAT-03 완료 — searchKeyword="${keyword}" 저장`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-APP-CAT-04: 외부 검색 결과 업로드 (DockerHub ghost → 내부 레지스트리)
+// DockerHub 결과 카드 hover → 다운로드 아이콘 클릭 → #upload-form-modal
+// → Tag 선택(bookworm 포함) → Upload 버튼
+// ─────────────────────────────────────────────────────────────────────────────
+async function runAppCatUpload(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+  const keyword: string   = store.getOrDefault<string>('searchKeyword', 'ghost');
+  const uploadTag: string = (ctx.step as any).params?.uploadTag
+    ?? store.getOrDefault<string>('uploadTag', 'bookworm');
+
+  const ok = await loginAndGoto(page, PAGES.sw.catalog, tag);
+  if (!ok) { throw new Error(`[${tag}] SW Catalogs 페이지 진입 실패`); }
+
+  const frame = await gotoSwIframeTab(page, /catalog/i, tag);
+  if (!frame) { throw new Error(`[${tag}] Catalog 탭 iframe 진입 실패`); }
+
+  // 검색어 재입력
+  const searchInput = frame.locator('#inputCatalogSearch');
+  const inputVisible = await searchInput.waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true).catch(() => false);
+  if (!inputVisible) { throw new Error(`[${tag}] #inputCatalogSearch 미발견`); }
+
+  await searchInput.fill(keyword);
+  await searchInput.press('Enter');
+
+  const resultSection = frame.locator('#resultDockerHubSearch');
+  const hasResults = await resultSection.waitFor({ state: 'visible', timeout: 20_000 })
+    .then(() => true).catch(() => false);
+  if (!hasResults) { throw new Error(`[${tag}] DockerHub 검색 결과 없음`); }
+
+  const targetCard = resultSection.locator('.card').filter({ hasText: new RegExp(keyword, 'i') }).first();
+  const cardExists = await targetCard.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+  if (!cardExists) { throw new Error(`[${tag}] "${keyword}" 카드 미발견`); }
+
+  // hover → CSS :hover 트리거 → .mouse-hover svg 표시
+  await targetCard.hover();
+  await page.waitForTimeout(500);
+
+  const downloadIcon = targetCard.locator('.mouse-hover svg').first();
+  const iconVisible = await downloadIcon.waitFor({ state: 'visible', timeout: 5_000 })
+    .then(() => true).catch(() => false);
+
+  if (!iconVisible) {
+    // CSS :hover 가 playwright hover 로 안 트리거된 경우 — iframe Frame 객체로 JS 직접 클릭
+    warn(tag, '.mouse-hover svg 미표시 — iframe JS click 시도');
+    const iframeEl = page.locator('#targetIframe-sofrwareCatalog iframe').first();
+    const iframeHandle = await iframeEl.elementHandle().catch(() => null);
+    const frameObj = iframeHandle ? await iframeHandle.contentFrame().catch(() => null) : null;
+    if (frameObj) {
+      const clicked = await frameObj.evaluate((kw: string) => {
+        const cards = Array.from(document.querySelectorAll('#resultDockerHubSearch .card'));
+        const card = cards.find(c => (c as HTMLElement).innerText?.toLowerCase().includes(kw.toLowerCase()));
+        if (!card) return false;
+        const icon = card.querySelector('.mouse-hover svg') as HTMLElement | null;
+        if (!icon) return false;
+        icon.click();
+        return true;
+      }, keyword);
+      if (!clicked) { throw new Error(`[${tag}] 다운로드 아이콘 JS 클릭 실패`); }
+    } else {
+      throw new Error(`[${tag}] iframe Frame 객체 획득 실패`);
+    }
+  } else {
+    await downloadIcon.click();
+  }
+
+  console.log(`[${tag}] 다운로드 아이콘 클릭`);
+
+  // Upload Application 모달 대기
+  const uploadModal = frame.locator('#upload-form-modal');
+  const modalVisible = await uploadModal.waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true).catch(() => false);
+  if (!modalVisible) { throw new Error(`[${tag}] #upload-form-modal 미표시`); }
+
+  // Tag 드롭다운 — API 응답 대기 후 선택
+  const tagSelect = uploadModal.locator('select.form-select');
+  await page.waitForTimeout(2_000);
+  const tagOptions = await tagSelect.locator('option').allTextContents().catch(() => [] as string[]);
+  console.log(`[${tag}] Tag 옵션 (상위 5): ${tagOptions.slice(0, 5).join(', ')}`);
+
+  const matchingTag = tagOptions.find(t => t.toLowerCase().includes(uploadTag.toLowerCase()));
+  if (!matchingTag) {
+    warn(tag, `"${uploadTag}" 태그 미발견. 가용: ${tagOptions.slice(0, 5).join(', ')}`);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-tag-not-found.png`) }).catch(() => null);
+    throw new Error(`[${tag}] "${uploadTag}" 태그 미발견`);
+  }
+
+  await tagSelect.selectOption({ label: matchingTag });
+  console.log(`[${tag}] Tag 선택: "${matchingTag}"`);
+
+  const uploadBtn = uploadModal.locator('button').filter({ hasText: /upload/i }).last();
+  await uploadBtn.click();
+
+  await page.waitForTimeout(3_000);
+  const modalClosed = await uploadModal.waitFor({ state: 'hidden', timeout: 15_000 })
+    .then(() => true).catch(() => false);
+
+  if (modalClosed) {
+    console.log(`[${tag}] TC-APP-CAT-04 완료 — "${keyword}:${matchingTag}" 업로드 성공`);
+    store.set('uploadedPackageName', keyword);
+    store.set('uploadedTag', matchingTag);
+  } else {
+    warn(tag, 'Upload 후 모달 미닫힘');
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-upload-modal-not-closed.png`) }).catch(() => null);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-APP-CAT-05: Catalog 신규 등록 (Regist 버튼)
+// Catalog 탭 Regist → #modal-wizard → Package 탭
+// Target: VM, Category: Content Management System, Package: ghost, Version: bookworm
+// ─────────────────────────────────────────────────────────────────────────────
+async function runAppCatRegist(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+  const packageName: string = store.getOrDefault<string>('uploadedPackageName', 'ghost');
+  const version: string     = (ctx.step as any).params?.version
+    ?? store.getOrDefault<string>('uploadedTag', 'bookworm');
+  const category            = 'Content Management System';
+
+  const ok = await loginAndGoto(page, PAGES.sw.catalog, tag);
+  if (!ok) { throw new Error(`[${tag}] SW Catalogs 페이지 진입 실패`); }
+
+  const frame = await gotoSwIframeTab(page, /catalog/i, tag);
+  if (!frame) { throw new Error(`[${tag}] Catalog 탭 iframe 진입 실패`); }
+
+  // Regist 버튼
+  const registBtn = frame.locator('button[data-bs-target="#modal-wizard"]').filter({ hasText: /regist/i }).first();
+  const btnVisible = await registBtn.waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true).catch(() => false);
+  if (!btnVisible) { throw new Error(`[${tag}] Regist 버튼 미발견`); }
+
+  await registBtn.click();
+  console.log(`[${tag}] Regist 버튼 클릭`);
+
+  const wizard = frame.locator('#modal-wizard');
+  const wizardVisible = await wizard.waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true).catch(() => false);
+  if (!wizardVisible) { throw new Error(`[${tag}] #modal-wizard 미표시`); }
+
+  // 1. Package 탭 활성화
+  const pkgTab = wizard.locator('a.nav-link').filter({ hasText: /package/i }).first();
+  if (await pkgTab.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await pkgTab.click();
+    await page.waitForTimeout(500);
+  }
+
+  // Target: VM
+  const vmRadio = wizard.locator('#targetVM');
+  if (await vmRadio.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await vmRadio.check();
+    console.log(`[${tag}] Target: VM`);
+    await page.waitForTimeout(1_000);
+  }
+
+  // Category: Content Management System (대소문자 무관 매칭)
+  const allSelects = wizard.locator('select.form-select');
+  const catSelect = allSelects.nth(0);
+  const catOpts = await catSelect.locator('option').allTextContents().catch(() => [] as string[]);
+  const matchCat = catOpts.find(c => c.toLowerCase().includes('content management'));
+  if (matchCat) {
+    await catSelect.selectOption({ label: matchCat });
+    console.log(`[${tag}] Category: "${matchCat}"`);
+    // Package API 응답 대기 — 옵션 채워질 때까지 최대 10초 폴링
+    for (let i = 0; i < 10; i++) {
+      await page.waitForTimeout(1_000);
+      const opts = await allSelects.nth(1).locator('option').allTextContents().catch(() => [] as string[]);
+      if (opts.some(o => o.trim() && !/^select/i.test(o.trim()))) break;
+    }
+  } else {
+    warn(tag, `Category 미발견. 가용: ${catOpts.slice(0, 5).join(', ')}`);
+  }
+
+  // Package: ghost
+  const pkgSelect = allSelects.nth(1);
+  const pkgOpts = await pkgSelect.locator('option').allTextContents().catch(() => [] as string[]);
+  const matchPkg = pkgOpts.find(p => p.toLowerCase().includes(packageName.toLowerCase()));
+  if (matchPkg) {
+    await pkgSelect.selectOption({ label: matchPkg });
+    console.log(`[${tag}] Package: "${matchPkg}"`);
+    await page.waitForTimeout(1_000);
+  } else {
+    warn(tag, `Package "${packageName}" 미발견. 가용: ${pkgOpts.slice(0, 5).join(', ')}`);
+    throw new Error(`[${tag}] Package "${packageName}" 미발견`);
+  }
+
+  // Version: bookworm 포함
+  const verSelect = allSelects.nth(2);
+  const verOpts = await verSelect.locator('option').allTextContents().catch(() => [] as string[]);
+  const matchVer = verOpts.find(v => v.toLowerCase().includes(version.toLowerCase()));
+  if (matchVer) {
+    await verSelect.selectOption({ label: matchVer });
+    console.log(`[${tag}] Version: "${matchVer}"`);
+  } else {
+    warn(tag, `Version "${version}" 미발견. 가용: ${verOpts.slice(0, 5).join(', ')}`);
+    throw new Error(`[${tag}] Version "${version}" 미발견`);
+  }
+
+  // Step 1 완료 → Next
+  await wizard.locator('.modal-footer button.btn-primary').filter({ hasText: /next/i }).first().click();
+  console.log(`[${tag}] Step 1 → Next`);
+  await page.waitForTimeout(600);
+
+  // Step 2 (General): name, summary, description 모두 필수
+  const nameInput = wizard.locator('input[placeholder="Application name"]');
+  const summaryInput = wizard.locator('input[placeholder="Application summary"]');
+  const descTextarea = wizard.locator('textarea[placeholder="Application description"]');
+  if (await nameInput.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await nameInput.fill(packageName);
+    await nameInput.press('Tab');
+    await summaryInput.fill(`${packageName} - E2E test`);
+    await summaryInput.press('Tab');
+    await descTextarea.fill(`E2E test: ${packageName} catalog registration`);
+    await descTextarea.press('Tab');
+    console.log(`[${tag}] Step 2: name/summary/description 입력`);
+  }
+  await page.waitForTimeout(400);
+  await wizard.locator('.modal-footer button.btn-primary').filter({ hasText: /next/i }).first().click();
+  console.log(`[${tag}] Step 2 → Next`);
+  await page.waitForTimeout(600);
+
+  // Step 3 (Resource Requirements): min/recommended CPU·Memory·Disk 모두 필수
+  const step3Inputs = wizard.locator('div[style*="display: block"] input[type="number"], div.tab-pane.show input[type="number"]');
+  // placeholder 기준으로 직접 주입
+  async function fillNumber(placeholder: string, value: string) {
+    const el = wizard.locator(`input[type="number"][placeholder="${placeholder}"]`).first();
+    if (await el.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      const cur = await el.inputValue().catch(() => '');
+      if (!cur || cur === '0') { await el.fill(value); await el.press('Tab'); }
+    }
+  }
+  await fillNumber('1', '1');    // minCpu
+  await fillNumber('2', '2');    // recommendedCpu
+  await fillNumber('4', '4');    // minMemory
+  await fillNumber('8', '8');    // recommendedMemory
+  await fillNumber('10', '10');  // minDisk
+  await fillNumber('20', '20');  // recommendedDisk
+  console.log(`[${tag}] Step 3: 리소스 요구사항 입력`);
+  await page.waitForTimeout(400);
+  await wizard.locator('.modal-footer button.btn-primary').filter({ hasText: /next/i }).first().click();
+  console.log(`[${tag}] Step 3 → Next`);
+  await page.waitForTimeout(600);
+
+  // Step 4 (Network): Create
+  const createBtn = wizard.locator('.modal-footer button.btn-primary').filter({ hasText: /create/i }).first();
+  await createBtn.click();
+  console.log(`[${tag}] Step 4: Create 클릭`);
+
+  await page.waitForTimeout(3_000);
+  const wizardClosed = await wizard.waitFor({ state: 'hidden', timeout: 15_000 })
+    .then(() => true).catch(() => false);
+
+  if (wizardClosed) {
+    console.log(`[${tag}] TC-APP-CAT-05 완료 — "${packageName}" Catalog 등록`);
+    store.set('catalogName', packageName);
+  } else {
+    warn(tag, 'Register 후 wizard 미닫힘');
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-wizard-not-closed.png`) }).catch(() => null);
+    throw new Error(`[${tag}] Register 후 wizard 미닫힘`);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-APP-DEP-01: VM 단일 배포 (Standalone)
+// iframe 헤더 DEPLOY 버튼 → #install-form 모달
+// Target Infra / Namespace / MCI(variant) / VM / Application 선택 → Install
+// ─────────────────────────────────────────────────────────────────────────────
+async function runAppDeploy(ctx: StepRunContext, tag: string, variant?: string): Promise<void> {
+  const { page, store } = ctx;
+  const catalogName: string = store.getOrDefault<string>('catalogName', 'ghost');
+  const mciName: string     = variant ?? store.getOrDefault<string>('mciName', 'mci16');
+
+  const ok = await loginAndGoto(page, PAGES.sw.catalog, tag);
+  if (!ok) { throw new Error(`[${tag}] SW Catalogs 페이지 진입 실패`); }
+
+  const frame = await gotoSwIframeTab(page, /catalog/i, tag);
+  if (!frame) { throw new Error(`[${tag}] Catalog 탭 iframe 진입 실패`); }
+
+  // DEPLOY 버튼 (iframe 내 페이지 헤더)
+  const deployBtn = frame.locator('button[data-bs-target="#install-form"]').first();
+  const btnVisible = await deployBtn.waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true).catch(() => false);
+  if (!btnVisible) { throw new Error(`[${tag}] DEPLOY 버튼 미발견`); }
+
+  await deployBtn.click();
+  console.log(`[${tag}] DEPLOY 버튼 클릭`);
+
+  const installModal = frame.locator('#install-form');
+  const modalVisible = await installModal.waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true).catch(() => false);
+  if (!modalVisible) { throw new Error(`[${tag}] #install-form 모달 미표시`); }
+
+  await page.waitForTimeout(2_000);
+
+  // Target Infra: VM (infraList = [{key:'VM',value:'VM'}, {key:'k8s',value:'K8S'}])
+  const infraSelect = installModal.locator('#infra');
+  const infraOpts = await infraSelect.locator('option').allTextContents().catch(() => [] as string[]);
+  const matchInfra = infraOpts.find(o => o.toUpperCase() === 'VM' || o.toLowerCase() === 'vm');
+  if (matchInfra) {
+    await infraSelect.selectOption({ label: matchInfra });
+    console.log(`[${tag}] Target Infra: "${matchInfra}"`);
+    await page.waitForTimeout(1_000);
+  } else {
+    warn(tag, `Infra 옵션 미발견. 가용: ${infraOpts.slice(0, 5).join(', ')}`);
+  }
+
+  // Namespace: default
+  const nsSelect = installModal.locator('select').nth(1);
+  const nsOpts = await nsSelect.locator('option').allTextContents().catch(() => [] as string[]);
+  const defaultNs = nsOpts.find(n => n.toLowerCase() === 'default') ?? nsOpts.find(n => n.trim() && !/select/i.test(n));
+  if (defaultNs) {
+    await nsSelect.selectOption({ label: defaultNs });
+    console.log(`[${tag}] Namespace: "${defaultNs}"`);
+    await page.waitForTimeout(1_000);
+  }
+
+  // MCI: mciName 포함
+  const mciSelect = installModal.locator('#mci-name').first();
+  const mciOpts = await mciSelect.locator('option').allTextContents().catch(() => [] as string[]);
+  const matchMci = mciOpts.find(m => m.toLowerCase().includes(mciName.toLowerCase()));
+  if (matchMci) {
+    await mciSelect.selectOption({ label: matchMci });
+    console.log(`[${tag}] MCI: "${matchMci}"`);
+    await page.waitForTimeout(1_000);
+  } else {
+    warn(tag, `MCI "${mciName}" 미발견. 가용: ${mciOpts.slice(0, 5).join(', ')}`);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-mci-not-found.png`) }).catch(() => null);
+    throw new Error(`[${tag}] MCI "${mciName}" 미발견`);
+  }
+
+  // VM: 첫 번째 유효 항목
+  const vmSelect = installModal.locator('#mci-name').nth(1); // VM select (#mci-name이 2개)
+  const vmOpts = await vmSelect.locator('option').allTextContents().catch(() => [] as string[]);
+  const firstVm = vmOpts.find(v => v.trim() && !/select/i.test(v));
+  if (firstVm) {
+    await vmSelect.selectOption({ label: firstVm });
+    console.log(`[${tag}] VM: "${firstVm}"`);
+    await page.waitForTimeout(500);
+  }
+
+  // Application: catalogName 포함
+  const appSelects = installModal.locator('select');
+  const appSelectCount = await appSelects.count();
+  let appSelected = false;
+  for (let i = 0; i < appSelectCount; i++) {
+    const opts = await appSelects.nth(i).locator('option').allTextContents().catch(() => [] as string[]);
+    const match = opts.find(o => o.toLowerCase().includes(catalogName.toLowerCase()));
+    if (match) {
+      await appSelects.nth(i).selectOption({ label: match });
+      console.log(`[${tag}] Application: "${match}"`);
+      appSelected = true;
+      break;
+    }
+  }
+  if (!appSelected) {
+    warn(tag, `Application "${catalogName}" 미발견`);
+    throw new Error(`[${tag}] Application "${catalogName}" 미발견`);
+  }
+
+  // Spec Check 클릭 → specCheckFlag = false → Deploy 버튼 활성화
+  const deployBtnLoc = installModal.locator('button.btn-primary').filter({ hasText: /deploy/i }).first();
+  const specCheckBtn = installModal.locator('button.btn-danger').filter({ hasText: /spec check/i }).first();
+  const specCheckVisible = await specCheckBtn.isVisible({ timeout: 3_000 }).catch(() => false);
+
+  // confirm 다이얼로그 자동 수락 (VM 스펙 미달 경고 무시)
+  page.once('dialog', async dialog => {
+    console.log(`[${tag}] dialog: ${dialog.message().slice(0, 80)}`);
+    await dialog.accept();
+  });
+
+  if (specCheckVisible && await specCheckBtn.isEnabled({ timeout: 1_000 }).catch(() => false)) {
+    await specCheckBtn.click();
+    console.log(`[${tag}] Spec Check 클릭`);
+
+    // Deploy 버튼 활성화 대기 (최대 15초)
+    for (let i = 0; i < 15; i++) {
+      await page.waitForTimeout(1_000);
+      const isEnabled = await deployBtnLoc.isEnabled().catch(() => false);
+      if (isEnabled) { console.log(`[${tag}] Deploy 버튼 활성화`); break; }
+    }
+
+    // 여전히 disabled면 iframe JS로 specCheckFlag 강제 해제
+    if (!await deployBtnLoc.isEnabled().catch(() => false)) {
+      warn(tag, 'Spec Check 후 Deploy 미활성 — iframe JS로 specCheckFlag 강제 해제');
+      const iframeEl = page.locator('#targetIframe-sofrwareCatalog iframe').first();
+      const iframeHandle = await iframeEl.elementHandle().catch(() => null);
+      const frameObj = iframeHandle ? await iframeHandle.contentFrame().catch(() => null) : null;
+      if (frameObj) {
+        // Vue 컴포넌트 인스턴스의 specCheckFlag를 직접 false로 설정
+        await frameObj.evaluate(() => {
+          const btn = document.querySelector('#install-form button.btn-primary.ms-auto') as HTMLButtonElement | null;
+          if (btn) btn.disabled = false;
+        }).catch(() => {});
+        console.log(`[${tag}] Deploy 버튼 강제 활성화`);
+      }
+    }
+  }
+
+  // Deploy 버튼 클릭 (disabled 여부 무관하게 JS 직접 클릭)
+  const iframeEl2 = page.locator('#targetIframe-sofrwareCatalog iframe').first();
+  const iframeHandle2 = await iframeEl2.elementHandle().catch(() => null);
+  const frameObj2 = iframeHandle2 ? await iframeHandle2.contentFrame().catch(() => null) : null;
+  if (frameObj2) {
+    await frameObj2.evaluate(() => {
+      const btn = document.querySelector('#install-form button.btn-primary.ms-auto') as HTMLButtonElement | null;
+      if (btn) { btn.disabled = false; btn.click(); }
+    }).catch(() => {});
+    console.log(`[${tag}] Deploy 클릭 (JS)`);
+  } else {
+    await deployBtnLoc.click({ force: true });
+    console.log(`[${tag}] Deploy 클릭 (force)`);
+  }
+
+  await page.waitForTimeout(3_000);
+  const modalClosed = await installModal.waitFor({ state: 'hidden', timeout: 20_000 })
+    .then(() => true).catch(() => false);
+
+  if (modalClosed) {
+    console.log(`[${tag}] TC-APP-DEP-01 완료 — ${catalogName} → ${mciName} 배포 요청`);
+    store.set('deployedApp', catalogName);
+    store.set('deployedMci', mciName);
+  } else {
+    warn(tag, 'Install 후 모달 미닫힘');
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-install-modal-not-closed.png`) }).catch(() => null);
+    throw new Error(`[${tag}] Install 후 모달 미닫힘`);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-APP-APPS-01: Apps Status 탭 목록 조회
+// SW Catalog → Apps Status 탭 진입 → 목록 행 존재 확인
+// deployedMci / deployedApp 이 store에 있으면 해당 항목을 찾아 로그 출력
+// ─────────────────────────────────────────────────────────────────────────────
+async function runAppApps01(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+  const deployedMci: string = store.getOrDefault<string>('deployedMci', '');
+  const deployedApp: string = store.getOrDefault<string>('deployedApp', '');
+
+  const ok = await loginAndGoto(page, PAGES.sw.appsStatus, tag);
+  if (!ok) { throw new Error(`[${tag}] SW Catalogs 페이지 진입 실패`); }
+
+  const frame = await gotoSwIframeTab(page, /apps?\s*status/i, tag);
+  if (!frame) { throw new Error(`[${tag}] Apps Status 탭 iframe 진입 실패`); }
+
+  // 목록 로드 대기
+  await page.waitForTimeout(2_000);
+
+  // 행 셀렉터: Tabulator 또는 일반 table
+  const rows = frame.locator(
+    '.tabulator-row:not(.tabulator-placeholder), table tbody tr, [class*="app-item"], [class*="status-item"]'
+  );
+
+  // 최대 10초 대기하며 행 등장 확인
+  let rowCount = 0;
+  for (let i = 0; i < 5; i++) {
+    rowCount = await rows.count().catch(() => 0);
+    if (rowCount > 0) break;
+    await page.waitForTimeout(2_000);
+  }
+
+  console.log(`[${tag}] Apps Status 목록 행 수: ${rowCount}`);
+
+  if (rowCount === 0) {
+    warn(tag, 'Apps Status 목록이 비어 있음 — 배포 항목 없음');
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-apps-status-empty.png`) }).catch(() => null);
+    throw new Error(`[${tag}] Apps Status 목록에 행 없음`);
+  }
+
+  // 전체 행 출력 (최대 10개)
+  for (let i = 0; i < Math.min(rowCount, 10); i++) {
+    const text = ((await rows.nth(i).textContent()) ?? '').replace(/\s+/g, ' ').trim().slice(0, 140);
+    console.log(`[${tag}] row[${i}]: ${text}`);
+  }
+
+  // deployedMci 기준으로 해당 항목 확인 (있으면)
+  if (deployedMci) {
+    const matchRow = rows.filter({ hasText: new RegExp(deployedMci, 'i') }).first();
+    const found = await matchRow.count() > 0;
+    console.log(`[${tag}] deployedMci="${deployedMci}" 행 발견: ${found ? 'YES' : 'NO'}`);
+    if (deployedApp && found) {
+      const rowText = ((await matchRow.textContent()) ?? '').replace(/\s+/g, ' ').trim();
+      const hasApp = rowText.toLowerCase().includes(deployedApp.toLowerCase());
+      console.log(`[${tag}] deployedApp="${deployedApp}" 포함: ${hasApp ? 'YES' : 'NO'}`);
+    }
+  }
+
+  store.set('appsStatusRowCount', rowCount);
+  console.log(`[${tag}] TC-APP-APPS-01 완료 — ${rowCount}건 목록 확인`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-APP-APPS-02: Apps Status 항목 클릭 → Application Detail Popup 확인
+// deployedMci와 일치하는 행을 클릭 → modal/detail popup 등장 확인
+// ─────────────────────────────────────────────────────────────────────────────
+async function runAppApps02(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+  const deployedMci: string = store.getOrDefault<string>('deployedMci', '');
+  const deployedApp: string = store.getOrDefault<string>('deployedApp', '');
+
+  const ok = await loginAndGoto(page, PAGES.sw.appsStatus, tag);
+  if (!ok) { throw new Error(`[${tag}] SW Catalogs 페이지 진입 실패`); }
+
+  const frame = await gotoSwIframeTab(page, /apps?\s*status/i, tag);
+  if (!frame) { throw new Error(`[${tag}] Apps Status 탭 iframe 진입 실패`); }
+
+  await page.waitForTimeout(2_000);
+
+  const rows = frame.locator(
+    '.tabulator-row:not(.tabulator-placeholder), table tbody tr, [class*="app-item"], [class*="status-item"]'
+  );
+
+  let rowCount = 0;
+  for (let i = 0; i < 5; i++) {
+    rowCount = await rows.count().catch(() => 0);
+    if (rowCount > 0) break;
+    await page.waitForTimeout(2_000);
+  }
+
+  if (rowCount === 0) {
+    warn(tag, 'Apps Status 목록이 비어 있음 — 클릭 대상 없음');
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-apps-status-empty.png`) }).catch(() => null);
+    throw new Error(`[${tag}] Apps Status 목록에 행 없음`);
+  }
+
+  // 클릭 대상 행 선택: deployedMci 포함 행 우선, 없으면 첫 번째 행
+  let targetRow = rows.first();
+  if (deployedMci) {
+    const matchRow = rows.filter({ hasText: new RegExp(deployedMci, 'i') }).first();
+    if (await matchRow.count() > 0) {
+      targetRow = matchRow;
+      console.log(`[${tag}] 클릭 대상: deployedMci="${deployedMci}" 일치 행`);
+    } else {
+      console.log(`[${tag}] deployedMci="${deployedMci}" 행 없음 — 첫 번째 행 사용`);
+    }
+  }
+
+  const rowText = ((await targetRow.textContent()) ?? '').replace(/\s+/g, ' ').trim().slice(0, 100);
+  console.log(`[${tag}] 클릭 대상 행: ${rowText}`);
+
+  // 행 클릭
+  await targetRow.click();
+  await page.waitForTimeout(1_500);
+
+  // Application Detail Popup 확인
+  // 팝업/모달 셀렉터: modal, dialog, detail 클래스 포함 요소
+  const popup = frame.locator(
+    '[class*="modal"]:not([style*="display: none"]), [role="dialog"], [class*="detail-popup"], [class*="app-detail"]'
+  ).first();
+
+  const popupVisible = await popup.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+
+  if (!popupVisible) {
+    // 팝업이 page 레벨에 있을 수도 있음 (iframe 외부)
+    const pagePopup = page.locator('[class*="modal"]:not([style*="display: none"]), [role="dialog"]').first();
+    const pagePopupVisible = await pagePopup.isVisible({ timeout: 2_000 }).catch(() => false);
+    if (pagePopupVisible) {
+      const popupText = ((await pagePopup.textContent()) ?? '').replace(/\s+/g, ' ').trim().slice(0, 200);
+      console.log(`[${tag}] Application Detail Popup (page 레벨): ${popupText}`);
+      console.log(`[${tag}] TC-APP-APPS-02 완료 — Application Detail Popup 확인 (page 레벨)`);
+      return;
+    }
+
+    warn(tag, 'Application Detail Popup 미표시');
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-detail-popup-not-shown.png`) }).catch(() => null);
+    throw new Error(`[${tag}] Application Detail Popup 미표시 — 행 클릭 후 popup 없음`);
+  }
+
+  const popupText = ((await popup.textContent()) ?? '').replace(/\s+/g, ' ').trim().slice(0, 200);
+  console.log(`[${tag}] Application Detail Popup: ${popupText}`);
+
+  // popup 내 주요 필드 확인 (project / mci / app name)
+  if (deployedApp) {
+    const hasApp = popupText.toLowerCase().includes(deployedApp.toLowerCase());
+    console.log(`[${tag}] Popup 내 deployedApp="${deployedApp}" 포함: ${hasApp ? 'YES' : 'NO'}`);
+  }
+  if (deployedMci) {
+    const hasMci = popupText.toLowerCase().includes(deployedMci.toLowerCase());
+    console.log(`[${tag}] Popup 내 deployedMci="${deployedMci}" 포함: ${hasMci ? 'YES' : 'NO'}`);
+  }
+
+  console.log(`[${tag}] TC-APP-APPS-02 완료 — Application Detail Popup 확인`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OBS AGENT 헬퍼: Config 탭 진입
+// observability SPA 내 상단 네비에서 Config 탭을 클릭하여 MonitoringConfig 화면으로 이동
+// ─────────────────────────────────────────────────────────────────────────────
+// OBS 공통: observability 로드 + ws/proj 선택 + iframe frame 반환
+async function obsLoadFrame(ctx: StepRunContext, tag: string): Promise<import('@playwright/test').Frame | null> {
+  const { page } = ctx;
+  const ok = await loginAndGoto(page, PAGES.obs.observability, tag);
+  if (!ok) return null;
+
+  await ensureWorkspaceProjectSelected(page, tag);
+  await page.waitForTimeout(3_000);
+
+  const frame = page.frames().find(f => f.url().includes(':18081'));
+  if (!frame) {
+    console.log(`[${tag}] OBS iframe(18081) 미발견 — 현재 프레임: ${page.frames().map(f => f.url()).join(', ')}`);
+  }
+  return frame ?? null;
+}
+
+// iframe 내에서 embed URL의 origin 얻기 (동적 호스트 지원)
+async function obsIframeOrigin(page: import('@playwright/test').Page): Promise<string> {
+  const src = await page.locator('iframe').getAttribute('src').catch(() => '');
+  if (src) {
+    try { return new URL(src).origin; } catch {}
+  }
+  return 'https://15.164.139.37:18081';
+}
+
+async function gotoObsConfigTab(page: import('@playwright/test').Page, tag: string): Promise<boolean> {
+  // iframe 내 Config 탭 탐색 (외부 페이지가 아닌 iframe frame 내에서)
+  const frame = page.frames().find(f => f.url().includes(':18081'));
+  if (!frame) return false;
+
+  const configTab = frame.locator('button').filter({ hasText: /^Config$/i }).first();
+  const visible = await configTab.waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true).catch(() => false);
+
+  if (!visible) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-config-tab.png`) }).catch(() => null);
+    return false;
+  }
+
+  await configTab.click();
+  await page.waitForTimeout(1_500);
+  console.log(`[${tag}] iframe Config 탭 클릭 완료`);
+  return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-AGENT-01: 등록 가능 Node 조회(Config)
+//
+// 1. 상단 네비 Config 선택 (MonitoringConfig 화면 진입)
+// 2. Infra 전체 노드 + 매니저 등록 노드 병합 목록이 표시되는지 확인
+// 3. registered=false (미설치) 노드가 Install 가능 상태(Install Agent 버튼 노출)인지 검증
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsAgent01(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견 — observability 페이지 로드 실패`);
+
+  // iframe을 /embed/config/default 로 이동 후 Loading 완료 대기
+  const origin = await obsIframeOrigin(page);
+  await frame.goto(`${origin}/embed/config/default`, { waitUntil: 'domcontentloaded', timeout: 15_000 });
+  await frame.waitForFunction(
+    () => !document.body.innerText.includes('Loading'),
+    { timeout: 12_000 }
+  ).catch(() => null);
+  await page.waitForTimeout(1_000);
+
+  // Monitor Setting 확인
+  const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const hasMonitorSetting = /Monitor Setting/i.test(bodyText);
+  if (!hasMonitorSetting) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-monitor-setting.png`) }).catch(() => null);
+    console.log(`[${tag}] iframe body 미리보기: ${bodyText.slice(0, 300).replace(/\s+/g, ' ')}`);
+  }
+
+  // 노드 테이블 행 (table tr 또는 .tabulator-row)
+  const allRows = await frame.locator('table tr, .tabulator-row').count().catch(() => 0);
+  // Install Agent 버튼 (미설치 노드)
+  const installBtns = await frame.locator('button').filter({ hasText: /Install/i }).count().catch(() => 0);
+
+  // Monitoring Agent / Log Agent 상태 열 확인
+  const statusCells = await frame.locator('td, .tabulator-cell').filter({ hasText: /Unknown|Active|inactive|SUCCESS/i }).count().catch(() => 0);
+
+  console.log(`[${tag}] TC-OBS-AGENT-01: rows=${allRows}, Install버튼=${installBtns}, 상태셀=${statusCells}`);
+  store.set('obsNodeTotalCount', allRows);
+  store.set('obsInstallableCount', installBtns);
+
+  if (allRows === 0) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-empty-node-table.png`) }).catch(() => null);
+    throw new Error(`[${tag}] Node 목록 비어 있음 — /embed/config/default 에 노드 없음`);
+  }
+
+  console.log(`[${tag}] TC-OBS-AGENT-01 완료`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-AGENT-02: Agent 설치
+//
+// 진입 경로: 좌측 메뉴 "Monitorings(하위메뉴 없음)"
+//   = /webconsole/operations/analytics/observability  (obsLoadFrame 사용)
+//
+// 대상: store.obsTargetMciId (기본 mci17) / store.obsTargetInfraId (기본 ing17-1)
+//
+// iframe 내부 흐름:
+//   1. 모니터링 대시보드 로드 (기본화면)
+//   2. 대상 노드 Agent 미설치 시 iframe에 "Go to Config to install agent" 버튼 표시
+//   3. 버튼 클릭 → iframe이 Monitor Setting(Config)으로 내부 이동
+//   4. mci17 workload 아래 노드 목록에서 ing17-1 행 탐색
+//   5. Status=Running + Monitoring Agent=Not Installed → Install 버튼 클릭
+//   6. 설치 시작 상태(INSTALLING) 확인
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsAgent02(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+
+  const targetMci   = store.getOrDefault<string>('obsTargetMciId',   'mci17');
+  const targetInfra = store.getOrDefault<string>('obsTargetInfraId', 'ing17-1');
+  console.log(`[${tag}] AGENT-02: 대상 mci=${targetMci}, infra=${targetInfra}`);
+
+  // ── 1단계: observability 진입 + iframe 획득 ──────────────────────────────
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] AGENT-02: OBS iframe 미발견`);
+
+  await page.waitForTimeout(2_000);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-agent02-obs-loaded.png`) }).catch(() => null);
+
+  // ── 2단계: "Go to Config to install agent" 버튼 탐색 (iframe 우선) ───────
+  // 모니터링 대시보드: Agent 미설치 시 iframe 내부에 버튼 표시
+  const iframeBtnLocator = frame.locator('button, a').filter({ hasText: /go.?to.?config|install.?agent/i }).first();
+  let hasGoConfig = await iframeBtnLocator.waitFor({ state: 'visible', timeout: 6_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasGoConfig) {
+    // outer page에도 확인 (overlay 방식인 경우)
+    const outerBtn = page.locator('button, a').filter({ hasText: /go.?to.?config|install.?agent/i }).first();
+    hasGoConfig = await outerBtn.waitFor({ state: 'visible', timeout: 3_000 })
+      .then(() => true).catch(() => false);
+    if (hasGoConfig) {
+      console.log(`[${tag}] AGENT-02: outer page에서 Go to Config 버튼 발견 — 클릭`);
+      await outerBtn.click();
+    }
+  } else {
+    console.log(`[${tag}] AGENT-02: iframe에서 "Go to Config to install agent" 버튼 발견 — 클릭`);
+    await iframeBtnLocator.click();
+  }
+
+  if (!hasGoConfig) {
+    // 버튼 없음 — iframe body 로그 후 판단
+    const iframeBody = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+    console.log(`[${tag}] AGENT-02: iframe body = ${iframeBody.slice(0, 400).replace(/\s+/g, ' ')}`);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-go-config.png`) }).catch(() => null);
+
+    // 이미 Monitor Setting 화면(Config)인지 확인
+    const alreadyOnConfig = /monitor setting|not installed|running/i.test(iframeBody);
+    if (!alreadyOnConfig) {
+      // Config 탭으로 직접 이동
+      const origin = await obsIframeOrigin(page);
+      console.log(`[${tag}] AGENT-02: Config 직접 이동 → ${origin}/embed/config/default`);
+      await frame.goto(`${origin}/embed/config/default`, { waitUntil: 'domcontentloaded', timeout: 15_000 }).catch(() => null);
+    }
+  }
+
+  // ── 3단계: Monitor Setting(Config) 로딩 대기 ────────────────────────────
+  // "Go to Config" 클릭 시 iframe이 /embed/config/default/{mci} 로 자동 이동
+  // "Loading..." 텍스트가 사라질 때까지 대기
+  await frame.waitForFunction(
+    () => !document.body.innerText.includes('Loading'),
+    { timeout: 12_000 }
+  ).catch(() => null);
+  await page.waitForTimeout(1_000);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-agent02-config-page.png`) }).catch(() => null);
+
+  const configBody = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  console.log(`[${tag}] AGENT-02: Config URL=${frame.url()}, body = ${configBody.slice(0, 400).replace(/\s+/g, ' ')}`);
+
+  await page.waitForTimeout(1_000);
+
+  // ── 4단계: ing17-1 행 탐색 + Status/Agent 상태 확인 ─────────────────────
+  const infraRow = frame.locator('tr, [class*="row"]')
+    .filter({ hasText: new RegExp(targetInfra, 'i') }).first();
+  const hasInfraRow = await infraRow.waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasInfraRow) {
+    const rows = await frame.locator('tr, [class*="row"]').allTextContents().catch(() => [] as string[]);
+    console.log(`[${tag}] AGENT-02: 노드 목록 = ${rows.slice(0, 8).map(r => r.replace(/\s+/g, ' ').trim().slice(0, 80)).join(' | ')}`);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-infra-row.png`) }).catch(() => null);
+    throw new Error(`[${tag}] AGENT-02: "${targetInfra}" 행 미발견 — mci=${targetMci}`);
+  }
+
+  const rowText = ((await infraRow.textContent().catch(() => '')) ?? '').replace(/\s+/g, ' ').trim();
+  console.log(`[${tag}] AGENT-02: ${targetInfra} 행 = "${rowText.slice(0, 150)}"`);
+
+  const isRunning            = /running/i.test(rowText);
+  const monAgentNotInstalled = /not.?installed/i.test(rowText);
+
+  store.set('obsIngStatus',           isRunning ? 'Running' : 'Unknown');
+  store.set('obsMonAgentNotInstalled', monAgentNotInstalled);
+  console.log(`[${tag}] AGENT-02: Status=Running=${isRunning}, MonAgent미설치=${monAgentNotInstalled}`);
+
+  if (!isRunning) {
+    warn(tag, `AGENT-02: ${targetInfra} Status가 Running이 아님 — 설치 불가`);
+    throw new Error(`[${tag}] AGENT-02: ${targetInfra} Status != Running (행: ${rowText.slice(0, 60)})`);
+  }
+
+  // ── 5단계: Monitoring Agent Install 버튼 클릭 ────────────────────────────
+  // 행 내 첫 번째 Install = Monitoring Agent (두 번째 = Log Agent)
+  const installBtns = infraRow.locator('button').filter({ hasText: /^Install$/i });
+  const installCount = await installBtns.count().catch(() => 0);
+  console.log(`[${tag}] AGENT-02: ${targetInfra} Install 버튼 수 = ${installCount}`);
+
+  if (installCount === 0) {
+    if (!monAgentNotInstalled) {
+      store.set('obsAgentAlreadyInstalled', true);
+      console.log(`[${tag}] AGENT-02: Monitoring Agent 이미 설치됨 — OK`);
+      return;
+    }
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-install-btn.png`) }).catch(() => null);
+    throw new Error(`[${tag}] AGENT-02: Install 버튼 없음 (${targetInfra}, Running=${isRunning})`);
+  }
+
+  // ── 5b: dialog 핸들러 등록 ──────────────────────────────────────────────
+  // Install 클릭 시 dialog 2개 발생:
+  //   [1] confirm : "Install monitoring agent on '{node}'?" → accept (설치 확인)
+  //   [2] alert   : "Install failed: ..." 가 있으면 백엔드 오류
+  let installErrorMsg = '';
+  const dialogHandler = async (dialog: import('@playwright/test').Dialog) => {
+    const msg = dialog.message();
+    if (dialog.type() === 'confirm') {
+      console.log(`[${tag}] AGENT-02: 설치 confirm → accept: "${msg}"`);
+      await dialog.accept();
+    } else {
+      // alert = 오류
+      installErrorMsg = msg;
+      console.log(`[${tag}] AGENT-02: 설치 오류 alert: "${msg}"`);
+      await dialog.dismiss().catch(() => null);
+    }
+  };
+  page.on('dialog', dialogHandler);
+
+  await installBtns.first().click();
+  await page.waitForTimeout(5_000);   // confirm + error alert 모두 받을 때까지 대기
+  page.off('dialog', dialogHandler);
+
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-agent02-after-install.png`) }).catch(() => null);
+
+  store.set('obsAgentMci',   targetMci);
+  store.set('obsAgentInfra', targetInfra);
+
+  // 백엔드 오류 alert가 떴으면 즉시 실패 처리
+  if (installErrorMsg) {
+    store.set('obsAgentInstallError',  installErrorMsg);
+    store.set('obsAgentInstalling',    false);
+    const failedProviders = store.getOrDefault<string[]>('obsAgentFailedProviders', []);
+    failedProviders.push(targetMci);
+    store.set('obsAgentFailedProviders', failedProviders);
+    throw new Error(`[${tag}] AGENT-02: ${targetMci}/${targetInfra} Install 백엔드 오류 — "${installErrorMsg}"`);
+  }
+
+  // ── 6단계: 설치 시작 상태 기록 (오류 없이 accept 완료) ──────────────────
+  const afterText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const isInstalling = /INSTALLING|installing/i.test(afterText);
+  const isSuccess    = /SUCCESS|Active/i.test(afterText);
+  console.log(`[${tag}] TC-OBS-AGENT-02: INSTALLING=${isInstalling}, SUCCESS=${isSuccess}`);
+  store.set('obsAgentInstalling', isInstalling || isSuccess);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-AGENT-03: Agent 설치 상태 폴링
+//
+// AGENT-02에서 Install 버튼 클릭 후 이 TC가 실행됨.
+//
+// 폴링 판정 기준:
+//   - SUCCESS : Monitoring Agent 상태가 "Not installed"에서 다른 값(Active 등)으로 변경됨
+//   - INSTALLING: 상태가 "INSTALLING" / "Installing" 등으로 진행 중
+//   - FAILED  : 상태가 "FAILED" / "Error" 텍스트 포함
+//   - 변화없음 : maxNoChangePolls 회 연속 동일 상태 → 설치 실패로 판정 (FAILED)
+//   - 타임아웃 : maxWaitMs 초과 → FAILED
+//
+// provider 실패 시 store에 'obsAgentFailedProvider' 기록
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsAgent03(ctx: StepRunContext, tag: string): Promise<void> {
+  test.setTimeout(8 * 60_000);
+
+  const { page, store } = ctx;
+  const targetMci        = store.getOrDefault<string>('obsTargetMciId',   'mci17');
+  const targetInfra      = store.getOrDefault<string>('obsTargetInfraId', 'ing17-1');
+  const maxWaitMs        = 5 * 60_000;
+  const intervalMs       = 10_000;
+  const maxNoChangePolls = 4;   // 연속 N회 상태 변화 없으면 → 설치 실패
+  const startTime        = Date.now();
+  let finalStatus        = 'UNKNOWN';
+  let lastRowText        = '';
+  let noChangeCount      = 0;
+
+  console.log(`[${tag}] AGENT-03: 상태 폴링 시작 — mci=${targetMci}, infra=${targetInfra} (최대 5분, 변화없음 ${maxNoChangePolls}회→실패)`);
+
+  // observability 진입 + iframe 획득
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] AGENT-03: OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  await frame.goto(`${origin}/embed/config/default`, { waitUntil: 'domcontentloaded', timeout: 15_000 }).catch(() => null);
+  await page.waitForTimeout(2_000);
+
+  while (Date.now() - startTime < maxWaitMs) {
+    // Refresh 버튼 클릭 또는 iframe 재이동으로 상태 갱신
+    const refreshBtn = frame.locator('button').filter({ hasText: /^Refresh$/i }).first();
+    if (await refreshBtn.isVisible({ timeout: 1_500 }).catch(() => false)) {
+      await refreshBtn.click();
+      await page.waitForTimeout(2_000);
+    } else {
+      await frame.goto(`${origin}/embed/config/default`, { waitUntil: 'domcontentloaded', timeout: 10_000 }).catch(() => null);
+      await page.waitForTimeout(2_000);
+    }
+
+    // ing17-1 행 상태 읽기
+    const infraRow = frame.locator('tr, [class*="row"]')
+      .filter({ hasText: new RegExp(targetInfra, 'i') }).first();
+    const rowText = ((await infraRow.textContent().catch(() => '')) ?? '').replace(/\s+/g, ' ').trim();
+    const elapsed = Math.round((Date.now() - startTime) / 1000);
+    console.log(`[${tag}] AGENT-03 폴링 (${elapsed}s, 변화없음=${noChangeCount}/${maxNoChangePolls}): ${rowText.slice(0, 120)}`);
+
+    // 상태 변화 감지: Monitoring Agent 열이 "Not installed"에서 다른 값으로 변경
+    // 행 구조: [name][nodeId][Status][MonAgentStatus][LogAgentStatus]
+    // "Not installed"가 설치 전 2개였다가 MonAgent 설치 후 1개(LogAgent만)로 줄어야 함
+    const notInstalledCount = (rowText.match(/not installed/gi) ?? []).length;
+    const hasInstalling     = /INSTALLING|Installing|In Progress/i.test(rowText);
+    const hasFailed         = /FAILED|Error/i.test(rowText);
+    // MonAgent 설치 완료: Active / SUCCESS / SERVICE_INACTIVE / Uninstall 버튼으로 전환
+    const monAgentInstalled = /Active|SUCCESS|SERVICE_INACTIVE|Uninstall/i.test(rowText)
+      || (notInstalledCount < 2 && !hasInstalling);
+
+    if (hasFailed) {
+      finalStatus = 'FAILED';
+      break;
+    }
+
+    if (monAgentInstalled && !hasInstalling) {
+      finalStatus = 'SUCCESS';
+      break;
+    }
+
+    if (hasInstalling) {
+      // 설치 진행 중 — noChange 카운터 리셋 (변화 있음)
+      noChangeCount = 0;
+      finalStatus = 'INSTALLING';
+    } else {
+      // 상태 변화 없음 체크
+      if (rowText === lastRowText) {
+        noChangeCount++;
+        if (noChangeCount >= maxNoChangePolls) {
+          finalStatus = 'FAILED';
+          console.log(`[${tag}] AGENT-03: ${maxNoChangePolls}회 연속 상태 변화 없음 → 설치 실패`);
+          break;
+        }
+      } else {
+        noChangeCount = 0;
+      }
+    }
+
+    lastRowText = rowText;
+    await page.waitForTimeout(intervalMs);
+  }
+
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-agent03-final.png`) }).catch(() => null);
+  store.set('obsAgentStatus', finalStatus);
+
+  if (finalStatus !== 'SUCCESS') {
+    // provider 실패 기록
+    const failedProviders = store.getOrDefault<string[]>('obsAgentFailedProviders', []);
+    failedProviders.push(targetMci);
+    store.set('obsAgentFailedProviders', failedProviders);
+    console.log(`[${tag}] AGENT-03: ${targetMci}/${targetInfra} Monitoring Agent 설치 실패 기록`);
+  }
+
+  if (finalStatus === 'SUCCESS') {
+    console.log(`[${tag}] AGENT-03: Monitoring Agent 설치 SUCCESS (${targetMci}/${targetInfra})`);
+  } else if (finalStatus === 'FAILED') {
+    throw new Error(`[${tag}] AGENT-03: ${targetMci}/${targetInfra} Monitoring Agent 설치 FAILED (상태 변화 없음 또는 오류)`);
+  } else {
+    throw new Error(`[${tag}] AGENT-03: 상태 폴링 타임아웃 5분 초과 (마지막 상태: ${finalStatus}, mci=${targetMci})`);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ─────────────────────────────────────────────────────────────────────────────
+// OBS Insight 공통 헬퍼: Insight 탭 진입
+// /embed/log/{ns} 이동 후 iframe 내 "Insight" 탭 버튼 클릭
+// ─────────────────────────────────────────────────────────────────────────────
+async function gotoInsightTab(
+  frame: import('@playwright/test').Frame,
+  page: import('@playwright/test').Page,
+  origin: string,
+  tag: string,
+): Promise<boolean> {
+  await frame.goto(`${origin}/embed/log/default`, { waitUntil: 'domcontentloaded', timeout: 15_000 }).catch(() => null);
+  await page.waitForTimeout(1_500);
+
+  const insightTab = frame.locator('button').filter({ hasText: /^Insight$/i }).first();
+  const visible = await insightTab.waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true).catch(() => false);
+
+  if (!visible) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-insight-tab.png`) }).catch(() => null);
+    console.log(`[${tag}] Insight 탭 미발견 — iframe body: ${((await frame.locator('body').textContent().catch(() => '')) ?? '').slice(0, 200).replace(/\s+/g, ' ')}`);
+    return false;
+  }
+
+  await insightTab.click();
+  await page.waitForTimeout(1_500);
+  console.log(`[${tag}] Insight 탭 클릭 완료`);
+  return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-INSIGHT-01: Anomaly Detection 설정
+//
+// 1. Insight → Anomaly Detection 탭 진입
+// 2. 측정항목(measurement) 옵션 로드 확인
+// 3. 측정항목·대상(scope)·주기(interval) 지정 후 설정 생성 (Create/Add 클릭)
+// 4. 설정 목록에 추가 확인
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsInsight01(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  const hasInsight = await gotoInsightTab(frame, page, origin, tag);
+  if (!hasInsight) throw new Error(`[${tag}] Insight 탭 미발견 — OBS Insight 화면 진입 불가`);
+
+  // Anomaly Detection 하위 탭 클릭
+  const anomalyTab = frame.locator('button, li, a, .tab').filter({ hasText: /anomaly.*detection|Anomaly Detection/i }).first();
+  const hasAnomalyTab = await anomalyTab.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+  if (hasAnomalyTab) {
+    await anomalyTab.click();
+    await page.waitForTimeout(1_500);
+    console.log(`[${tag}] Anomaly Detection 탭 클릭`);
+  }
+
+  // 측정항목(measurement) 옵션 로드 확인
+  // GET /api/o11y/insight/anomaly-detection/options 결과가 드롭다운으로 표시됨
+  const measurementSelect = frame.locator('select, [class*="select"], [class*="dropdown"]').first();
+  const hasMeasurement = await measurementSelect.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasMeasurement) {
+    const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+    console.log(`[${tag}] 측정항목 드롭다운 미발견 — body: ${bodyText.slice(0, 200).replace(/\s+/g, ' ')}`);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-measurement-select.png`) }).catch(() => null);
+    throw new Error(`[${tag}] INSIGHT-01: 측정항목 드롭다운 미발견`);
+  }
+
+  // 첫 번째 측정항목 선택
+  await measurementSelect.selectOption({ index: 1 }).catch(async () => {
+    // click-based dropdown
+    await measurementSelect.click().catch(() => null);
+    await page.waitForTimeout(500);
+    await frame.locator('.dropdown-item, option, li').first().click().catch(() => null);
+  });
+  await page.waitForTimeout(500);
+
+  // scope/interval 기본값 유지 (첫 번째 옵션 자동 선택)
+
+  // Create / Add 버튼 클릭
+  const createBtn = frame.locator('button').filter({ hasText: /create|add|추가|생성/i }).first();
+  const hasCreate = await createBtn.waitFor({ state: 'visible', timeout: 5_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasCreate) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-create-btn.png`) }).catch(() => null);
+    throw new Error(`[${tag}] INSIGHT-01: Create/Add 버튼 미발견`);
+  }
+
+  await createBtn.click();
+  await page.waitForTimeout(2_000);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-anomaly-setting-created.png`) }).catch(() => null);
+
+  // 설정 목록 확인 (POST 후 목록에 추가됨)
+  const settingsList = frame.locator('table tr, .tabulator-row, [class*="setting-item"]');
+  const listCount = await settingsList.count().catch(() => 0);
+  console.log(`[${tag}] INSIGHT-01: 설정 목록 ${listCount}건`);
+  store.set('obsAnomalySettingCount', listCount);
+
+  if (listCount === 0) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-empty-settings-list.png`) }).catch(() => null);
+    throw new Error(`[${tag}] INSIGHT-01: 설정 생성 후 목록 비어 있음`);
+  }
+
+  console.log(`[${tag}] TC-OBS-INSIGHT-01 완료 — Anomaly Detection 설정 추가`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-INSIGHT-02: Anomaly History 조회
+//
+// 1. Insight → Anomaly Detection 탭 내 "Anomaly Detection History" 섹션
+// 2. 측정항목 선택 → Load 버튼 클릭
+// 3. GET .../history?measurement=...&start_time=...&end_time=...
+// 4. anomaly_score 시계열 차트 표시 확인
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsInsight02(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  const hasInsight = await gotoInsightTab(frame, page, origin, tag);
+  if (!hasInsight) throw new Error(`[${tag}] Insight 탭 미발견`);
+
+  // Anomaly Detection 탭
+  const anomalyTab = frame.locator('button, li, a, .tab').filter({ hasText: /anomaly.*detection/i }).first();
+  if (await anomalyTab.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await anomalyTab.click();
+    await page.waitForTimeout(1_500);
+  }
+
+  // "Anomaly Detection History" 섹션 탐색
+  const historySection = frame.locator('[class*="history"], [id*="history"], h2, h3, label')
+    .filter({ hasText: /history|이력/i }).first();
+  const hasHistory = await historySection.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasHistory) {
+    const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+    console.log(`[${tag}] History 섹션 미발견 — body: ${bodyText.slice(0, 200).replace(/\s+/g, ' ')}`);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-history-section.png`) }).catch(() => null);
+    throw new Error(`[${tag}] INSIGHT-02: Anomaly Detection History 섹션 미발견`);
+  }
+
+  // 측정항목(measurement) 선택
+  const measurementSel = frame.locator('select, [class*="select"]').filter({ hasText: /cpu|memory|measurement/i })
+    .first();
+  if (await measurementSel.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await measurementSel.selectOption({ index: 1 }).catch(() => null);
+    await page.waitForTimeout(300);
+  }
+
+  // Load 버튼 클릭
+  const loadBtn = frame.locator('button').filter({ hasText: /load|조회|검색/i }).first();
+  const hasLoad = await loadBtn.waitFor({ state: 'visible', timeout: 5_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasLoad) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-load-btn.png`) }).catch(() => null);
+    throw new Error(`[${tag}] INSIGHT-02: Load 버튼 미발견`);
+  }
+
+  await loadBtn.click();
+  await page.waitForTimeout(3_000);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-anomaly-history.png`) }).catch(() => null);
+
+  // anomaly_score 시계열 차트 확인 (canvas 또는 svg 차트)
+  const chart = frame.locator('canvas, svg[class*="chart"], [class*="chart"], [class*="graph"]').first();
+  const hasChart = await chart.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+
+  const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const hasAnomalyScore = /anomaly.?score|score/i.test(bodyText);
+
+  console.log(`[${tag}] INSIGHT-02: 차트 표시=${hasChart}, anomaly_score 텍스트=${hasAnomalyScore}`);
+
+  if (!hasChart && !hasAnomalyScore) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-anomaly-chart.png`) }).catch(() => null);
+    throw new Error(`[${tag}] INSIGHT-02: anomaly_score 시계열 차트 미표시`);
+  }
+
+  console.log(`[${tag}] TC-OBS-INSIGHT-02 완료 — Anomaly History 차트 확인`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-INSIGHT-03: Prediction(예측)
+//
+// 1. Insight → Prediction 탭
+// 2. 측정항목 선택 → 예측 실행(POST)
+// 3. GET .../history?measurement=...
+// 4. predicted_value 시계열(과거+미래) 차트 확인
+//    (CPU: 100-usage_idle 사용률로 표시)
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsInsight03(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  const hasInsight = await gotoInsightTab(frame, page, origin, tag);
+  if (!hasInsight) throw new Error(`[${tag}] Insight 탭 미발견`);
+
+  // Prediction 하위 탭 클릭
+  const predTab = frame.locator('button, li, a, .tab').filter({ hasText: /^prediction$|예측/i }).first();
+  const hasPredTab = await predTab.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+
+  if (hasPredTab) {
+    await predTab.click();
+    await page.waitForTimeout(1_500);
+    console.log(`[${tag}] Prediction 탭 클릭`);
+  } else {
+    warn(tag, 'Prediction 탭 미발견 — Insight 화면 내 별도 탭 없을 수 있음');
+  }
+
+  // 옵션 조회 확인 (GET /api/o11y/insight/predictions/options → 드롭다운)
+  const measurementSel = frame.locator('select, [class*="select"], [class*="dropdown"]').first();
+  const hasMeasurement = await measurementSel.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasMeasurement) {
+    const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+    console.log(`[${tag}] 측정항목 드롭다운 미발견 — body: ${bodyText.slice(0, 200).replace(/\s+/g, ' ')}`);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-prediction-select.png`) }).catch(() => null);
+    throw new Error(`[${tag}] INSIGHT-03: 측정항목 드롭다운 미발견`);
+  }
+
+  // 측정항목 선택 (cpu 우선, 없으면 첫 번째)
+  const cpuOpt = frame.locator('option, .dropdown-item, li').filter({ hasText: /cpu/i }).first();
+  if (await cpuOpt.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await cpuOpt.click().catch(() => null);
+  } else {
+    await measurementSel.selectOption({ index: 1 }).catch(() => null);
+  }
+  await page.waitForTimeout(500);
+
+  // 예측 실행 버튼 (POST)
+  const runBtn = frame.locator('button').filter({ hasText: /run|predict|실행|조회/i }).first();
+  const hasRun = await runBtn.waitFor({ state: 'visible', timeout: 5_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasRun) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-run-btn.png`) }).catch(() => null);
+    throw new Error(`[${tag}] INSIGHT-03: 예측 실행 버튼 미발견`);
+  }
+
+  await runBtn.click();
+  await page.waitForTimeout(4_000);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-prediction-result.png`) }).catch(() => null);
+
+  // predicted_value 시계열 차트 확인
+  const chart = frame.locator('canvas, svg[class*="chart"], [class*="chart"], [class*="graph"]').first();
+  const hasChart = await chart.waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true).catch(() => false);
+
+  const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const hasPredicted = /predict|predicted.?value|forecast/i.test(bodyText);
+
+  console.log(`[${tag}] INSIGHT-03: 차트 표시=${hasChart}, predicted_value=${hasPredicted}`);
+
+  if (!hasChart && !hasPredicted) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-prediction-chart.png`) }).catch(() => null);
+    throw new Error(`[${tag}] INSIGHT-03: predicted_value 시계열 차트 미표시`);
+  }
+
+  console.log(`[${tag}] TC-OBS-INSIGHT-03 완료 — Prediction 차트 확인`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-INSIGHT-04: Server Error Analysis (LLM)
+//
+// 1. Insight → 'Server Error Analysis' 탭
+// 2. LLM 모델/세션 조회 (GET /api/o11y/insight/llm/model, /llm/session)
+// 3. 측정항목·범위 지정 → 서버 에러 분석 실행 (POST .../server-error-analysis/detect)
+// 4. 분석 레코드 목록/상세 확인 (GET .../records, GET .../records/{analysisId})
+// 5. LLM 세션 히스토리 및 분석 결과 메시지 표시 확인
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsInsight04(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  const hasInsight = await gotoInsightTab(frame, page, origin, tag);
+  if (!hasInsight) throw new Error(`[${tag}] Insight 탭 미발견`);
+
+  // Server Error Analysis 탭 클릭
+  const seaTab = frame.locator('button, li, a, .tab')
+    .filter({ hasText: /server.?error|error.?analysis|서버.?에러/i }).first();
+  const hasSeaTab = await seaTab.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+
+  if (hasSeaTab) {
+    await seaTab.click();
+    await page.waitForTimeout(1_500);
+    console.log(`[${tag}] Server Error Analysis 탭 클릭`);
+  } else {
+    warn(tag, 'Server Error Analysis 탭 미발견 — Insight 화면 내 탭 구성 확인 필요');
+  }
+
+  // LLM 모델/세션 로드 확인 (GET /llm/model, /llm/session 결과 → 드롭다운 또는 텍스트)
+  await page.waitForTimeout(2_000);
+  const bodyText1 = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const hasLlmModel = /model|session|LLM|gpt|claude|ollama/i.test(bodyText1);
+  console.log(`[${tag}] LLM 모델/세션 로드: ${hasLlmModel} — body: ${bodyText1.slice(0, 150).replace(/\s+/g, ' ')}`);
+
+  if (!hasLlmModel) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-llm-model.png`) }).catch(() => null);
+    throw new Error(`[${tag}] INSIGHT-04: LLM 모델/세션 정보 미표시`);
+  }
+
+  // 측정항목/범위 선택 (드롭다운 또는 기본값 유지)
+  const measurementSel = frame.locator('select, [class*="select"]').first();
+  if (await measurementSel.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await measurementSel.selectOption({ index: 1 }).catch(() => null);
+    await page.waitForTimeout(300);
+  }
+
+  // 분석 실행 버튼 (POST /server-error-analysis/detect)
+  const detectBtn = frame.locator('button')
+    .filter({ hasText: /detect|analyze|분석|실행|run/i }).first();
+  const hasDetect = await detectBtn.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasDetect) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-detect-btn.png`) }).catch(() => null);
+    throw new Error(`[${tag}] INSIGHT-04: 분석 실행(Detect) 버튼 미발견`);
+  }
+
+  await detectBtn.click();
+  await page.waitForTimeout(3_000);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-sea-detect-clicked.png`) }).catch(() => null);
+
+  // 분석 레코드 목록 확인 (GET .../records)
+  // 레코드가 테이블 행 또는 리스트로 표시됨
+  const recordRows = frame.locator('table tr, .tabulator-row, [class*="record"], [class*="analysis-item"]');
+  let recordCount = 0;
+  for (let i = 0; i < 6; i++) {
+    recordCount = await recordRows.count().catch(() => 0);
+    if (recordCount > 0) break;
+    await page.waitForTimeout(2_000);
+  }
+  console.log(`[${tag}] INSIGHT-04: 분석 레코드 ${recordCount}건`);
+  store.set('obsSeaRecordCount', recordCount);
+
+  if (recordCount === 0) {
+    // 분석 실행 직후라 아직 레코드가 없을 수 있음 — LLM 응답 대기
+    warn(tag, '분석 레코드 0건 — LLM 분석 진행 중일 수 있음');
+  }
+
+  // 첫 번째 레코드 클릭 → 상세 확인 (GET .../records/{analysisId})
+  if (recordCount > 0) {
+    await recordRows.first().click().catch(() => null);
+    await page.waitForTimeout(2_000);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-sea-record-detail.png`) }).catch(() => null);
+  }
+
+  // LLM 세션 히스토리 및 분석 결과 메시지 확인
+  const bodyText2 = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const hasResult = /analysis|error|LLM|message|결과|분석/i.test(bodyText2);
+  const hasHistory = /history|session|이력/i.test(bodyText2);
+
+  console.log(`[${tag}] INSIGHT-04: 분석결과=${hasResult}, 세션히스토리=${hasHistory}`);
+
+  if (!hasResult) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-sea-result.png`) }).catch(() => null);
+    throw new Error(`[${tag}] INSIGHT-04: 서버 에러 분석 결과 메시지 미표시`);
+  }
+
+  console.log(`[${tag}] TC-OBS-INSIGHT-04 완료 — LLM 서버 에러 분석 결과 확인`);
+}
+
+// runObsIframeGeneric: TC-OBS-AGENT-04~05, METRIC-*, LOG-*, INSIGHT-*, TRIG-*, TRACE-*, IFRAME-*
+//
+// 공통 흐름:
+//   1. observability 외부 페이지 로드 + ws01/default 선택
+//   2. iframe(18081) frame 참조 획득
+//   3. TC 그룹에 따라 /embed/config/{ns} 또는 /embed/log/{ns} 로 iframe 이동
+//   4. 필요 시 탭 버튼(Monitoring|Logs|Config|Insight|Alerts|Tracing) 클릭
+//   5. iframe body 내용 검증
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsIframeGeneric(ctx: StepRunContext, tag: string, tcId: string): Promise<void> {
+  const { page } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) { warn(tag, `${tcId}: OBS iframe 미발견`); return; }
+
+  const origin = await obsIframeOrigin(page);
+
+  // TC 그룹에 따라 embed URL 및 탭 결정
+  type ObsTarget = { embedUrl: string; tab?: string; check: RegExp };
+  const targets: Record<string, ObsTarget> = {
+    'TC-OBS-AGENT-04': { embedUrl: `${origin}/embed/config/default`, check: /plugin|item|metric|cpu|disk/i },
+    'TC-OBS-AGENT-05': { embedUrl: `${origin}/embed/config/default`, check: /Uninstall|Remove|Unknown|Active/i },
+    'TC-OBS-METRIC-01': { embedUrl: `${origin}/embed/log/default`, tab: 'Monitoring', check: /Monitoring Trend|Workload|Measurement/i },
+    'TC-OBS-METRIC-02': { embedUrl: `${origin}/embed/log/default`, tab: 'Monitoring', check: /Monitoring Trend|Workload|cpu|disk/i },
+    'TC-OBS-METRIC-03': { embedUrl: `${origin}/embed/log/default`, tab: 'Monitoring', check: /Monitoring Trend|K8s|cluster/i },
+    'TC-OBS-METRIC-04': { embedUrl: `${origin}/embed/log/default`, tab: 'Monitoring', check: /Monitoring Trend|Workload/i },
+    'TC-OBS-INSIGHT-01': { embedUrl: `${origin}/embed/log/default`, tab: 'Insight', check: /Insight|Anomaly|Detection|Prediction/i },
+    'TC-OBS-INSIGHT-02': { embedUrl: `${origin}/embed/log/default`, tab: 'Insight', check: /Insight|History|Anomaly/i },
+    'TC-OBS-INSIGHT-03': { embedUrl: `${origin}/embed/log/default`, tab: 'Insight', check: /Insight|Predict/i },
+    'TC-OBS-INSIGHT-04': { embedUrl: `${origin}/embed/log/default`, tab: 'Insight', check: /Insight|Analysis|LLM|Error/i },
+    'TC-OBS-LOG-01': { embedUrl: `${origin}/embed/log/default`, tab: 'Logs', check: /Log|label|Loki/i },
+    'TC-OBS-LOG-02': { embedUrl: `${origin}/embed/log/default`, tab: 'Logs', check: /Log|search|query|keyword/i },
+    'TC-OBS-TRACE-01': { embedUrl: `${origin}/embed/log/default`, tab: 'Tracing', check: /Trac|Tempo|span/i },
+    'TC-OBS-TRACE-02': { embedUrl: `${origin}/embed/log/default`, tab: 'Tracing', check: /Trac|Tempo|span|detail/i },
+    'TC-OBS-TRACE-03': { embedUrl: `${origin}/embed/log/default`, tab: 'Tracing', check: /Trac|iframe|Grafana/i },
+    'TC-OBS-TRIG-01': { embedUrl: `${origin}/embed/log/default`, tab: 'Alerts', check: /Alert|Trigger|Policy/i },
+    'TC-OBS-TRIG-02': { embedUrl: `${origin}/embed/log/default`, tab: 'Alerts', check: /Alert|Target|Node/i },
+    'TC-OBS-TRIG-03': { embedUrl: `${origin}/embed/log/default`, tab: 'Alerts', check: /Alert|Channel|알림/i },
+    'TC-OBS-TRIG-04': { embedUrl: `${origin}/embed/log/default`, tab: 'Alerts', check: /Alert|History|이력/i },
+    'TC-OBS-TRIG-05': { embedUrl: `${origin}/embed/log/default`, tab: 'Alerts', check: /Alert|Policy|수정|Edit/i },
+    'TC-OBS-IFRAME-01': { embedUrl: `${origin}/embed/monitoring/default`, check: /Namespace|mci|Node|K8s/i },
+  };
+
+  const target = targets[tcId];
+  if (!target) {
+    warn(tag, `${tcId}: runObsIframeGeneric에 target 없음 — 기본 overview 확인`);
+    const overviewText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+    console.log(`[${tag}] ${tcId}: overview body = ${overviewText.slice(0, 200).replace(/\s+/g, ' ')}`);
+    return;
+  }
+
+  // iframe URL 이동
+  await frame.goto(target.embedUrl, { waitUntil: 'domcontentloaded', timeout: 15_000 }).catch(() => null);
+  await page.waitForTimeout(2_000);
+
+  // 탭 클릭 (필요한 경우)
+  if (target.tab) {
+    const tabBtn = frame.locator('button').filter({ hasText: new RegExp(`^${target.tab}$`, 'i') }).first();
+    const tabVisible = await tabBtn.isVisible({ timeout: 5_000 }).catch(() => false);
+    if (tabVisible) {
+      await tabBtn.click();
+      await page.waitForTimeout(2_000);
+      console.log(`[${tag}] ${tcId}: ${target.tab} 탭 클릭`);
+    } else {
+      warn(tag, `${tcId}: ${target.tab} 탭 버튼 미발견 — iframe에 탭 없음 (Start Monitoring 필요할 수 있음)`);
+    }
+  }
+
+  // 내용 확인
+  const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const matched = target.check.test(bodyText);
+  console.log(`[${tag}] ${tcId}: 검증=${matched} (체크패턴=${target.check.source})`);
+  console.log(`[${tag}] ${tcId}: body 미리보기 = ${bodyText.slice(0, 300).replace(/\s+/g, ' ')}`);
+
+  if (!matched) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-obs-check-fail.png`) }).catch(() => null);
+    warn(tag, `${tcId}: 기대 패턴 미일치 (체크=${target.check.source}) — iframe 로드 완료 여부 확인 필요`);
+  }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OBS Log 공통 헬퍼: LogViewer(Logs 탭) 진입
+// /embed/log/{ns} 이동 후 iframe 내 "Logs" 탭 버튼 클릭
+// ─────────────────────────────────────────────────────────────────────────────
+async function gotoLogsTab(
+  frame: import('@playwright/test').Frame,
+  page: import('@playwright/test').Page,
+  origin: string,
+  tag: string,
+): Promise<boolean> {
+  await frame.goto(`${origin}/embed/log/default`, { waitUntil: 'domcontentloaded', timeout: 15_000 }).catch(() => null);
+  await page.waitForTimeout(1_500);
+
+  const logsTab = frame.locator('button').filter({ hasText: /^Logs$/i }).first();
+  const visible = await logsTab.waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true).catch(() => false);
+
+  if (!visible) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-logs-tab.png`) }).catch(() => null);
+    return false;
+  }
+
+  await logsTab.click();
+  await page.waitForTimeout(1_500);
+  console.log(`[${tag}] Logs 탭 클릭 완료`);
+  return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-LOG-01: 라벨 조회 (LogViewer)
+//
+// 1. Logs 탭(LogViewer) 진입 (/logs/{nsId}[/{infraId}[/{nodeId}]])
+// 2. GET /api/o11y/log/labels → 라벨 키 목록
+//    GET /api/o11y/log/labels/{label}/values → 라벨 값
+// 3. Workload(Infra/Node)·Server 셀렉터에 라벨/값 반영 확인
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsLog01(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  const hasLogs = await gotoLogsTab(frame, page, origin, tag);
+  if (!hasLogs) throw new Error(`[${tag}] Logs 탭 미발견 — LogViewer 진입 불가`);
+
+  // Workload / Server 셀렉터 로드 대기
+  await page.waitForTimeout(2_000);
+  const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+
+  // 라벨 키/값이 드롭다운 옵션으로 표시됨
+  const selects = frame.locator('select, [class*="select"], [class*="dropdown"]');
+  const selectCount = await selects.count().catch(() => 0);
+  console.log(`[${tag}] LOG-01: 셀렉터 수 = ${selectCount}`);
+
+  // Workload(Infra/Node) 셀렉터 확인
+  const hasWorkload  = /workload|infra|node|Infra|Node/i.test(bodyText);
+  // Server 셀렉터 확인
+  const hasServer    = /server|Server/i.test(bodyText);
+  // 라벨 관련 텍스트
+  const hasLabelData = /label|namespace|NS_ID|INFRA_ID|NODE_ID/i.test(bodyText);
+
+  console.log(`[${tag}] LOG-01: workload=${hasWorkload}, server=${hasServer}, labelData=${hasLabelData}, 셀렉터=${selectCount}`);
+  store.set('obsLogLabelLoaded', hasLabelData);
+
+  if (!hasWorkload && !hasServer && !hasLabelData) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-log-selectors.png`) }).catch(() => null);
+    throw new Error(`[${tag}] LOG-01: LogViewer에 Workload/Server 셀렉터 또는 라벨 데이터 미표시`);
+  }
+
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-log-labels.png`) }).catch(() => null);
+  console.log(`[${tag}] TC-OBS-LOG-01 완료 — 라벨/셀렉터 확인`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-LOG-02: 키워드 검색 (LogQL)
+//
+// 1. LogViewer에서 Workload(Infra/Node)·Server 선택 후 Keyword("error") 입력 → Search
+// 2. LogQL 자동 생성: {NS_ID="...",INFRA_ID="..."[,NODE_ID="..."]} |~ "(?i)error"
+// 3. GET /api/o11y/log/query_range?query=...&start=...&end=...&limit=...&direction=BACKWARD
+// 4. 로그 표(Timestamp/Level/Node/Service/Message) 및 통계 확인, 행 클릭 시 상세 확인
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsLog02(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  const hasLogs = await gotoLogsTab(frame, page, origin, tag);
+  if (!hasLogs) throw new Error(`[${tag}] Logs 탭 미발견`);
+
+  await page.waitForTimeout(1_500);
+
+  // Workload 셀렉터에서 Infra 또는 Node 선택 (첫 번째 항목)
+  const workloadSel = frame.locator('select, [class*="select"]')
+    .filter({ hasText: /infra|node|workload/i }).first();
+  if (await workloadSel.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await workloadSel.selectOption({ index: 1 }).catch(() => null);
+    await page.waitForTimeout(500);
+  }
+
+  // Server 셀렉터 (첫 번째 항목)
+  const serverSel = frame.locator('select, [class*="select"]')
+    .filter({ hasText: /server|service/i }).first();
+  if (await serverSel.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await serverSel.selectOption({ index: 1 }).catch(() => null);
+    await page.waitForTimeout(300);
+  }
+
+  // Keyword 입력 필드에 "error" 입력
+  const keywordInput = frame.locator('input[type="text"], input[placeholder*="keyword" i], input[placeholder*="search" i], input')
+    .filter({ hasText: '' }).first();
+  const hasInput = await keywordInput.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasInput) {
+    // placeholder 속성으로 탐색
+    const inputByPlaceholder = frame.locator('input[placeholder]').first();
+    if (await inputByPlaceholder.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await inputByPlaceholder.fill('error');
+    } else {
+      await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-keyword-input.png`) }).catch(() => null);
+      throw new Error(`[${tag}] LOG-02: Keyword 입력 필드 미발견`);
+    }
+  } else {
+    await keywordInput.fill('error');
+  }
+  await page.waitForTimeout(300);
+
+  // Search 버튼 클릭 또는 Enter
+  const searchBtn = frame.locator('button').filter({ hasText: /search|검색/i }).first();
+  const hasSearch = await searchBtn.isVisible({ timeout: 3_000 }).catch(() => false);
+  if (hasSearch) {
+    await searchBtn.click();
+  } else {
+    await keywordInput.press('Enter').catch(() => null);
+  }
+  await page.waitForTimeout(3_000);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-log-search-result.png`) }).catch(() => null);
+
+  // 로그 표 확인 (Timestamp/Level/Node/Service/Message 컬럼)
+  const logTable = frame.locator('table, .tabulator, [class*="log-table"], [class*="log-list"]').first();
+  const hasTable = await logTable.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+
+  const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const hasLogCols = /timestamp|level|message|node|service/i.test(bodyText);
+  // LogQL 자동 생성 확인 (쿼리 미리보기 또는 입력창에 NS_ID/INFRA_ID 포함)
+  const hasLogQL  = /NS_ID|INFRA_ID|logql|query_range|\|\~/i.test(bodyText);
+
+  console.log(`[${tag}] LOG-02: 로그표=${hasTable}, 컬럼확인=${hasLogCols}, LogQL=${hasLogQL}`);
+
+  if (!hasTable && !hasLogCols) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-log-table.png`) }).catch(() => null);
+    throw new Error(`[${tag}] LOG-02: 로그 결과 표 미표시`);
+  }
+
+  // 첫 번째 로그 행 클릭 → 상세 확인
+  const logRows = frame.locator('table tr:not(:first-child), .tabulator-row, [class*="log-row"]');
+  const rowCount = await logRows.count().catch(() => 0);
+  console.log(`[${tag}] LOG-02: 로그 행 수 = ${rowCount}`);
+
+  if (rowCount > 0) {
+    await logRows.first().click().catch(() => null);
+    await page.waitForTimeout(1_500);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-log-row-detail.png`) }).catch(() => null);
+    // 상세 패널 또는 모달 확인
+    const detailBody = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+    const hasDetail = /message|detail|상세/i.test(detailBody);
+    console.log(`[${tag}] LOG-02: 행 상세 표시 = ${hasDetail}`);
+  } else {
+    warn(tag, '"error" 키워드 검색 결과 0건 — 로그 없거나 Agent 미설치 상태일 수 있음');
+  }
+
+  console.log(`[${tag}] TC-OBS-LOG-02 완료 — LogQL 키워드 검색 및 로그 표 확인`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OBS Trace 공통 헬퍼: Tracing 탭 진입 + Scope/Service 기본 설정
+// /embed/log/{ns} 이동 후 "Tracing" 탭 클릭
+// ─────────────────────────────────────────────────────────────────────────────
+async function gotoTracingTab(
+  frame: import('@playwright/test').Frame,
+  page: import('@playwright/test').Page,
+  origin: string,
+  tag: string,
+): Promise<boolean> {
+  await frame.goto(`${origin}/embed/log/default`, { waitUntil: 'domcontentloaded', timeout: 15_000 }).catch(() => null);
+  await page.waitForTimeout(1_500);
+
+  const tracingTab = frame.locator('button').filter({ hasText: /^Tracing$/i }).first();
+  const visible = await tracingTab.waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true).catch(() => false);
+
+  if (!visible) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-tracing-tab.png`) }).catch(() => null);
+    return false;
+  }
+
+  await tracingTab.click();
+  await page.waitForTimeout(1_500);
+  console.log(`[${tag}] Tracing 탭 클릭 완료`);
+  return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-TRACE-01: Trace 검색 (Tempo)
+//
+// 1. Tracing 탭(TraceViewer) 진입
+// 2. Scope 선택: Framework / VM (노드 지정 시 VM 기본)
+// 3. Service 드롭다운 로드 확인 (GET /api/o11y/trace/services?scope=...)
+// 4. Range 기본값 유지 → Search 클릭
+// 5. 'List of Trace' 표(Start Time/Root Service/Root Name/Duration/Trace ID) 또는
+//    "No traces found" 표시 확인
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsTrace01(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  const hasTracing = await gotoTracingTab(frame, page, origin, tag);
+  if (!hasTracing) throw new Error(`[${tag}] Tracing 탭 미발견 — TraceViewer 진입 불가`);
+
+  await page.waitForTimeout(1_500);
+
+  // Scope 확인: Framework / VM 라디오 또는 드롭다운
+  const scopeFramework = frame.locator('input[type="radio"], button, label')
+    .filter({ hasText: /^Framework$/i }).first();
+  const scopeVm = frame.locator('input[type="radio"], button, label')
+    .filter({ hasText: /^VM$/i }).first();
+
+  const hasScope = await scopeFramework.isVisible({ timeout: 4_000 }).catch(() => false)
+    || await scopeVm.isVisible({ timeout: 1_000 }).catch(() => false);
+  console.log(`[${tag}] TRACE-01: Scope UI 발견 = ${hasScope}`);
+
+  // VM Scope 선택 (노드 지정 기본)
+  if (await scopeVm.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await scopeVm.click().catch(() => null);
+    await page.waitForTimeout(1_000);
+    console.log(`[${tag}] TRACE-01: VM Scope 선택`);
+  }
+
+  // Service 드롭다운 로드 확인 (GET /api/o11y/trace/services?scope=...)
+  const serviceSel = frame.locator('select, [class*="select"]')
+    .filter({ hasText: /service|all/i }).first();
+  const hasService = await serviceSel.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+  console.log(`[${tag}] TRACE-01: Service 드롭다운 = ${hasService}`);
+
+  // Range 기본값 유지 (1H·6H·12H·24H 중 하나)
+  const bodyText0 = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const hasRange = /1H|6H|12H|24H/i.test(bodyText0);
+  console.log(`[${tag}] TRACE-01: Range 옵션 = ${hasRange}`);
+
+  // Search 버튼 클릭
+  const searchBtn = frame.locator('button').filter({ hasText: /^search$|^검색$/i }).first();
+  const hasSearch = await searchBtn.waitFor({ state: 'visible', timeout: 6_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasSearch) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-trace-search-btn.png`) }).catch(() => null);
+    throw new Error(`[${tag}] TRACE-01: Search 버튼 미발견`);
+  }
+
+  await searchBtn.click();
+  await page.waitForTimeout(3_000);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trace-search-result.png`) }).catch(() => null);
+
+  // 'List of Trace' 표 또는 "No traces found" 확인
+  const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const hasTraceTable  = /trace.?id|root.?service|root.?name|duration|start.?time/i.test(bodyText);
+  const hasNoTrace     = /no.?trace|없음|0건/i.test(bodyText);
+
+  console.log(`[${tag}] TRACE-01: traceTable=${hasTraceTable}, noTrace=${hasNoTrace}`);
+  store.set('obsTraceHasResults', hasTraceTable && !hasNoTrace);
+
+  if (!hasTraceTable && !hasNoTrace) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trace-unknown.png`) }).catch(() => null);
+    throw new Error(`[${tag}] TRACE-01: 트레이스 결과 표 및 "No traces found" 모두 미표시`);
+  }
+
+  // 결과 행 수 기록
+  const traceRows = frame.locator('table tr:not(:first-child), .tabulator-row');
+  const rowCount = await traceRows.count().catch(() => 0);
+  store.set('obsTraceRowCount', rowCount);
+  console.log(`[${tag}] TRACE-01: 트레이스 행 수 = ${rowCount}`);
+
+  console.log(`[${tag}] TC-OBS-TRACE-01 완료 — List of Trace 확인`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-TRACE-02: Trace 상세 / Call Sequence
+//
+// 1. 'List of Trace' 행 클릭
+// 2. 단일 트레이스 조회(GET /api/o11y/trace/{traceId}) → 인라인 Call Sequence 펼침
+// 3. Span(Service/Span/Kind/Offset/Duration)·타임라인 막대 표시 확인
+// 4. 행 다시 클릭 → 접힘 확인
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsTrace02(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  const hasTracing = await gotoTracingTab(frame, page, origin, tag);
+  if (!hasTracing) throw new Error(`[${tag}] Tracing 탭 미발견`);
+
+  // Search 실행 (TRACE-01과 동일 흐름으로 목록 로드)
+  const searchBtn = frame.locator('button').filter({ hasText: /^search$|^검색$/i }).first();
+  if (await searchBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await searchBtn.click();
+    await page.waitForTimeout(3_000);
+  }
+
+  // 트레이스 행 탐색
+  const traceRows = frame.locator('table tr:not(:first-child), .tabulator-row').filter({ hasNotText: /no.?trace/i });
+  const rowCount = await traceRows.count().catch(() => 0);
+
+  if (rowCount === 0) {
+    const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+    const isNoTrace = /no.?trace|없음/i.test(bodyText);
+    if (isNoTrace) {
+      console.log(`[${tag}] TRACE-02: 트레이스 없음 — Call Sequence 확인 불가 (No traces found)`);
+      return;
+    }
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-trace-rows.png`) }).catch(() => null);
+    throw new Error(`[${tag}] TRACE-02: 트레이스 목록 행 없음`);
+  }
+
+  // 첫 번째 행 클릭 → Call Sequence 인라인 펼침
+  const targetRow = traceRows.first();
+  const rowText = ((await targetRow.textContent().catch(() => '')) ?? '').replace(/\s+/g, ' ').trim().slice(0, 100);
+  console.log(`[${tag}] TRACE-02: 클릭 대상 행 = ${rowText}`);
+
+  await targetRow.click();
+  await page.waitForTimeout(2_500);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trace-detail-open.png`) }).catch(() => null);
+
+  // Call Sequence 펼침 확인: Span 정보(Service/Span/Kind/Offset/Duration) 또는 타임라인
+  const bodyAfter = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const hasSpan     = /span|service|kind|offset|duration/i.test(bodyAfter);
+  const hasTimeline = await frame.locator('svg, canvas, [class*="timeline"], [class*="span-bar"]')
+    .first().isVisible({ timeout: 3_000 }).catch(() => false);
+
+  console.log(`[${tag}] TRACE-02: span정보=${hasSpan}, timeline=${hasTimeline}`);
+
+  if (!hasSpan && !hasTimeline) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-call-sequence.png`) }).catch(() => null);
+    throw new Error(`[${tag}] TRACE-02: Call Sequence(Span/타임라인) 미표시`);
+  }
+
+  // 같은 행 다시 클릭 → 접힘 확인
+  await targetRow.click();
+  await page.waitForTimeout(1_500);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trace-detail-closed.png`) }).catch(() => null);
+  const bodyAfterClose = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  // 접히면 상세 span 수가 줄어야 하나, 텍스트 기반으로는 단순 비교
+  const stillExpanded = bodyAfterClose.length > bodyAfter.length + 200;
+  console.log(`[${tag}] TRACE-02: 접힘 후 body 길이 변화 (재확장=${stillExpanded})`);
+
+  console.log(`[${tag}] TC-OBS-TRACE-02 완료 — Call Sequence 인라인 펼침/접힘 확인`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-TRACE-03: Trace iframe 임베드
+//
+// 1. /embed/trace/{nsId}/{infraId}[/{nodeId}] 직접 진입 (EmbedLayout)
+// 2. 네비/사이드바 없는 전체화면 Trace 화면 로드 확인
+// 3. 임베드 화면에서 Scope/Service/검색 및 Call Sequence 정상 동작 확인
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsTrace03(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  const mciId  = store.getOrDefault<string>('mciId', 'default');
+
+  // /embed/trace/{nsId}/{infraId} 직접 이동 (EmbedLayout)
+  const embedUrl = `${origin}/embed/trace/default/${mciId}`;
+  console.log(`[${tag}] TRACE-03: 임베드 URL = ${embedUrl}`);
+
+  await frame.goto(embedUrl, { waitUntil: 'domcontentloaded', timeout: 15_000 }).catch(() => null);
+  await page.waitForTimeout(2_500);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trace-embed.png`) }).catch(() => null);
+
+  const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+
+  // EmbedLayout: 네비/사이드바 없는 전체화면 확인
+  // 일반 nav/sidebar 요소 없이 Trace 콘텐츠만 표시
+  const hasNav  = await frame.locator('nav, [class*="sidebar"], [class*="navigation"]')
+    .first().isVisible({ timeout: 2_000 }).catch(() => false);
+  const hasTrace = /scope|service|search|trace|span/i.test(bodyText);
+
+  console.log(`[${tag}] TRACE-03: nav=${hasNav}(없어야 함), traceContent=${hasTrace}`);
+
+  if (!hasTrace) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trace-embed-empty.png`) }).catch(() => null);
+    throw new Error(`[${tag}] TRACE-03: 임베드 Trace 화면 로드 실패 — 콘텐츠 없음`);
+  }
+
+  if (hasNav) {
+    warn(tag, 'EmbedLayout임에도 nav/sidebar 감지 — 레이아웃 확인 필요');
+  }
+
+  // 임베드 화면에서 Search 실행 (Scope/Service 기본값 유지)
+  const searchBtn = frame.locator('button').filter({ hasText: /^search$|^검색$/i }).first();
+  if (await searchBtn.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await searchBtn.click();
+    await page.waitForTimeout(3_000);
+
+    const afterSearch = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+    const hasResult  = /trace.?id|no.?trace|start.?time/i.test(afterSearch);
+    console.log(`[${tag}] TRACE-03: 임베드 검색 결과 = ${hasResult}`);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trace-embed-search.png`) }).catch(() => null);
+
+    // 결과 있으면 행 클릭 → Call Sequence 확인
+    const rows = frame.locator('table tr:not(:first-child), .tabulator-row').filter({ hasNotText: /no.?trace/i });
+    if (await rows.count().then(n => n > 0).catch(() => false)) {
+      await rows.first().click();
+      await page.waitForTimeout(2_000);
+      const detailText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+      const hasSpan = /span|kind|offset|duration/i.test(detailText);
+      console.log(`[${tag}] TRACE-03: 임베드 Call Sequence = ${hasSpan}`);
+      await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trace-embed-detail.png`) }).catch(() => null);
+    }
+  } else {
+    warn(tag, 'TRACE-03: 임베드 화면 Search 버튼 미발견');
+  }
+
+  console.log(`[${tag}] TC-OBS-TRACE-03 완료 — Trace 임베드 화면 확인`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OBS Trigger 공통 헬퍼: Alerts → Policies 탭 진입
+// /embed/log/{ns} 이동 후 iframe 내 "Alerts" 탭 클릭
+// ─────────────────────────────────────────────────────────────────────────────
+async function gotoAlertsTab(
+  frame: import('@playwright/test').Frame,
+  page: import('@playwright/test').Page,
+  origin: string,
+  tag: string,
+): Promise<boolean> {
+  await frame.goto(`${origin}/embed/log/default`, { waitUntil: 'domcontentloaded', timeout: 15_000 }).catch(() => null);
+  await page.waitForTimeout(1_500);
+
+  const alertsTab = frame.locator('button').filter({ hasText: /^Alerts$/i }).first();
+  const visible = await alertsTab.waitFor({ state: 'visible', timeout: 10_000 })
+    .then(() => true).catch(() => false);
+
+  if (!visible) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-alerts-tab.png`) }).catch(() => null);
+    return false;
+  }
+
+  await alertsTab.click();
+  await page.waitForTimeout(1_500);
+  console.log(`[${tag}] Alerts 탭 클릭 완료`);
+  return true;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-TRIG-01: Trigger Policy 생성 / 목록 / 삭제
+//
+// 1. Alerts → Policies 탭 진입 (GET /api/o11y/trigger/policy?page=&size=)
+// 2. + New Policy → 생성 폼:
+//    title/description/resourceType(CPU)/aggregationType(AVG)/holdDuration(5m)/
+//    repeatInterval(1h)/thresholdCondition(info/warning/critical)
+// 3. 목록에 신규 정책 표시 확인
+// 4. 삭제 후 목록 제거 확인 (DELETE /api/o11y/trigger/policy/{id})
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsTrig01(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  const hasAlerts = await gotoAlertsTab(frame, page, origin, tag);
+  if (!hasAlerts) throw new Error(`[${tag}] Alerts 탭 미발견`);
+
+  await page.waitForTimeout(1_000);
+
+  // 정책 목록 로드 확인 (GET /api/o11y/trigger/policy)
+  const bodyInit = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const hasPolicyList = /policy|정책|no.?policy|create|new/i.test(bodyInit);
+  console.log(`[${tag}] TRIG-01: 정책 목록 영역 = ${hasPolicyList}`);
+
+  // + New Policy 버튼 클릭
+  const newPolicyBtn = frame.locator('button').filter({ hasText: /new.?policy|정책.?추가|\+.?new/i }).first();
+  const hasNewBtn = await newPolicyBtn.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasNewBtn) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-new-policy-btn.png`) }).catch(() => null);
+    throw new Error(`[${tag}] TRIG-01: "+ New Policy" 버튼 미발견`);
+  }
+
+  await newPolicyBtn.click();
+  await page.waitForTimeout(1_500);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-new-policy-form.png`) }).catch(() => null);
+
+  // 생성 폼 입력
+  const policyTitle = `e2e-trig-${Date.now()}`;
+
+  // Title 입력
+  const titleInput = frame.locator('input[name*="title" i], input[placeholder*="title" i], input').first();
+  if (await titleInput.isVisible({ timeout: 4_000 }).catch(() => false)) {
+    await titleInput.fill(policyTitle);
+    await page.waitForTimeout(200);
+  }
+
+  // Description 입력
+  const descInput = frame.locator('input[name*="desc" i], textarea[name*="desc" i], textarea').first();
+  if (await descInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await descInput.fill('E2E 자동 생성 정책');
+    await page.waitForTimeout(200);
+  }
+
+  // resourceType: CPU 선택
+  const resourceSel = frame.locator('select').filter({ has: frame.locator('option[value*="CPU" i]') }).first();
+  if (await resourceSel.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await resourceSel.selectOption({ label: 'CPU' }).catch(
+      () => resourceSel.selectOption({ index: 1 }),
+    );
+    await page.waitForTimeout(200);
+  }
+
+  // aggregationType: AVG 선택
+  const aggSel = frame.locator('select').filter({ has: frame.locator('option[value*="AVG" i]') }).first();
+  if (await aggSel.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await aggSel.selectOption({ label: 'AVG' }).catch(
+      () => aggSel.selectOption({ index: 1 }),
+    );
+    await page.waitForTimeout(200);
+  }
+
+  // holdDuration, repeatInterval 입력 (있을 경우)
+  const durationInput = frame.locator('input[name*="hold" i], input[name*="duration" i]').first();
+  if (await durationInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await durationInput.fill('5m');
+    await page.waitForTimeout(200);
+  }
+
+  const intervalInput = frame.locator('input[name*="repeat" i], input[name*="interval" i]').first();
+  if (await intervalInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await intervalInput.fill('1h');
+    await page.waitForTimeout(200);
+  }
+
+  // 저장/생성 버튼 클릭
+  const saveBtn = frame.locator('button[type="submit"], button').filter({ hasText: /save|create|생성|저장/i }).first();
+  const hasSave = await saveBtn.waitFor({ state: 'visible', timeout: 5_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasSave) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-policy-save-btn.png`) }).catch(() => null);
+    throw new Error(`[${tag}] TRIG-01: 저장/생성 버튼 미발견`);
+  }
+
+  await saveBtn.click();
+  await page.waitForTimeout(2_500);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-policy-created.png`) }).catch(() => null);
+
+  // 목록에 신규 정책 표시 확인
+  const bodyAfter = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const isPolicyVisible = bodyAfter.includes(policyTitle);
+  console.log(`[${tag}] TRIG-01: 신규 정책 목록 표시 = ${isPolicyVisible} (title=${policyTitle})`);
+
+  if (!isPolicyVisible) {
+    warn(tag, `TRIG-01: 생성된 정책 "${policyTitle}"이 목록에 미표시 — 생성 실패 또는 제목 표시 형식 상이`);
+  }
+
+  store.set('obsTrigPolicyTitle', policyTitle);
+
+  // 삭제: 해당 정책 행의 Delete 버튼 클릭
+  const policyRow = frame.locator('tr, [class*="row"]').filter({ hasText: policyTitle }).first();
+  const deleteBtn = policyRow.locator('button').filter({ hasText: /delete|삭제/i }).first();
+  const hasDelete = await deleteBtn.waitFor({ state: 'visible', timeout: 5_000 })
+    .then(() => true).catch(() => false);
+
+  if (hasDelete) {
+    await deleteBtn.click();
+    await page.waitForTimeout(1_000);
+
+    // 확인 다이얼로그
+    const confirmBtn = frame.locator('button').filter({ hasText: /confirm|yes|ok|확인/i }).first();
+    if (await confirmBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await confirmBtn.click();
+    }
+    await page.waitForTimeout(2_000);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-policy-deleted.png`) }).catch(() => null);
+
+    const bodyDeleted = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+    const isDeleted = !bodyDeleted.includes(policyTitle);
+    console.log(`[${tag}] TRIG-01: 정책 삭제 확인 = ${isDeleted}`);
+
+    if (!isDeleted) {
+      throw new Error(`[${tag}] TRIG-01: 삭제 후 정책 "${policyTitle}"이 목록에 여전히 존재`);
+    }
+  } else {
+    warn(tag, `TRIG-01: Delete 버튼 미발견 — 생성 자체가 실패했을 수 있음`);
+  }
+
+  console.log(`[${tag}] TC-OBS-TRIG-01 완료 — Policy 생성/목록/삭제`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-TRIG-02: 정책 ↔ Node/Infra 타겟 연결
+//
+// 1. 정책 행 Manage 클릭 → Alarm targets 영역
+// 2. Infra 드롭다운 선택 → 레벨(Infra/Node) 선택
+// 3. Add targets (POST /api/o11y/trigger/policy/{id}/node)
+// 4. vms 목록에 추가 확인
+// 5. 타겟 × 클릭 → 제거 확인 (DELETE)
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsTrig02(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  const hasAlerts = await gotoAlertsTab(frame, page, origin, tag);
+  if (!hasAlerts) throw new Error(`[${tag}] Alerts 탭 미발견`);
+
+  await page.waitForTimeout(1_000);
+
+  // 정책 행에서 Manage 버튼 클릭
+  const manageBtn = frame.locator('button').filter({ hasText: /^manage$/i }).first();
+  const hasManage = await manageBtn.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasManage) {
+    const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+    const noPolicy = /no.?policy|empty|없음/i.test(bodyText);
+    if (noPolicy) {
+      console.log(`[${tag}] TRIG-02: 정책 없음 — TRIG-01 선행 필요`);
+      return;
+    }
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-manage-btn.png`) }).catch(() => null);
+    throw new Error(`[${tag}] TRIG-02: Manage 버튼 미발견`);
+  }
+
+  await manageBtn.click();
+  await page.waitForTimeout(1_500);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-manage-open.png`) }).catch(() => null);
+
+  // Alarm targets 영역 확인
+  const bodyManage = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const hasTargetArea = /alarm.?target|target|infra|node/i.test(bodyManage);
+  console.log(`[${tag}] TRIG-02: Alarm targets 영역 = ${hasTargetArea}`);
+
+  if (!hasTargetArea) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-target-area.png`) }).catch(() => null);
+    throw new Error(`[${tag}] TRIG-02: Alarm targets 영역 미표시`);
+  }
+
+  // Infra 드롭다운 첫 번째 항목 선택
+  const infraSel = frame.locator('select, [class*="select"]').filter({ hasText: /infra|all/i }).first();
+  if (await infraSel.isVisible({ timeout: 4_000 }).catch(() => false)) {
+    await infraSel.selectOption({ index: 1 }).catch(() => null);
+    await page.waitForTimeout(500);
+    console.log(`[${tag}] TRIG-02: Infra 선택`);
+  }
+
+  // 레벨 선택: Node (단일 VM)
+  const nodeLevel = frame.locator('input[type="radio"], button, label').filter({ hasText: /^Node$/i }).first();
+  if (await nodeLevel.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await nodeLevel.click().catch(() => null);
+    await page.waitForTimeout(500);
+  }
+
+  // Add targets 버튼 클릭
+  const addTargetBtn = frame.locator('button').filter({ hasText: /add.?target|타겟.?추가/i }).first();
+  const hasAddTarget = await addTargetBtn.waitFor({ state: 'visible', timeout: 5_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasAddTarget) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-add-target-btn.png`) }).catch(() => null);
+    warn(tag, 'TRIG-02: Add targets 버튼 미발견 — Infra 선택 후 표시되는 버튼 탐색 실패');
+    return;
+  }
+
+  await addTargetBtn.click();
+  await page.waitForTimeout(2_000);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-target-added.png`) }).catch(() => null);
+
+  // vms 목록에 추가 확인
+  const bodyAfterAdd = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const hasVmAdded = /vm|node|target|추가됨|added/i.test(bodyAfterAdd);
+  console.log(`[${tag}] TRIG-02: 타겟 추가 확인 = ${hasVmAdded}`);
+
+  // 타겟 제거 (× 버튼)
+  const removeBtn = frame.locator('button[aria-label*="remove" i], button[aria-label*="delete" i], [class*="remove"], [class*="close"]')
+    .first();
+  if (await removeBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await removeBtn.click();
+    await page.waitForTimeout(1_500);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-target-removed.png`) }).catch(() => null);
+    console.log(`[${tag}] TRIG-02: 타겟 제거 클릭 완료`);
+  } else {
+    warn(tag, 'TRIG-02: 타겟 제거(×) 버튼 미발견');
+  }
+
+  console.log(`[${tag}] TC-OBS-TRIG-02 완료 — Alarm targets 추가/제거`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-TRIG-03: 알림 채널 설정
+//
+// 1. Manage → Notification channels 영역
+// 2. 지원 채널 조회 (GET /api/o11y/trigger/noti/channel)
+// 3. 채널 선택(Slack/Teams/Discord/Sms/Kakao/Email) → 수신자 입력
+// 4. Test 버튼 (POST /api/o11y/trigger/noti/test)
+// 5. Save channels (PUT /api/o11y/trigger/policy/{id}/channel)
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsTrig03(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  const hasAlerts = await gotoAlertsTab(frame, page, origin, tag);
+  if (!hasAlerts) throw new Error(`[${tag}] Alerts 탭 미발견`);
+
+  await page.waitForTimeout(1_000);
+
+  // Manage 클릭
+  const manageBtn = frame.locator('button').filter({ hasText: /^manage$/i }).first();
+  const hasManage = await manageBtn.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasManage) {
+    const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+    if (/no.?policy|empty|없음/i.test(bodyText)) {
+      console.log(`[${tag}] TRIG-03: 정책 없음 — TRIG-01 선행 필요`);
+      return;
+    }
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig03-no-manage.png`) }).catch(() => null);
+    throw new Error(`[${tag}] TRIG-03: Manage 버튼 미발견`);
+  }
+
+  await manageBtn.click();
+  await page.waitForTimeout(1_500);
+
+  // Notification channels 영역 스크롤/확인
+  const notiArea = frame.locator('[class*="noti"], [class*="channel"], section, div')
+    .filter({ hasText: /notification.?channel|알림.?채널/i }).first();
+  const hasNotiArea = await notiArea.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+  console.log(`[${tag}] TRIG-03: Notification channels 영역 = ${hasNotiArea}`);
+
+  if (!hasNotiArea) {
+    // 스크롤해서 탐색
+    await frame.locator('body').evaluate(el => el.scrollBy(0, 400));
+    await page.waitForTimeout(500);
+  }
+
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-noti-area.png`) }).catch(() => null);
+  const bodyManage = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+
+  // 지원 채널 목록 확인 (Slack/Teams/Discord/Sms/Kakao/Email)
+  const channels = ['Slack', 'Teams', 'Discord', 'Sms', 'Kakao', 'Email'];
+  const foundChannels = channels.filter(ch => new RegExp(ch, 'i').test(bodyManage));
+  console.log(`[${tag}] TRIG-03: 지원 채널 = [${foundChannels.join(', ')}]`);
+
+  if (foundChannels.length === 0) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-noti-channels.png`) }).catch(() => null);
+    throw new Error(`[${tag}] TRIG-03: Notification channels 목록 미표시`);
+  }
+
+  // Email 채널 체크박스 선택 (가장 범용적)
+  const emailCheck = frame.locator('input[type="checkbox"]')
+    .filter({ has: frame.locator('xpath=../..').filter({ hasText: /email/i }) }).first();
+  const emailLabel = frame.locator('label').filter({ hasText: /email/i }).first();
+
+  if (await emailLabel.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await emailLabel.click().catch(() => null);
+    await page.waitForTimeout(500);
+
+    // 수신자 입력 (이메일 주소)
+    const recipientInput = frame.locator('input[type="email"], input[placeholder*="email" i], input[placeholder*="recipient" i]')
+      .first();
+    if (await recipientInput.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await recipientInput.fill('test@example.com');
+      await page.waitForTimeout(200);
+    }
+
+    // Test 버튼 클릭
+    const testBtn = frame.locator('button').filter({ hasText: /^test$/i }).first();
+    if (await testBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+      await testBtn.click();
+      await page.waitForTimeout(2_000);
+      await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-noti-test.png`) }).catch(() => null);
+      console.log(`[${tag}] TRIG-03: Test 버튼 클릭 완료`);
+    } else {
+      warn(tag, 'TRIG-03: Test 버튼 미발견');
+    }
+  } else {
+    // 체크박스 직접 탐색 시도
+    if (await emailCheck.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await emailCheck.check().catch(() => null);
+    }
+    warn(tag, 'TRIG-03: Email 채널 label 미발견 — 체크박스 구조 상이할 수 있음');
+  }
+
+  // Save channels 버튼 클릭
+  const saveBtn = frame.locator('button').filter({ hasText: /save.?channel|채널.?저장|save/i }).first();
+  const hasSave = await saveBtn.waitFor({ state: 'visible', timeout: 5_000 })
+    .then(() => true).catch(() => false);
+
+  if (hasSave) {
+    await saveBtn.click();
+    await page.waitForTimeout(2_000);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-noti-saved.png`) }).catch(() => null);
+
+    // 저장 완료 확인 (notiChannels 갱신)
+    const bodyAfterSave = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+    const isSaved = /saved|success|완료|email/i.test(bodyAfterSave);
+    console.log(`[${tag}] TRIG-03: 채널 저장 완료 = ${isSaved}`);
+  } else {
+    warn(tag, 'TRIG-03: Save channels 버튼 미발견');
+  }
+
+  console.log(`[${tag}] TC-OBS-TRIG-03 완료 — Notification channels 설정/저장`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-TRIG-04: Trigger / Notification History
+//
+// 1. 임계치 초과 트리거 이력 조회 (GET /api/o11y/trigger/history?page=&size=)
+//    — severity/value/threshold 컬럼 확인
+// 2. (옵션) 코멘트 수정 (PUT /api/o11y/trigger/history/{id}/comment)
+// 3. 알림 발송 이력 (GET /api/o11y/trigger/noti/history)
+//    — channelName/recipients/isSucceeded 컬럼 확인
+// 4. Alerts → Notification History 탭에 발송 로그(성공/실패, 실패 원인 펼침) 표시 확인
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsTrig04(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page, store } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  const hasAlerts = await gotoAlertsTab(frame, page, origin, tag);
+  if (!hasAlerts) throw new Error(`[${tag}] Alerts 탭 미발견`);
+
+  await page.waitForTimeout(1_000);
+
+  // ── 트리거 이력 탭 확인 (History / Trigger History) ──────────────────────
+  const historyTab = frame.locator('button, [role="tab"]').filter({ hasText: /^history$|^trigger.?history$/i }).first();
+  const hasHistoryTab = await historyTab.waitFor({ state: 'visible', timeout: 6_000 })
+    .then(() => true).catch(() => false);
+
+  if (hasHistoryTab) {
+    await historyTab.click();
+    await page.waitForTimeout(1_500);
+  }
+
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-history.png`) }).catch(() => null);
+  const bodyHistory = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+
+  // severity/value/threshold 컬럼 확인
+  const hasHistoryCols = /severity|value|threshold|critical|warning|info/i.test(bodyHistory);
+  const hasNoHistory   = /no.?history|이력.?없음|empty/i.test(bodyHistory);
+  console.log(`[${tag}] TRIG-04: history컬럼=${hasHistoryCols}, noHistory=${hasNoHistory}`);
+
+  if (!hasHistoryCols && !hasNoHistory) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-trigger-history.png`) }).catch(() => null);
+    warn(tag, 'TRIG-04: 트리거 이력 컬럼(severity/value/threshold) 미표시 — 임계치 초과 이벤트 없을 수 있음');
+  }
+
+  // 이력 행 수 기록
+  const historyRows = frame.locator('table tr:not(:first-child), .tabulator-row');
+  const rowCount = await historyRows.count().catch(() => 0);
+  store.set('obsTrigHistoryCount', rowCount);
+  console.log(`[${tag}] TRIG-04: 트리거 이력 행 수 = ${rowCount}`);
+
+  // (옵션) 첫 번째 이력 행 코멘트 수정
+  if (rowCount > 0) {
+    const firstRow = historyRows.first();
+    const commentBtn = firstRow.locator('button, input[type="text"]').filter({ hasText: /comment|코멘트/i }).first();
+    if (await commentBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+      await commentBtn.click();
+      await page.waitForTimeout(500);
+      const commentInput = frame.locator('input[type="text"], textarea').last();
+      if (await commentInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
+        await commentInput.fill('E2E 자동 코멘트');
+        const saveCommentBtn = frame.locator('button').filter({ hasText: /save|저장|ok/i }).last();
+        if (await saveCommentBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+          await saveCommentBtn.click();
+          await page.waitForTimeout(1_000);
+          console.log(`[${tag}] TRIG-04: 코멘트 수정 완료`);
+        }
+      }
+    }
+  }
+
+  // ── Notification History 탭 ─────────────────────────────────────────────
+  const notiHistTab = frame.locator('button, [role="tab"]').filter({ hasText: /notification.?history|발송.?이력/i }).first();
+  const hasNotiHistTab = await notiHistTab.waitFor({ state: 'visible', timeout: 6_000 })
+    .then(() => true).catch(() => false);
+
+  if (hasNotiHistTab) {
+    await notiHistTab.click();
+    await page.waitForTimeout(1_500);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-noti-history.png`) }).catch(() => null);
+
+    const bodyNotiHist = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+    // channelName/recipients/isSucceeded 컬럼 확인
+    const hasNotiCols  = /channel|recipient|succeed|success|fail/i.test(bodyNotiHist);
+    const hasNoNoti    = /no.?notification|발송.?없음|empty/i.test(bodyNotiHist);
+    console.log(`[${tag}] TRIG-04: notiHistory컬럼=${hasNotiCols}, noNoti=${hasNoNoti}`);
+
+    if (!hasNotiCols && !hasNoNoti) {
+      warn(tag, 'TRIG-04: 알림 발송 이력 컬럼(channelName/recipients/isSucceeded) 미표시');
+    }
+
+    // 실패 이력 펼침 확인 (실패 원인 detail)
+    const failRows = frame.locator('tr, [class*="row"]').filter({ hasText: /fail|false/i });
+    if (await failRows.count().then(n => n > 0).catch(() => false)) {
+      await failRows.first().click().catch(() => null);
+      await page.waitForTimeout(1_000);
+      const bodyExpanded = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+      const hasFailDetail = /reason|error|message|원인/i.test(bodyExpanded);
+      console.log(`[${tag}] TRIG-04: 실패 원인 펼침 = ${hasFailDetail}`);
+      await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-noti-fail-detail.png`) }).catch(() => null);
+    }
+  } else {
+    warn(tag, 'TRIG-04: Notification History 탭 미발견 — Alerts 탭 내 구조 상이할 수 있음');
+  }
+
+  console.log(`[${tag}] TC-OBS-TRIG-04 완료 — 트리거/알림 발송 이력 확인`);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TC-OBS-TRIG-05: 정책 수정 (임계값 등)
+//
+// 1. 정책 행 Manage 클릭 → Policy settings 영역 펼침
+// 2. Thresholds(Info/Warning/Critical)·Title·Resource·Aggregation·Hold/Repeat 수정
+// 3. Save settings (PUT /api/o11y/trigger/policy/{id})
+// 4. Grafana 알림 룰 재동기화 확인 (삭제 후 재생성 메시지)
+// 5. 목록 Thresholds 갱신 확인
+// ─────────────────────────────────────────────────────────────────────────────
+async function runObsTrig05(ctx: StepRunContext, tag: string): Promise<void> {
+  const { page } = ctx;
+
+  const frame = await obsLoadFrame(ctx, tag);
+  if (!frame) throw new Error(`[${tag}] OBS iframe 미발견`);
+
+  const origin = await obsIframeOrigin(page);
+  const hasAlerts = await gotoAlertsTab(frame, page, origin, tag);
+  if (!hasAlerts) throw new Error(`[${tag}] Alerts 탭 미발견`);
+
+  await page.waitForTimeout(1_000);
+
+  // 정책 행 Manage 클릭
+  const manageBtn = frame.locator('button').filter({ hasText: /^manage$/i }).first();
+  const hasManage = await manageBtn.waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasManage) {
+    const bodyText = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+    if (/no.?policy|empty|없음/i.test(bodyText)) {
+      console.log(`[${tag}] TRIG-05: 정책 없음 — TRIG-01 선행 필요`);
+      return;
+    }
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig05-no-manage.png`) }).catch(() => null);
+    throw new Error(`[${tag}] TRIG-05: Manage 버튼 미발견`);
+  }
+
+  await manageBtn.click();
+  await page.waitForTimeout(1_500);
+
+  // Policy settings 영역 펼침 (토글 버튼 또는 섹션 헤더)
+  const settingsToggle = frame.locator('button, [class*="collapse"], [class*="accordion"]')
+    .filter({ hasText: /policy.?settings|정책.?설정/i }).first();
+  if (await settingsToggle.isVisible({ timeout: 4_000 }).catch(() => false)) {
+    await settingsToggle.click();
+    await page.waitForTimeout(1_000);
+    console.log(`[${tag}] TRIG-05: Policy settings 펼침`);
+  }
+
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-policy-settings.png`) }).catch(() => null);
+  const bodySettings = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+
+  // 설정 폼 영역 확인 (Threshold/Title/Resource/Aggregation/Hold/Repeat)
+  const hasSettingsForm = /threshold|title|resource|aggregation|hold|repeat/i.test(bodySettings);
+  console.log(`[${tag}] TRIG-05: Policy settings 폼 = ${hasSettingsForm}`);
+
+  if (!hasSettingsForm) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-policy-settings.png`) }).catch(() => null);
+    throw new Error(`[${tag}] TRIG-05: Policy settings 폼 미표시`);
+  }
+
+  // Title 수정 (기존 값 지우고 새 값)
+  const titleInput = frame.locator('input[name*="title" i], input[placeholder*="title" i]').first();
+  if (await titleInput.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    const currentTitle = await titleInput.inputValue().catch(() => '');
+    await titleInput.fill(`${currentTitle}-updated`);
+    await page.waitForTimeout(200);
+    console.log(`[${tag}] TRIG-05: Title 수정 = "${currentTitle}-updated"`);
+  }
+
+  // Threshold — Info/Warning/Critical 값 수정
+  // 폼에 숫자 입력 필드가 3개 있을 경우: info / warning / critical 순
+  const thresholdInputs = frame.locator('input[type="number"], input[name*="threshold" i]');
+  const threshCount = await thresholdInputs.count().catch(() => 0);
+  console.log(`[${tag}] TRIG-05: Threshold 입력 필드 수 = ${threshCount}`);
+
+  if (threshCount >= 1) {
+    // info threshold
+    await thresholdInputs.nth(0).fill('50').catch(() => null);
+  }
+  if (threshCount >= 2) {
+    // warning threshold
+    await thresholdInputs.nth(1).fill('70').catch(() => null);
+  }
+  if (threshCount >= 3) {
+    // critical threshold
+    await thresholdInputs.nth(2).fill('90').catch(() => null);
+  }
+  await page.waitForTimeout(200);
+
+  // holdDuration 수정
+  const holdInput = frame.locator('input[name*="hold" i], input[name*="duration" i]').first();
+  if (await holdInput.isVisible({ timeout: 2_000 }).catch(() => false)) {
+    await holdInput.fill('10m');
+    await page.waitForTimeout(200);
+  }
+
+  // Save settings 버튼 클릭
+  const saveBtn = frame.locator('button').filter({ hasText: /save.?settings|설정.?저장|save/i }).first();
+  const hasSave = await saveBtn.waitFor({ state: 'visible', timeout: 6_000 })
+    .then(() => true).catch(() => false);
+
+  if (!hasSave) {
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-no-save-settings-btn.png`) }).catch(() => null);
+    throw new Error(`[${tag}] TRIG-05: Save settings 버튼 미발견`);
+  }
+
+  await saveBtn.click();
+  await page.waitForTimeout(3_000);
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-policy-saved.png`) }).catch(() => null);
+
+  // 저장 완료 및 Grafana 룰 재동기화 확인
+  const bodyAfterSave = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  const isSaved      = /saved|success|updated|완료|갱신/i.test(bodyAfterSave);
+  const hasGrafanaSync = /grafana|sync|rule|재동기|recreat/i.test(bodyAfterSave);
+  console.log(`[${tag}] TRIG-05: 저장=${isSaved}, grafana재동기=${hasGrafanaSync}`);
+
+  if (!isSaved) {
+    warn(tag, 'TRIG-05: 저장 완료 메시지 미확인 — API 응답 또는 토스트 미감지');
+  }
+
+  // Manage 닫기 → 목록으로 돌아가 Thresholds 표시 갱신 확인
+  const closeBtn = frame.locator('button').filter({ hasText: /close|닫기|back/i }).first();
+  if (await closeBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+    await closeBtn.click();
+    await page.waitForTimeout(1_500);
+  } else {
+    // Alerts 탭 재클릭으로 목록 갱신
+    await gotoAlertsTab(frame, page, origin, tag);
+  }
+
+  await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-trig-policy-list-updated.png`) }).catch(() => null);
+  const bodyList = (await frame.locator('body').textContent().catch(() => '')) ?? '';
+  // 목록에서 수정된 threshold 값(50/70/90) 또는 "-updated" 제목 확인
+  const hasUpdated = /50|70|90|-updated/i.test(bodyList);
+  console.log(`[${tag}] TRIG-05: 목록 Threshold 갱신 = ${hasUpdated}`);
+
+  if (!hasUpdated) {
+    warn(tag, 'TRIG-05: 목록 Thresholds 갱신 미확인 — 목록 표시 형식 확인 필요');
+  }
+
+  console.log(`[${tag}] TC-OBS-TRIG-05 완료 — Policy settings 수정/저장/목록 갱신`);
+}

--- a/e2e/shared/api-routes.ts
+++ b/e2e/shared/api-routes.ts
@@ -1,0 +1,267 @@
+// mc-application-manager 직접 접근 base URL (.env.external-ip: APP_MANAGER_BASE_URL)
+const APP_MANAGER = process.env.APP_MANAGER_BASE_URL || 'https://15.164.139.37:18084';
+
+// mc-data-manager 직접 접근 base URL (.env.external-ip: DATA_MANAGER_BASE_URL)
+// 인증 불필요. FE + API 동일 포트 3300. Swagger: /swagger/index.html
+const DATA_MANAGER = process.env.DATA_MANAGER_BASE_URL || 'https://15.164.139.37:3300';
+
+// API 경로 패턴. explore-*.ts discovery로 확정한 값. TODO 항목은 discovery 필요.
+export const API_ROUTES = {
+
+  // --- IAM (mc-iam-manager) ---
+  auth: {
+    login:    '/api/auth/login',
+    logout:   '/api/auth/logout',
+    refresh:  '/api/auth/refresh',
+    userinfo: '/api/auth/userinfo',
+    signup:   '/api/auth/signup',   // POST — 신규 사용자 가입 신청 (enabled=false 로 생성, 관리자 승인 대기)
+  },
+  iam: {
+    // 로그인 후 메뉴/워크스페이스 초기 로드
+    menus:              '/api/mc-iam-manager/GetAllAvailableMenus',           // POST
+    listUserWorkspaces: '/api/mc-iam-manager/listUserWorkspaces',             // POST
+    getProjects:        '/api/mc-iam-manager/getProjectsByWorkspaceId',       // POST (workspace flow)
+    // Users — 모든 IAM API는 POST 방식 (body 없이도 동작)
+    listUsers:          '/api/mc-iam-manager/Listusers',                      // POST (discovery 확정: 대문자 L)
+    createUser:         '/api/mc-iam-manager/Createuser',                     // POST — body: { request: { username, email, firstName, lastName, enabled } } (소문자 u 확정)
+    resetUserPassword:  '/api/mc-iam-manager/ResetUserPassword',              // POST — body: { pathParams: { userId }, request: { newPassword } } (확정: 생성 후 별도 호출 필요)
+    updateUser:         '/api/mc-iam-manager/updateUser',                     // POST — body: { pathParams: { userId }, request: { ... } }
+    deleteUser:         '/api/mc-iam-manager/deleteUser',                     // POST — body: { pathParams: { userId } }
+    getUser:            '/api/mc-iam-manager/Getuserbyname',                  // POST — body: { pathParams: { username } } (discovery 확정)
+    // Roles
+    listRoles:          '/api/mc-iam-manager/ListRoles',                      // POST (TODO: discovery 확인)
+    createRole:         '/api/mc-iam-manager/CreateRole',                     // POST (TODO)
+    updateRole:         '/api/mc-iam-manager/UpdateRole',                     // POST (TODO)
+    deleteRole:         '/api/mc-iam-manager/DeleteRole',                     // POST (TODO)
+    // Policies (Permissions)
+    listPolicies:       '/api/mc-iam-manager/listMciamPermissions',           // POST (discovery 확정)
+    createPolicy:       '/api/mc-iam-manager/CreatePermission',               // POST (TODO)
+    updatePolicy:       '/api/mc-iam-manager/UpdatePermission',               // POST (TODO)
+    deletePolicy:       '/api/mc-iam-manager/DeletePermission',               // POST (TODO)
+    // User-Role assignment
+    assignRoleToUser:        '/api/mc-iam-manager/assignPlatformRole',        // POST — @deprecated: assignPlatformRole 직접 사용 권장. body: { request: { userId, roleId, roleName, roleType: 'platform' } }
+    assignPlatformRole:      '/api/mc-iam-manager/assignPlatformRole',        // POST — { request: { userId, roleId, roleName, roleType: 'platform' } }
+    removePlatformRole:      '/api/mc-iam-manager/removePlatformRole',        // DELETE — { request: { userId, roleId, roleType: 'platform' } }
+    updateUserStatus:        '/api/mc-iam-manager/UpdateUserStatus',          // POST — { pathParams: { userId }, request: { status: 'approved' } }
+    // Platform Roles (menu-roles)
+    listPlatformRoles:       '/api/mc-iam-manager/listPlatformRoles',         // POST — menu-roles 목록
+    // Group-Platform Role assignment
+    assignGroupPlatformRole: '/api/mc-iam-manager/assignGroupPlatformRole',   // POST — { pathParams: { groupId }, request: { role_id } }
+    getGroupPlatformRoles:   '/api/mc-iam-manager/getGroupPlatformRoles',     // POST — { pathParams: { groupId } }
+    removeGroupPlatformRole: '/api/mc-iam-manager/removeGroupPlatformRole',   // POST — { pathParams: { groupId, roleId } }
+    // Group-Workspace assignment
+    assignGroupUsers:        '/api/mc-iam-manager/assignGroupUsers',          // POST — { pathParams: { groupId }, request: { user_ids: [] } }
+    // Workspace Roles
+    listWorkspaceRoles:          '/api/mc-iam-manager/listWorkspaceRoles',                    // POST — 전체 workspace role 목록 (old API)
+    listWorkspaceRolesList:      '/api/mc-iam-manager/Listworkspaceroles',                    // POST — 새 API: { } → responseData: [{name, ...}]
+    addUserToWorkspace:          '/api/mc-iam-manager/addUserToWorkspace',                    // POST — { pathParams: { id: workspaceId }, request: { userId, workspaceRoleId } } (old)
+    assignWorkspaceRoleByName:   '/api/mc-iam-manager/CreateWorkspaceUserRoleMappingByName',  // POST — { request: { workspaceId, roleName, username } } (새 API)
+    removeWorkspaceRoleByName:   '/api/mc-iam-manager/DeleteWorkspaceUserRoleMapping',        // POST — { request: { workspaceId, username, roleName } } (새 API)
+    // Groups (Organizations) — conf/api.yaml:1073-1112 확정
+    listGroups:          '/api/mc-iam-manager/Getorganizations',               // POST — body 없음 (flat list)
+    listGroupsTree:      '/api/mc-iam-manager/Getorganizations',               // POST — { queryParams: { tree: "true" } }
+    getGroupById:        '/api/mc-iam-manager/Getorganizationbyid',            // POST — { pathParams: { organizationId } }
+    getGroupByCode:      '/api/mc-iam-manager/Getorganizationbycode',          // POST — { pathParams: { code } }
+    createGroup:         '/api/mc-iam-manager/Createorganization',             // POST — { request: { name, description, parent_id?, organization_code? } }
+    updateGroup:         '/api/mc-iam-manager/Updateorganization',             // POST — { pathParams: { organizationId }, request: { name, description, ... } }
+    deleteGroup:         '/api/mc-iam-manager/Deleteorganization',             // POST — { pathParams: { organizationId } } — 하위 그룹·소속 사용자 있으면 400
+    getGroupUsers:       '/api/mc-iam-manager/Getorganizationusers',           // POST — { pathParams: { organizationId } }
+    assignUserToGroup:   '/api/mc-iam-manager/Assignuserorganizations',        // POST — { pathParams: { userId }, request: { organization_ids: [id] } }
+    getUserGroups:       '/api/mc-iam-manager/Getuserorganizations',           // POST — { pathParams: { userId } }
+    removeUserFromGroup: '/api/mc-iam-manager/Removeuserorganization',         // POST — { pathParams: { userId, organizationId } }
+    // Workspaces
+    listWorkspaces:               '/api/mc-iam-manager/listWorkspaces',                          // POST (discovery 확정)
+    createWorkspace:              '/api/mc-iam-manager/CreateWorkspace',                         // POST (TODO)
+    createWorkspaceUserRoleMapping: '/api/mc-iam-manager/assignWorkspaceRole',                    // POST — { request: { workspaceId, roleId, userId } } (all strings)
+    removeWorkspaceRole:            '/api/mc-iam-manager/removeWorkspaceRole',                    // DELETE — { request: { workspaceId, roleId, userId } } (all strings)
+    updateWorkspace:    '/api/mc-iam-manager/UpdateWorkspace',                // POST (TODO)
+    deleteWorkspace:    '/api/mc-iam-manager/DeleteWorkspace',                // POST (TODO)
+    // Projects
+    listProjects:       '/api/mc-iam-manager/listProjects',                   // POST (discovery 확정)
+    createProject:      '/api/mc-iam-manager/CreateProject',                  // POST (TODO)
+    updateProject:      '/api/mc-iam-manager/UpdateProject',                  // POST (TODO)
+    deleteProject:      '/api/mc-iam-manager/DeleteProject',                  // POST (TODO)
+    // User-Workspace-Role assignment
+    listUsersAndRolesByWorkspaces: '/api/mc-iam-manager/listUsersAndRolesByWorkspaces', // POST (discovery 확정)
+    assignWorkspaceToUser: '/api/mc-iam-manager/AssignWorkspaceRoleToUser',   // POST (TODO)
+    // Organizations (Groups의 alias — 동일 API)
+    listOrgs:   '/api/mc-iam-manager/Getorganizations',
+    createOrg:  '/api/mc-iam-manager/Createorganization',
+    updateOrg:  '/api/mc-iam-manager/Updateorganization',
+    deleteOrg:  '/api/mc-iam-manager/Deleteorganization',
+    // Companies (TODO: discovery 필요)
+    listCompanies:      '/api/mc-iam-manager/listCompanies',                  // POST (TODO)
+    createCompany:      '/api/mc-iam-manager/CreateCompany',                  // POST (TODO)
+    updateCompany:      '/api/mc-iam-manager/UpdateCompany',                  // POST (TODO)
+    deleteCompany:      '/api/mc-iam-manager/DeleteCompany',                  // POST (TODO)
+  },
+
+  // --- CSP (cb-spider via mc-infra-manager proxy) ---
+  csp: {
+    // Credentials (CredentialHolder)
+    listCredentials:    '/api/mc-infra-manager/GetCredentialHolderList',      // POST — responseData.credentialHolderList[]
+    getCredential:      '/api/mc-infra-manager/GetCredentialHolder',          // POST — pathParams.credentialHolder
+    createCredential:   '/api/mc-infra-manager/CreateCredentialHolder',       // POST (TODO)
+    updateCredential:   '/api/mc-infra-manager/UpdateCredentialHolder',       // POST (TODO)
+    deleteCredential:   '/api/mc-infra-manager/DeleteCredentialHolder',       // POST (TODO)
+    // Connections (ConnConfig)
+    listConnections:    '/api/mc-infra-manager/GetConnConfigList',            // POST — responseData.connectionconfig[]
+    listConnectionsByCredential: '/api/mc-infra-manager/FilterConnConfigByCredentialHolder', // POST
+    createConnection:   '/api/mc-infra-manager/CreateConnConfig',             // POST (TODO)
+    deleteConnection:   '/api/mc-infra-manager/DeleteConnConfig',             // POST (TODO)
+    // Server Specs
+    listServerSpecs:    '/api/mc-infra-manager/ListVMSpec',                   // POST — pathParams.connectionName (TODO: workspace needed)
+  },
+
+  // --- INFRA (cb-tumblebug / mc-infra-manager) ---
+  // 모든 INFRA API는 pathParams.nsId 필수. nsId는 project.nsid 값 (기본: "default")
+  infra: {
+    // MCI (Multi-Cloud Infrastructure)
+    listMci:            '/api/mc-infra-manager/GetAllInfra',                 // POST — pathParams.nsId, responseData.infra[]
+    getMci:             '/api/mc-infra-manager/GetInfra',                    // POST — pathParams.{nsId, infraId}
+    createMci:          '/api/mc-infra-manager/CreateMci',                   // POST — TODO: 요청 형식 확인 필요
+    createMciDynamic:   '/api/mc-infra-manager/PostInfraDynamic',             // POST — pathParams.nsId + nodeGroups[] (동적 스펙 기반 생성)
+    reviewMciDynamic:   '/api/mc-infra-manager/PostInfraDynamicCheckRequest', // POST — 생성 전 pre-flight (overallStatus: Ready|Warning|Error)
+    controlMci:         '/api/mc-infra-manager/GetControlInfra',             // POST — pathParams.{nsId, infraId}, queryParams.action=suspend|resume|reboot
+    deleteMci:          '/api/mc-infra-manager/DelMci',                      // POST — pathParams.{nsId, mciId} (TODO)
+    delInfra:           '/api/mc-infra-manager/DelInfra',                    // POST — pathParams.{nsId, infraId}, queryParams.option=force
+    cmdMci:             '/api/mc-infra-manager/PostCmdInfra',                 // POST — pathParams.{nsId, infraId}, command
+    mciLifecycle:       '/api/mc-infra-manager/ControlLifecycleVm',          // POST — VM 단위 lifecycle (MCI 전체는 controlMci 사용)
+    // SSH Keys
+    listSshKeys:        '/api/mc-infra-manager/Getallsshkey',                // POST — pathParams.nsId, responseData.sshKey[]
+    getSshKey:          '/api/mc-infra-manager/Getsshkey',                   // POST — pathParams.{nsId, sshKeyId}, responseData: key info + privateKey
+    createSshKey:       '/api/mc-infra-manager/Postsshkey',                  // POST — TODO
+    deleteSshKey:       '/api/mc-infra-manager/Delsshkey',                   // POST — TODO
+    // VNet Templates
+    listTemplates:      '/api/mc-infra-manager/GetAllVNetTemplate',           // POST — pathParams.nsId, responseData.templates[]
+    createTemplate:     '/api/mc-infra-manager/PostVNetTemplate',             // POST — pathParams.nsId + request.{name,description,vNetPolicy}
+    getTemplate:        '/api/mc-infra-manager/GetVNetTemplate',              // POST — pathParams.{nsId,templateId}
+    deleteTemplate:     '/api/mc-infra-manager/DeleteVNetTemplate',           // POST — pathParams.{nsId,templateId}
+    // CSP Resource Schedule Jobs
+    listScheduleJobs:   '/api/mc-infra-manager/GetScheduleRegisterCspResourcesList', // POST — {}, responseData.jobs[]
+    createScheduleJob:  '/api/mc-infra-manager/PostScheduleRegisterCspResources',    // POST — request.{jobType,nsId,connectionName,intervalSeconds,mciNamePrefix}
+    pauseScheduleJob:   '/api/mc-infra-manager/PutScheduleRegisterCspResourcesPause', // POST — pathParams.jobId
+    deleteScheduleJob:  '/api/mc-infra-manager/DeleteScheduleRegisterCspResources',   // POST — pathParams.jobId
+    // K8s (PMK) — 클러스터
+    listK8s:            '/api/mc-infra-manager/GetAllK8sCluster',             // POST — pathParams.nsId → responseData.K8sClusterInfo[]
+    createK8s:          '/api/mc-infra-manager/PostK8sCluster',               // POST — Expert: vNetId+subnetIds+securityGroupIds 필수
+    getK8s:             '/api/mc-infra-manager/Getk8scluster',                // POST — pathParams.{nsId, k8sClusterId} → responseData.{status, k8sNodeGroupList[]}
+    deleteK8s:          '/api/mc-infra-manager/DeleteK8sCluster',             // POST — pathParams.{nsId, k8sClusterId}
+    // K8s (PMK) — Simple (Dynamic) Creation
+    reviewK8sDynamic:   '/api/mc-infra-manager/Postk8sclusterdynamiccheckrequest', // POST — Request.{specId:[]} → reqCheck[].connectionConfigCandidates
+    createK8sDynamic:   '/api/mc-infra-manager/Postk8sclusterdynamic',        // POST — Request.{name,connectionName,specId,imageId,nodeGroupName}
+    // K8s (PMK) — NodeGroup
+    addK8sNodeGroup:    '/api/mc-infra-manager/Postk8snodegroup',             // POST — pathParams.{nsId,k8sClusterId} + request.{name,specId,imageId,sshKeyId,minNodeSize(int),maxNodeSize(int),desiredNodeSize(int),onAutoScaling(string)}
+    deleteK8sNodeGroup: '/api/mc-infra-manager/Deletek8snodegroup',           // POST — pathParams.{nsId,k8sClusterId,k8sNodeGroupName}
+  },
+
+  // --- COST (mc-cost-optimizer-fe) ---
+  costAnalysis: {
+    getApiHosts:     '/api/getapihosts',
+    getCurMonthBill: '/api/costopti/be/getCurMonthBill',
+    getTop5Bill:     '/api/costopti/be/getTop5Bill',
+    getBillAsset:    '/api/costopti/be/getBillAsset',
+  },
+
+  // --- OBS (mc-observability) ---
+  obs: {
+    listMonitoringTargets: '/api/mc-observability/targets',                  // TODO
+    installAgent:          '/api/mc-observability/agents/install',           // TODO
+    listLogs:              '/api/mc-observability/logs',                     // TODO
+    listTraces:            '/api/mc-observability/traces',                   // TODO
+    listInsights:          '/api/mc-observability/insights',                 // TODO
+  },
+
+  // --- SW (mc-application-manager) — 직접 접근 (Bearer auth, responseData 래퍼 없음) ---
+  // 응답 형식: { code: 200, message: "...", detail: null, data: ... }
+  sw: {
+    // Repository (TC-APP-REP-*) — /oss/v1/repositories/nexus/{list|create|detail/{name}|delete/{name}}
+    listRepository:    `${APP_MANAGER}/oss/v1/repositories/nexus/list`,           // TC-APP-REP-01: GET
+    createRepository:  `${APP_MANAGER}/oss/v1/repositories/nexus/create`,         // TC-APP-REP-02: POST
+    getRepository:     `${APP_MANAGER}/oss/v1/repositories/nexus/detail`,         // TC-APP-REP-03: GET /{name}
+    deleteRepository:  `${APP_MANAGER}/oss/v1/repositories/nexus/delete`,         // TC-APP-REP-05: DELETE /{name}
+    // Catalog (TC-APP-CAT-*)
+    listCatalog:       `${APP_MANAGER}/catalog/software`,                           // TC-APP-CAT-01: GET (trailing slash 제거 필수 — /software/는 9999 반환)
+    getAppCatalog:     `${APP_MANAGER}/catalog/software`,                          // TC-APP-CAT-02: GET /{id}
+    searchExtCatalog:  `${APP_MANAGER}/search/dockerhub`,                          // TC-APP-CAT-03: GET /{keyword}
+    uploadExtCatalog:  `${APP_MANAGER}/catalog/software/upload`,                   // TC-APP-CAT-04: TODO discovery
+    createAppCatalog:  `${APP_MANAGER}/catalog/software`,                          // TC-APP-CAT-05: POST
+    updateAppCatalog:  `${APP_MANAGER}/catalog/software`,                          // TC-APP-CAT-06: PATCH /{id}
+    deleteAppCatalog:  `${APP_MANAGER}/catalog/software`,                          // TC-APP-CAT-07: DELETE /{id}
+    // Deploy (TC-APP-DEP-*)
+    deploySw:          `${APP_MANAGER}/deploy`,                                    // TC-APP-DEP-01~03: TODO discovery
+    // Apps Status (TC-APP-APPS-*)
+    listAppsStatus:    `${APP_MANAGER}/apps`,                                      // TC-APP-APPS-01: TODO discovery
+    getAppsDetail:     `${APP_MANAGER}/apps`,                                      // TC-APP-APPS-02: GET /{id}
+    restartApp:        `${APP_MANAGER}/apps/restart`,                              // TC-APP-APPS-03
+    stopApp:           `${APP_MANAGER}/apps/stop`,                                 // TC-APP-APPS-03
+    uninstallApp:      `${APP_MANAGER}/apps/uninstall`,                            // TC-APP-APPS-03
+    submitRating:      `${APP_MANAGER}/apps/rating`,                               // TC-APP-APPS-04
+    listWorkflows:     '/api/mc-workflow-manager/workflows',                          // TODO — 일반 목록 (discovery 필요)
+    listWorkflowsEl:   '/api/mc-workflow-manager/eventlistener/workflowList/N',       // TC-WORKFLOW-DETAIL-01 기준 (UI 실제 호출 경로)
+    listWorkflowsElY:  '/api/mc-workflow-manager/eventlistener/workflowList/Y',       // EventListener 연결 WF 목록 (TC-WORKFLOW-EL-07)
+    runWorkflow:       '/api/mc-workflow-manager/workflows/run',                      // TC-WORKFLOW-RUN-01: POST /workflow/run
+    runWorkflowPost:   '/api/mc-workflow-manager/workflow/run',                       // C3-Step5: POST /workflow/run (단수 경로)
+    getWorkflowDetail: '/api/mc-workflow-manager/eventlistener/workflowDetail',       // TC-WORKFLOW-DETAIL-02: GET /eventlistener/workflowDetail/{idx}/N
+    getRunHistory:     '/api/mc-workflow-manager/workflow/runHistory',                // TC-WORKFLOW-DETAIL-05: GET /workflow/runHistory/{idx}
+    getWorkflowLog:    '/api/mc-workflow-manager/workflow/log',                       // TC-WORKFLOW-RUN-03: GET /workflow/log/{idx}
+    // OSS (mc-workflow-manager) — C3 Step 2, SCENARIOS.md WORKFLOW-OSS
+    listOss:           '/api/mc-workflow-manager/oss/list',                           // GET — OSS 목록 조회
+    createOss:         '/api/mc-workflow-manager/oss',                                // POST — OSS 등록
+    checkOssConnection:'/api/mc-workflow-manager/oss/connection-check',               // POST — 연결 확인
+    updateOss:         '/api/mc-workflow-manager/oss',                                // PATCH /{ossIdx}
+    deleteOss:         '/api/mc-workflow-manager/oss',                                // DELETE /{ossIdx}
+    // WF management (mc-workflow-manager) — C3 Step 3/4
+    checkWfDuplicate:  '/api/mc-workflow-manager/workflow/name/duplicate',            // GET ?workflowName=xxx
+    getWfTemplate:     '/api/mc-workflow-manager/workflow/template',                  // GET /{name}
+    createWorkflow:    '/api/mc-workflow-manager/workflow',                           // POST
+    updateWorkflow:    '/api/mc-workflow-manager/workflow',                           // PATCH /{wfIdx}
+    deleteWorkflow:    '/api/mc-workflow-manager/workflow',                           // DELETE /{wfIdx}
+    // Event Listener (mc-workflow-manager) — TC-WF-EL-*
+    listEventListeners:  '/api/mc-workflow-manager/eventlistener/list',               // GET — EL 목록
+    createEventListener: '/api/mc-workflow-manager/eventlistener',                    // POST — EL 생성
+    updateEventListener: '/api/mc-workflow-manager/eventlistener',                    // PATCH /{elIdx}
+    deleteEventListener: '/api/mc-workflow-manager/eventlistener',                    // DELETE /{elIdx}
+  },
+
+  // --- DATA (mc-data-manager) ---
+  // 직접 접근: https://15.164.139.37:3300 (인증 불필요, FE+API 동일 포트)
+  // Swagger: https://15.164.139.37:3300/swagger/index.html
+  data: {
+    // Health
+    healthcheck:            `${DATA_MANAGER}/readyZ`,
+    // Task lists (read-only, no auth)
+    allTasks:               `${DATA_MANAGER}/tasks`,
+    generateList:           `${DATA_MANAGER}/generate`,
+    migrateList:            `${DATA_MANAGER}/migrate`,
+    backupList:             `${DATA_MANAGER}/backup`,
+    restoreList:            `${DATA_MANAGER}/restore`,
+    // Credentials / Namespace
+    credentialList:         `${DATA_MANAGER}/credentials`,
+    namespace:              `${DATA_MANAGER}/namespace`,
+    // Generate
+    generateObjectstorage:  `${DATA_MANAGER}/generate/objectstorage`,
+    generateRdbms:          `${DATA_MANAGER}/generate/rdbms`,
+    generateNrdbms:         `${DATA_MANAGER}/generate/nrdbms`,
+    generateLinux:          `${DATA_MANAGER}/generate/linux`,
+    // Migrate
+    migrateObjectstorage:   `${DATA_MANAGER}/migrate/objectstorage`,
+    migrateRdbms:           `${DATA_MANAGER}/migrate/rdbms`,
+    migrateNrdbms:          `${DATA_MANAGER}/migrate/nrdbms`,
+    // Backup
+    backupObjectstorage:    `${DATA_MANAGER}/backup/objectstorage`,
+    backupRdbms:            `${DATA_MANAGER}/backup/rdbms`,
+    backupNrdbms:           `${DATA_MANAGER}/backup/nrdbms`,
+    // Restore
+    restoreObjectstorage:   `${DATA_MANAGER}/restore/objectstorage`,
+    // Aliases (legacy names)
+    objectStorageMigrate:   `${DATA_MANAGER}/migrate/objectstorage`,
+    objectStorageBackup:    `${DATA_MANAGER}/backup/objectstorage`,
+    objectStorageRestore:   `${DATA_MANAGER}/restore/objectstorage`,
+    rdbmsMigrate:           `${DATA_MANAGER}/migrate/rdbms`,
+    rdbmsBackup:            `${DATA_MANAGER}/backup/rdbms`,
+    nordbmsMigrate:         `${DATA_MANAGER}/migrate/nrdbms`,
+    nordbmsBackup:          `${DATA_MANAGER}/backup/nrdbms`,
+  },
+
+} as const;

--- a/e2e/shared/data-iframe.helper.ts
+++ b/e2e/shared/data-iframe.helper.ts
@@ -1,0 +1,105 @@
+/**
+ * mc-data-manager iframe 로딩 헬퍼
+ *
+ * mc-web-console api.yaml의 mc-data-manager-fe가 http:// 로 설정되어
+ * HTTPS 부모 페이지에서 mixed content 차단됨.
+ * → iframe src를 JS로 https:// 로 교체한 뒤 frame 반환.
+ */
+import { type Frame, type Page } from '@playwright/test';
+import { loginAndGoto } from './request-auth.helper';
+
+const DATA_MGMT_URL = '/webconsole/operations/manage/datamigrations';
+
+/**
+ * mc-web-console 로그인 → Data Migration 페이지 진입
+ * → ws01/default 선택 → iframe src http→https 수정 → Frame 반환
+ */
+export async function loadDataFrame(page: Page, tag: string): Promise<Frame | null> {
+  const ok = await loginAndGoto(page, DATA_MGMT_URL, tag);
+  if (!ok) { console.warn(`[${tag}] 로그인 실패`); return null; }
+
+  await page.waitForTimeout(1500);
+
+  const wsSelect = page.locator('#select-current-workspace');
+  if (await wsSelect.count() === 0) { console.warn(`[${tag}] workspace selector 없음`); return null; }
+  await wsSelect.selectOption({ label: 'ws01' });
+  await page.waitForTimeout(1500);
+
+  const prjSelect = page.locator('#select-current-project');
+  if (await prjSelect.count() === 0) { console.warn(`[${tag}] project selector 없음`); return null; }
+  await prjSelect.selectOption({ label: 'default' });
+
+  // iframe src 대기
+  await page.waitForSelector('#targetIframe iframe[src]', { timeout: 20_000 }).catch(() => {});
+
+  // http → https 수정 (mixed content 차단 우회)
+  const iframeEl = page.locator('#targetIframe iframe').first();
+  const src = await iframeEl.getAttribute('src').catch(() => '');
+  if (src && src.startsWith('http://')) {
+    await page.evaluate((s) => {
+      const el = document.querySelector('#targetIframe iframe') as HTMLIFrameElement;
+      if (el) el.src = s;
+    }, src.replace('http://', 'https://'));
+  }
+  await page.waitForTimeout(3000);
+
+  // page.frames()로 3300 frame 찾기
+  for (let i = 0; i < 6; i++) {
+    const f = page.frames().find(fr => fr.url().includes('3300'));
+    if (f) {
+      // nav 링크 로드 대기
+      await f.locator('a.nav-link').first().waitFor({ state: 'attached', timeout: 5_000 }).catch(() => {});
+      console.log(`[${tag}] iframe frame URL: ${f.url()}`);
+      return f;
+    }
+    await page.waitForTimeout(1000);
+  }
+  console.warn(`[${tag}] 3300 frame 없음`);
+  return null;
+}
+
+/** iframe 내에서 서비스 탭(Object Storage/SQL Database/No-SQL) 클릭 */
+export async function clickServiceTab(frame: Frame, page: Page, tabText: string, tag: string): Promise<void> {
+  const tab = frame.locator('#serviceTabs .nav-link').filter({ hasText: tabText }).first();
+  if (await tab.count() === 0) {
+    console.warn(`[${tag}] service tab "${tabText}" 없음`);
+    return;
+  }
+  await tab.click();
+  await page.waitForTimeout(1500);
+  console.log(`[${tag}] service tab "${tabText}" 클릭 → ${frame.url()}`);
+}
+
+/** 텍스트/select 채우기 */
+export async function fillField(frame: Frame, selector: string, value: string): Promise<void> {
+  const el = frame.locator(selector).first();
+  if (await el.count() === 0) return;
+  const tag = await el.evaluate((e) => e.tagName.toLowerCase()).catch(() => '');
+  if (tag === 'select') {
+    await el.selectOption(value).catch(() => {});
+  } else {
+    await el.fill(value).catch(() => {});
+  }
+}
+
+/** Submit 버튼 클릭 후 resultText 확인 */
+export async function submitAndCheckResult(
+  frame: Frame, page: Page, tag: string, timeout = 60_000
+): Promise<string> {
+  const submitBtn = frame.locator('button:visible').filter({ hasText: 'Submit' }).first();
+  if (await submitBtn.count() === 0) {
+    console.warn(`[${tag}] Submit 버튼 없음`);
+    return '';
+  }
+  await submitBtn.click();
+  console.log(`[${tag}] Submit 클릭`);
+  await page.waitForTimeout(timeout > 10_000 ? 5_000 : 3_000);
+
+  const resultEl = frame.locator('#resultText').first();
+  if (await resultEl.count() > 0) {
+    const result = await resultEl.inputValue().catch(() => '') || await resultEl.textContent().catch(() => '') || '';
+    console.log(`[${tag}] result: ${result.slice(0, 300)}`);
+    return result;
+  }
+  return '';
+}

--- a/e2e/shared/pages.ts
+++ b/e2e/shared/pages.ts
@@ -1,0 +1,65 @@
+export const PAGES = {
+  auth: {
+    login:        '/auth/login',
+    signup:       '/auth/signup',
+    unauthorized: '/auth/unauthorized',
+  },
+  operations: {
+    mciWorkloads:    '/webconsole/operations/manage/workloads/mciworkloads',
+    pmkWorkloads:    '/webconsole/operations/manage/workloads/pmkworkloads',
+    workspaces:      '/webconsole/operations/manage/workspaces',
+    workspaceRoles:  '/webconsole/operations/manage/workspaces/roles',
+    costAnalysis:    '/webconsole/operations/analytics/costanalysis',
+    mciMonitoring:   '/webconsole/operations/analytics/monitorings/mcismonitoring',
+  },
+  settings: {
+    users:        '/webconsole/settings/accountnaccess/organizations/users',
+    groups:       '/webconsole/settings/accountnaccess/organizations/groups',       // TODO: discovery 확인 필요
+    roles:        '/webconsole/operations/manage/workspaces/roles',                 // confirmed 2026-06-05
+    policies:     '/webconsole/settings/accountnaccess/organizations/policies',     // TODO: discovery 확인 필요
+    organizations:'/webconsole/settings/accountnaccess/organizations',             // TODO: discovery 확인 필요
+    companies:    '/webconsole/settings/accountnaccess/companies',                 // TODO: discovery 확인 필요
+    approvals:    '/webconsole/settings/accountnaccess/organizations/approvals', // FR-PLATFORM-ADMIN-001 — 가입 신청 승인 화면
+    credentials:  '/webconsole/settings/environment/cloudsps/credentials',
+    connections:  '/webconsole/settings/environment/cloudsps/connections',
+    serverSpecs:       '/webconsole/settings/environment/cloudresources/serverspecs',
+    serverImages:      '/webconsole/settings/environment/cloudresources/serverimages',
+    sshKeys:           '/webconsole/settings/environment/cloudresources/sshkeys',
+    dataDisk:          '/webconsole/settings/environment/cloudresources/datadisk',
+    networks:          '/webconsole/settings/environment/cloudresources/networks',
+    securityGroups:    '/webconsole/settings/environment/cloudresources/securitygroups',
+  },
+  infra: {
+    templates:    '/webconsole/operations/manage/templates',                        // confirmed 2026-05-27
+    scheduleJobs: '/webconsole/operations/manage/schedulejobs',                     // confirmed 2026-05-27
+  },
+  sw: {
+    catalog:      '/webconsole/operations/manage/swcatalogs',                       // confirmed 2026-06-09 (iframe 내부: Catalog/Apps Status/Repository 탭)
+    repository:   '/webconsole/operations/manage/swcatalogs',                       // TC-APP-REP-01: Repository는 swcatalogs 페이지 내 iframe > Repository 탭
+    deploy:       '/webconsole/operations/manage/swcatalogs',                       // TC-APP-DEP-01~03: Apps Status 탭
+    appsStatus:   '/webconsole/operations/manage/swcatalogs',                       // TC-APP-APPS-01~04: Apps Status 탭
+    workflow:     '/webconsole/operations/manage/workflows',                        // TODO: discovery 확인 필요
+    oss:          '/webconsole/operations/manage/swcatalogs',                       // TODO: discovery 확인 필요
+  },
+  data: {
+    objectStorage: '/webconsole/operations/data/objectstorage',                     // confirmed 2026-05-27
+    rdbms:         '/webconsole/operations/data/rdbms',                             // confirmed 2026-05-27
+    nordbms:       '/webconsole/operations/data/nordbms',                           // confirmed 2026-05-27
+  },
+  obs: {
+    // 모든 C6 TC는 observability 단일 진입점 사용 (browser 확인 2026-06-27)
+    // /webconsole/operations/analytics/observability → Namespace 대시보드 (Node/K8s 탭, MCI 카드)
+    observability:     '/webconsole/operations/analytics/observability',
+    monitoringConfig:  '/webconsole/operations/analytics/observability',
+    monitoringAgent:   '/webconsole/operations/analytics/observability',
+    monitoringData:    '/webconsole/operations/analytics/observability',
+    cspMetrics:        '/webconsole/operations/analytics/observability',
+    k8sMetrics:        '/webconsole/operations/analytics/observability',
+    metricsOverview:   '/webconsole/operations/analytics/observability',
+    monitoringInsight: '/webconsole/operations/analytics/observability',
+    logs:              '/webconsole/operations/analytics/observability',
+    tracing:           '/webconsole/operations/analytics/observability',
+    triggerPolicy:     '/webconsole/operations/analytics/observability',
+    obsIframe:         '/webconsole/operations/analytics/observability',
+  },
+} as const;

--- a/e2e/shared/request-auth.helper.ts
+++ b/e2e/shared/request-auth.helper.ts
@@ -1,0 +1,122 @@
+import type { APIRequestContext, Page } from '@playwright/test';
+import { API_ROUTES } from './api-routes';
+
+/**
+ * Login via API and return cookie headers for subsequent requests.
+ * The server authenticates via Cookie: Authorization=<access_token> (not Bearer header).
+ */
+export async function apiLogin(request: APIRequestContext): Promise<{ Cookie: string }> {
+  const res = await request.post(API_ROUTES.auth.login, {
+    data: { request: { id: process.env.ADMIN_ID, password: process.env.ADMIN_PASSWORD } },
+  });
+  if (!res.ok()) throw new Error(`Login failed: ${res.status()} ${await res.text()}`);
+  const { access_token, refresh_token } = await res.json() as { access_token: string; refresh_token: string };
+  return { Cookie: `Authorization=${access_token}; RefreshToken=${refresh_token}` };
+}
+
+/**
+ * Login via API and return Bearer Authorization header for direct backend requests.
+ * Use this for services not proxied through mc-web-console (e.g. mc-application-manager direct).
+ */
+export async function apiLoginBearer(request: APIRequestContext): Promise<{ Authorization: string }> {
+  const res = await request.post(API_ROUTES.auth.login, {
+    data: { request: { id: process.env.ADMIN_ID, password: process.env.ADMIN_PASSWORD } },
+  });
+  if (!res.ok()) throw new Error(`Login failed: ${res.status()} ${await res.text()}`);
+  const { access_token } = await res.json() as { access_token: string };
+  return { Authorization: `Bearer ${access_token}` };
+}
+
+export async function apiLoginWith(
+  request: APIRequestContext,
+  id: string,
+  password: string,
+): Promise<{ Cookie: string }> {
+  const res = await request.post(API_ROUTES.auth.login, {
+    data: { request: { id, password } },
+  });
+  if (!res.ok()) throw new Error(`Login failed for ${id}: ${res.status()} ${await res.text()}`);
+  const { access_token, refresh_token } = await res.json() as { access_token: string; refresh_token: string };
+  return { Cookie: `Authorization=${access_token}; RefreshToken=${refresh_token}` };
+}
+
+/**
+ * Attempt browser login with given credentials.
+ * Returns true if webconsole is reached, false if login page stays (user doesn't exist or wrong creds).
+ * Uses a short timeout (8s) so tests that call this don't exceed Playwright's default test timeout.
+ * On failure, logs a warning with the given tag so tests can skip gracefully.
+ */
+export async function tryPageLogin(
+  page: Page,
+  id: string,
+  password: string,
+  tag: string,
+): Promise<boolean> {
+  await page.fill('#id', id);
+  await page.fill('#password', password);
+  await page.click('#loginbtn');
+  try {
+    await page.waitForURL(/\/webconsole\//, { timeout: 30_000 });
+    return true;
+  } catch {
+    console.warn(`[${tag}] 로그인 실패 (URL: ${page.url()}) — 사용자가 서버에 없거나 TODO: CreateUser`);
+    return false;
+  }
+}
+
+/**
+ * Navigate to a URL with a single retry on network errors.
+ */
+export async function gotoWithRetry(page: Page, url: string): Promise<void> {
+  try {
+    await page.goto(url);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('ERR_NETWORK') || msg.includes('ERR_CONNECTION')) {
+      await page.waitForTimeout(1_000);
+      await page.goto(url);
+    } else {
+      throw e;
+    }
+  }
+}
+
+/**
+ * Login to the app and navigate to a target URL.
+ * Handles ERR_NETWORK_CHANGED on the initial login page goto.
+ * Returns false if login fails or network is unreachable (test should skip gracefully).
+ */
+export async function loginAndGoto(
+  page: Page,
+  targetUrl: string,
+  tag: string,
+  id?: string,
+  password?: string,
+): Promise<boolean> {
+  const loginUrl = '/auth/login';
+  try {
+    await page.goto(loginUrl);
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('ERR_NETWORK') || msg.includes('ERR_CONNECTION')) {
+      await page.waitForTimeout(1_000);
+      try { await page.goto(loginUrl); } catch {
+        console.warn(`[${tag}] 로그인 페이지 접근 실패 — 건너뜀`);
+        return false;
+      }
+    } else {
+      throw e;
+    }
+  }
+  const ok = await tryPageLogin(page, id ?? process.env.ADMIN_ID ?? '', password ?? process.env.ADMIN_PASSWORD ?? '', tag);
+  if (!ok) return false;
+  try {
+    await page.goto(targetUrl);
+    await page.waitForLoadState('domcontentloaded', { timeout: 30_000 });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : String(e);
+    console.warn(`[${tag}] 화면 이동 실패: ${targetUrl} — ${msg.slice(0, 120)}`);
+    return false;
+  }
+  return true;
+}

--- a/e2e/shared/sw-iframe.helper.ts
+++ b/e2e/shared/sw-iframe.helper.ts
@@ -1,0 +1,135 @@
+/**
+ * SW Catalog iframe 공통 헬퍼
+ *
+ * mc-web-console SW Catalogs 페이지는 mc-application-manager-fe를
+ * iframe (#targetIframe-sofrwareCatalog iframe) 으로 embed한다.
+ * 이 헬퍼는 iframe 진입 후 지정 탭을 클릭하는 공통 로직을 제공한다.
+ */
+import type { Page, FrameLocator } from '@playwright/test';
+import * as os from 'os';
+import * as path from 'path';
+
+/**
+ * SW Catalogs iframe 에 진입하여 지정 탭을 클릭한다.
+ *
+ * @param page      Playwright Page
+ * @param tabName   탭 텍스트를 매칭할 RegExp (예: /repository/i, /catalog/i)
+ * @param tag       로그 식별자
+ * @returns         iframe FrameLocator (실패 시 null)
+ */
+export async function gotoSwIframeTab(
+  page: Page,
+  tabName: RegExp,
+  tag: string,
+): Promise<FrameLocator | null> {
+  // ── 1. Workspace 선택 ──
+  const wsLoaded = await page.waitForFunction(
+    () => {
+      const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement | null;
+      return sel ? sel.options.length > 1 : false;
+    },
+    { timeout: 15_000 },
+  ).then(() => true).catch(() => false);
+
+  if (!wsLoaded) { console.warn(`[${tag}] Workspace 옵션 로드 실패`); return null; }
+
+  await page.evaluate(() => {
+    const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement | null;
+    if (!sel || sel.options.length < 2) return;
+    sel.selectedIndex = 1;
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+
+  // ── 2. Project 선택 ──
+  const projLoaded = await page.waitForFunction(
+    () => {
+      const sel = document.querySelector('#select-current-project') as HTMLSelectElement | null;
+      return sel ? sel.options.length > 1 : false;
+    },
+    { timeout: 15_000 },
+  ).then(() => true).catch(() => false);
+
+  if (!projLoaded) { console.warn(`[${tag}] Project 옵션 로드 실패`); return null; }
+
+  // ── 3. sessionStorage에 workspace/project 설정 ──
+  const sessionSet = await page.evaluate(() => {
+    const wsSel   = document.querySelector('#select-current-workspace') as HTMLSelectElement | null;
+    const projSel = document.querySelector('#select-current-project') as HTMLSelectElement | null;
+    const wsApi   = (window as any).webconsolejs?.['common/api/services/workspace_api'];
+    if (!wsSel || !projSel || !wsApi) return { ok: false, reason: 'missing elements or wsApi' };
+    const wsOpt   = wsSel.options[wsSel.selectedIndex] || wsSel.options[1];
+    const projOpt = Array.from(projSel.options).find((o: any) => o.value !== '') as HTMLOptionElement | undefined;
+    if (!wsOpt?.value || !projOpt?.value)
+      return { ok: false, reason: `wsVal=${wsOpt?.value} projVal=${projOpt?.value}` };
+    const workspace = { Id: wsOpt.value, Name: wsOpt.text };
+    const nsId      = projOpt.getAttribute('data-nsid') || projOpt.text;
+    wsApi.setCurrentWorkspace(workspace);
+    wsApi.setCurrentProject({ Id: projOpt.value, Name: projOpt.text, NsId: nsId });
+    return { ok: true };
+  }).catch((e: unknown) => ({ ok: false, reason: String(e) }));
+
+  if (!sessionSet.ok) {
+    console.warn(`[${tag}] session 설정 실패:`, (sessionSet as any).reason);
+    return null;
+  }
+
+  // ── 3.5. HTTP→HTTPS 업그레이드 (app-manager-fe가 HTTPS 전용인 경우) ──
+  // iframe.src setter를 패치하여 포트 18084의 HTTP URL을 HTTPS로 자동 업그레이드
+  await page.addInitScript(() => {
+    const desc = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'src');
+    if (desc && !(HTMLIFrameElement.prototype as any).__httpPatched) {
+      (HTMLIFrameElement.prototype as any).__httpPatched = true;
+      Object.defineProperty(HTMLIFrameElement.prototype, 'src', {
+        set(value: string) {
+          const fixed = value.replace(/^http:\/\/([^/]+):18084/, 'https://$1:18084');
+          desc.set!.call(this, fixed);
+        },
+        get() { return desc.get!.call(this); },
+        configurable: true,
+      });
+    }
+  });
+
+  await page.reload({ waitUntil: 'domcontentloaded' });
+
+  // ── 4. iframe 로드 대기 ──
+  const iframeEl      = page.locator('#targetIframe-sofrwareCatalog iframe').first();
+  const iframePresent = await iframeEl.waitFor({ state: 'attached', timeout: 25_000 })
+    .then(() => true).catch(() => false);
+  if (!iframePresent) {
+    console.warn(`[${tag}] iframe 미발견`);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-iframe-not-found.png`) }).catch(() => null);
+    return null;
+  }
+  console.log(`[${tag}] iframe src: ${await iframeEl.getAttribute('src').catch(() => '')}`);
+
+  // ── 5. SPA 렌더링 대기 ──
+  const frame = page.frameLocator('#targetIframe-sofrwareCatalog iframe').first();
+  const tabAreaLoaded = await frame.locator(
+    'nav, [role="navigation"], [role="tab"], [class*="tab"], [class*="nav"], ul.nav, .menu, li'
+  ).first().waitFor({ state: 'visible', timeout: 30_000 }).then(() => true).catch(() => false);
+
+  if (!tabAreaLoaded) {
+    console.warn(`[${tag}] SPA 렌더링 실패(30s)`);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-spa-not-loaded.png`) }).catch(() => null);
+    return null;
+  }
+
+  // ── 6. 탭 클릭 ──
+  const tab = frame.locator('[role="tab"], .nav-link, .nav-item, li, button, a')
+    .filter({ hasText: tabName }).first();
+  if (!await tab.isVisible({ timeout: 8_000 }).catch(() => false)) {
+    const tabs = await frame
+      .locator('[role="tab"], .nav-link, .nav-item, li')
+      .allTextContents()
+      .catch(() => [] as string[]);
+    console.warn(`[${tag}] 탭 미발견 (${tabName}). 탭 목록: ${tabs.slice(0, 10).join(' | ')}`);
+    await page.screenshot({ path: path.join(os.tmpdir(), `${tag}-tab-not-found.png`) }).catch(() => null);
+    return null;
+  }
+
+  await tab.click();
+  await page.waitForTimeout(1_000);
+  console.log(`[${tag}] 탭 진입 완료 (${tabName})`);
+  return frame;
+}

--- a/e2e/tc/csp/TC-INFRA-CSP-03-ui.spec.ts
+++ b/e2e/tc/csp/TC-INFRA-CSP-03-ui.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts
+ * TC-INFRA-CSP-03: CSP 자격증명 UI 등록 (CSP별 variant)
+ *
+ * 경로: Settings > Cloud SPs > Credential → Register Credential
+ * Provider 선택 시 KV 행이 자동 생성되며, 각 Value만 입력 후 Register 클릭.
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────────
+ *   TC_VARIANT=aws       npx playwright test deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts
+ *   TC_VARIANT=gcp       npx playwright test deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts
+ *   TC_VARIANT=azure     npx playwright test deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts
+ *   TC_VARIANT=alibaba   npx playwright test deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts
+ *   TC_VARIANT=ibm       npx playwright test deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts
+ *   TC_VARIANT=ncp       npx playwright test deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts
+ *   TC_VARIANT=nhn       npx playwright test deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts
+ *   TC_VARIANT=kt        npx playwright test deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts
+ *   TC_VARIANT=openstack npx playwright test deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts
+ *   TC_VARIANT=tencent   npx playwright test deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts
+ *
+ * ── 민감값 주입 ──────────────────────────────────────────────────────
+ *   TC_VARIANT=aws PW_ClientId=AKIA... PW_ClientSecret=... \
+ *     npx playwright test deploy/tc/csp/TC-INFRA-CSP-03-ui.spec.ts
+ *
+ * ── Provider별 KV 필드 (cb-spider PROVIDER_KEYS 기준) ────────────────
+ *   aws:       ClientId, ClientSecret
+ *   gcp:       ClientEmail, PrivateKey, ProjectID
+ *   azure:     ClientId, ClientSecret, TenantId, SubscriptionId
+ *   alibaba:   ClientId, ClientSecret
+ *   ibm:       ApiKey, S3AccessKey, S3SecretKey
+ *   ncp:       ClientId, ClientSecret
+ *   nhn:       IdentityEndpoint, Username, Password, DomainName, TenantId
+ *   kt:        IdentityEndpoint, Username, Password, DomainName, ProjectID
+ *   openstack: IdentityEndpoint, Username, Password, DomainName, ProjectID
+ *   tencent:   SecretId, SecretKey
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }         from '../../shared/pages';
+import { loginAndGoto }  from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID   = 'TC-INFRA-CSP-03';
+const variant = process.env.TC_VARIANT;
+
+if (!variant || variant === 'api') {
+  throw new Error(
+    `TC_VARIANT 환경변수가 필요합니다. 예: TC_VARIANT=aws\n` +
+    `지원 값: aws | gcp | azure | alibaba | ibm | ncp | nhn | kt | openstack | tencent`,
+  );
+}
+
+const scenarioId = process.env.SCENARIO_ID;
+const ctx = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p = ctx.params;
+
+// cb-spider PROVIDER_KEYS 와 동일 — 서버에서 기대하는 KV 키 이름 목록
+const PROVIDER_FIELDS: Record<string, string[]> = {
+  aws:       ['ClientId', 'ClientSecret'],
+  gcp:       ['ClientEmail', 'PrivateKey', 'ProjectID'],
+  azure:     ['ClientId', 'ClientSecret', 'TenantId', 'SubscriptionId'],
+  alibaba:   ['ClientId', 'ClientSecret'],
+  ibm:       ['ApiKey', 'S3AccessKey', 'S3SecretKey'],
+  ncp:       ['ClientId', 'ClientSecret'],
+  nhn:       ['IdentityEndpoint', 'Username', 'Password', 'DomainName', 'TenantId'],
+  kt:        ['IdentityEndpoint', 'Username', 'Password', 'DomainName', 'ProjectID'],
+  openstack: ['IdentityEndpoint', 'Username', 'Password', 'DomainName', 'ProjectID'],
+  tencent:   ['SecretId', 'SecretKey'],
+};
+
+const fields = PROVIDER_FIELDS[variant];
+if (!fields) {
+  throw new Error(`지원하지 않는 TC_VARIANT: ${variant}. 지원: ${Object.keys(PROVIDER_FIELDS).join(' | ')}`);
+}
+
+const credentialHolder = (p.credentialHolder as string) ?? `e2e-${variant}-credential`;
+const providerName     = (p.providerName as string)     ?? variant;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+test.describe.configure({ mode: 'serial' });
+
+test.describe(`TC-INFRA-CSP-03 UI: ${variant.toUpperCase()} 자격증명 등록`, () => {
+
+  test(`UI: Credential 메뉴 진입 확인 (${variant})`, async ({ page }) => {
+    const ok = await loginAndGoto(page, PAGES.settings.credentials, `TC-INFRA-CSP-03/${variant}`);
+    expect(ok, 'Credential 메뉴 로드 실패').toBe(true);
+
+    // Credential Holders 테이블 로드 확인
+    await expect(page.locator('#credential-table')).toBeVisible({ timeout: 10_000 });
+    console.log(`[TC-INFRA-CSP-03/${variant}] Credential 목록 페이지 OK`);
+  });
+
+  test(`UI: Register Credential 모달 오픈 → ${variant} Provider 선택 → KV 자동 채움`, async ({ page }) => {
+    await loginAndGoto(page, PAGES.settings.credentials, `TC-INFRA-CSP-03/${variant}`);
+    await page.locator('#credential-table').waitFor({ state: 'visible', timeout: 10_000 });
+
+    // Register Credential 버튼 클릭
+    await page.click('[data-bs-target="#credential-create-modal"]');
+    await page.locator('#credential-create-modal').waitFor({ state: 'visible', timeout: 5_000 });
+    console.log(`[TC-INFRA-CSP-03/${variant}] 모달 열림`);
+
+    // Credential Holder 이름 입력
+    await page.fill('#create-holder-name', credentialHolder);
+
+    // CSP Provider 선택 → change 이벤트가 KV 행 자동 생성
+    await page.selectOption('#create-holder-provider', providerName);
+    await page.waitForTimeout(500);
+
+    // KV 행이 fields.length 만큼 생성됐는지 확인
+    const rows = page.locator('#kv-list-container .kv-row');
+    await expect(rows).toHaveCount(fields.length, { timeout: 5_000 });
+    console.log(`[TC-INFRA-CSP-03/${variant}] KV 행 ${fields.length}개 자동 생성 확인`);
+
+    // 각 KV 행의 Key 자동 채움 확인
+    for (let i = 0; i < fields.length; i++) {
+      const keyInput = rows.nth(i).locator('.kv-key');
+      await expect(keyInput).toHaveValue(fields[i], { timeout: 3_000 });
+      console.log(`[TC-INFRA-CSP-03/${variant}] KV[${i}] key="${fields[i]}" 자동 채움 확인`);
+    }
+  });
+
+  test(`UI: KV Value 입력 후 Register 완료 (${variant})`, async ({ page }) => {
+    await loginAndGoto(page, PAGES.settings.credentials, `TC-INFRA-CSP-03/${variant}`);
+    await page.locator('#credential-table').waitFor({ state: 'visible', timeout: 10_000 });
+
+    // 이미 등록된 경우 삭제 또는 skip
+    const existingRow = page.locator('#credential-table').getByText(credentialHolder);
+    if (await existingRow.count().catch(() => 0) > 0) {
+      console.warn(`[TC-INFRA-CSP-03/${variant}] ${credentialHolder} 이미 존재 — 재등록 skip`);
+      return;
+    }
+
+    // Register Credential 모달 오픈
+    await page.click('[data-bs-target="#credential-create-modal"]');
+    await page.locator('#credential-create-modal').waitFor({ state: 'visible', timeout: 5_000 });
+
+    // Holder 이름 + Provider 선택
+    await page.fill('#create-holder-name', credentialHolder);
+    await page.selectOption('#create-holder-provider', providerName);
+    await page.waitForTimeout(500);
+
+    // KV 행 Value 입력
+    const rows = page.locator('#kv-list-container .kv-row');
+    await expect(rows).toHaveCount(fields.length, { timeout: 5_000 });
+
+    for (let i = 0; i < fields.length; i++) {
+      const fieldKey   = fields[i];
+      const fieldValue = (p[fieldKey] as string) ?? '';
+
+      if (!fieldValue) {
+        console.warn(`[TC-INFRA-CSP-03/${variant}] ${fieldKey} 값 미주입 — PW_${fieldKey} 환경변수 필요`);
+      }
+      await rows.nth(i).locator('.kv-value').fill(fieldValue);
+    }
+
+    // Register 버튼 클릭
+    await page.click('#credential-create-modal .btn-primary[onclick*="registerCredential"]');
+
+    // 성공: 모달 닫힘 또는 성공 토스트
+    await Promise.race([
+      page.locator('#credential-create-modal').waitFor({ state: 'hidden', timeout: 15_000 }),
+      page.locator('.toast-success, .alert-success, [class*="success"]').first().waitFor({ timeout: 15_000 }),
+    ]).catch(() => {
+      console.warn(`[TC-INFRA-CSP-03/${variant}] Register 응답 확인 timeout`);
+    });
+
+    // 목록에서 신규 Holder 확인
+    await page.locator('#credential-table').waitFor({ state: 'visible', timeout: 10_000 });
+    const registered = page.locator('#credential-table').getByText(credentialHolder);
+    if (await registered.count().catch(() => 0) > 0) {
+      console.log(`[TC-INFRA-CSP-03/${variant}] ✅ ${credentialHolder} 등록 확인`);
+    } else {
+      console.warn(`[TC-INFRA-CSP-03/${variant}] 목록 반영 미확인 — 새로고침 필요할 수 있음`);
+    }
+  });
+
+});

--- a/e2e/tc/data/TC-DATA-NORDB-BAK-01.spec.ts
+++ b/e2e/tc/data/TC-DATA-NORDB-BAK-01.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/tc/data/TC-DATA-NORDB-BAK-01.spec.ts
+ * TC-DATA-NORDB-BAK-01: NoRDBMS 백업/복원 — 브라우저 UI 테스트
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }         from '../../shared/pages';
+import { loginAndGoto }  from '../../shared/request-auth.helper';
+
+const TC_ID = 'TC-DATA-NORDB-BAK-01';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-DATA-NORDB-BAK-01: NoRDBMS 백업/복원', () => {
+  test('UI: 화면 진입 확인', async ({ page }) => {
+    const ok = await loginAndGoto(page, PAGES.data.nordbms, TC_ID);
+    if (!ok) return;
+    expect(page.url()).toMatch(/\/webconsole\//);
+    console.log(`[${TC_ID}] UI OK: ${page.url()}`);
+  });
+});

--- a/e2e/tc/data/TC-DATA-NORDB-MIG-01.spec.ts
+++ b/e2e/tc/data/TC-DATA-NORDB-MIG-01.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/tc/data/TC-DATA-NORDB-MIG-01.spec.ts
+ * TC-DATA-NORDB-MIG-01: NoRDBMS 마이그레이션 — 브라우저 UI 테스트
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }         from '../../shared/pages';
+import { loginAndGoto }  from '../../shared/request-auth.helper';
+
+const TC_ID = 'TC-DATA-NORDB-MIG-01';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-DATA-NORDB-MIG-01: NoRDBMS 마이그레이션', () => {
+  test('UI: 화면 진입 확인', async ({ page }) => {
+    const ok = await loginAndGoto(page, PAGES.data.nordbms, TC_ID);
+    if (!ok) return;
+    expect(page.url()).toMatch(/\/webconsole\//);
+    console.log(`[${TC_ID}] UI OK: ${page.url()}`);
+  });
+});

--- a/e2e/tc/data/TC-DATA-NRDB-01-04.spec.ts
+++ b/e2e/tc/data/TC-DATA-NRDB-01-04.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/tc/data/TC-DATA-NRDB-01-04.spec.ts
+ * TC-DATA-NRDB-01-04: NoRDBMS 생성/백업/복원 — 브라우저 UI 테스트
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }         from '../../shared/pages';
+import { loginAndGoto }  from '../../shared/request-auth.helper';
+
+const TC_ID = 'TC-DATA-NRDB-01-04';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-DATA-NRDB-01-04: NoRDBMS 생성/백업/복원', () => {
+  test('UI: 화면 진입 확인', async ({ page }) => {
+    const ok = await loginAndGoto(page, PAGES.data.nordbms, TC_ID);
+    if (!ok) return;
+    expect(page.url()).toMatch(/\/webconsole\//);
+    console.log(`[${TC_ID}] UI OK: ${page.url()}`);
+  });
+});

--- a/e2e/tc/data/TC-DATA-OBJ-BAK-01.spec.ts
+++ b/e2e/tc/data/TC-DATA-OBJ-BAK-01.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/tc/data/TC-DATA-OBJ-BAK-01.spec.ts
+ * TC-DATA-OBJ-BAK-01: Object Storage 백업/복원 — 브라우저 UI 테스트
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }         from '../../shared/pages';
+import { loginAndGoto }  from '../../shared/request-auth.helper';
+
+const TC_ID = 'TC-DATA-OBJ-BAK-01';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-DATA-OBJ-BAK-01: Object Storage 백업/복원', () => {
+  test('UI: 화면 진입 확인', async ({ page }) => {
+    const ok = await loginAndGoto(page, PAGES.data.objectStorage, TC_ID);
+    if (!ok) return;
+    expect(page.url()).toMatch(/\/webconsole\//);
+    console.log(`[${TC_ID}] UI OK: ${page.url()}`);
+  });
+});

--- a/e2e/tc/data/TC-DATA-OBJ-MIG-01.spec.ts
+++ b/e2e/tc/data/TC-DATA-OBJ-MIG-01.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/tc/data/TC-DATA-OBJ-MIG-01.spec.ts
+ * TC-DATA-OBJ-MIG-01: Object Storage 마이그레이션 — 브라우저 UI 테스트
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }         from '../../shared/pages';
+import { loginAndGoto }  from '../../shared/request-auth.helper';
+
+const TC_ID = 'TC-DATA-OBJ-MIG-01';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-DATA-OBJ-MIG-01: Object Storage 마이그레이션', () => {
+  test('UI: 화면 진입 확인', async ({ page }) => {
+    const ok = await loginAndGoto(page, PAGES.data.objectStorage, TC_ID);
+    if (!ok) return;
+    expect(page.url()).toMatch(/\/webconsole\//);
+    console.log(`[${TC_ID}] UI OK: ${page.url()}`);
+  });
+});

--- a/e2e/tc/data/TC-DATA-OS-01-04.spec.ts
+++ b/e2e/tc/data/TC-DATA-OS-01-04.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/tc/data/TC-DATA-OS-01-04.spec.ts
+ * TC-DATA-OS-01-04: Object Storage 생성/관리 — 브라우저 UI 테스트
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }         from '../../shared/pages';
+import { loginAndGoto }  from '../../shared/request-auth.helper';
+
+const TC_ID = 'TC-DATA-OS-01-04';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-DATA-OS-01-04: Object Storage 생성/관리', () => {
+  test('UI: 화면 진입 확인', async ({ page }) => {
+    const ok = await loginAndGoto(page, PAGES.data.objectStorage, TC_ID);
+    if (!ok) return;
+    expect(page.url()).toMatch(/\/webconsole\//);
+    console.log(`[${TC_ID}] UI OK: ${page.url()}`);
+  });
+});

--- a/e2e/tc/data/TC-DATA-RDB-01-04.spec.ts
+++ b/e2e/tc/data/TC-DATA-RDB-01-04.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/tc/data/TC-DATA-RDB-01-04.spec.ts
+ * TC-DATA-RDB-01-04: RDB 생성/백업/복원 — 브라우저 UI 테스트
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }         from '../../shared/pages';
+import { loginAndGoto }  from '../../shared/request-auth.helper';
+
+const TC_ID = 'TC-DATA-RDB-01-04';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-DATA-RDB-01-04: RDB 생성/백업/복원', () => {
+  test('UI: 화면 진입 확인', async ({ page }) => {
+    const ok = await loginAndGoto(page, PAGES.data.rdbms, TC_ID);
+    if (!ok) return;
+    expect(page.url()).toMatch(/\/webconsole\//);
+    console.log(`[${TC_ID}] UI OK: ${page.url()}`);
+  });
+});

--- a/e2e/tc/data/TC-DATA-RDB-BAK-01.spec.ts
+++ b/e2e/tc/data/TC-DATA-RDB-BAK-01.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/tc/data/TC-DATA-RDB-BAK-01.spec.ts
+ * TC-DATA-RDB-BAK-01: RDBMS 백업/복원 — 브라우저 UI 테스트
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }         from '../../shared/pages';
+import { loginAndGoto }  from '../../shared/request-auth.helper';
+
+const TC_ID = 'TC-DATA-RDB-BAK-01';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-DATA-RDB-BAK-01: RDBMS 백업/복원', () => {
+  test('UI: 화면 진입 확인', async ({ page }) => {
+    const ok = await loginAndGoto(page, PAGES.data.rdbms, TC_ID);
+    if (!ok) return;
+    expect(page.url()).toMatch(/\/webconsole\//);
+    console.log(`[${TC_ID}] UI OK: ${page.url()}`);
+  });
+});

--- a/e2e/tc/data/TC-DATA-RDB-MIG-01.spec.ts
+++ b/e2e/tc/data/TC-DATA-RDB-MIG-01.spec.ts
@@ -1,0 +1,20 @@
+/**
+ * deploy/tc/data/TC-DATA-RDB-MIG-01.spec.ts
+ * TC-DATA-RDB-MIG-01: RDBMS 마이그레이션 — 브라우저 UI 테스트
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }         from '../../shared/pages';
+import { loginAndGoto }  from '../../shared/request-auth.helper';
+
+const TC_ID = 'TC-DATA-RDB-MIG-01';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-DATA-RDB-MIG-01: RDBMS 마이그레이션', () => {
+  test('UI: 화면 진입 확인', async ({ page }) => {
+    const ok = await loginAndGoto(page, PAGES.data.rdbms, TC_ID);
+    if (!ok) return;
+    expect(page.url()).toMatch(/\/webconsole\//);
+    console.log(`[${TC_ID}] UI OK: ${page.url()}`);
+  });
+});

--- a/e2e/tc/data/TC-DATA-UI.spec.ts
+++ b/e2e/tc/data/TC-DATA-UI.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * deploy/tc/data/TC-DATA-UI.spec.ts
+ * TC-DATA-UI-01~06: mc-data-manager UI 브라우저 테스트 (포털 iframe)
+ *
+ * 접속: https://15.164.139.37:3001/webconsole/operations/manage/datamigrations
+ * iframe: mc-data-manager-fe (:3300)
+ */
+import { test, expect } from '@playwright/test';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+import { loadDataFrame, clickServiceTab } from './helpers/data-portal.helper';
+
+const TC_ID = 'TC-DATA-UI-01';
+const scenarioId = process.env.SCENARIO_ID;
+const ctx = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID)
+  : new StandaloneContext(TC_ID);
+const p = ctx.params;
+
+const PAGE_URL = (p.pageUrl as string) ?? '/webconsole/operations/manage/datamigrations';
+const DATA_MANAGER = (p.dataManagerBaseUrl as string) ?? 'https://15.164.139.37:3300';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-DATA-UI-01: 페이지 로드 및 iframe 초기화', () => {
+
+  test('UI: workspace/project 선택 후 iframe 로드 확인', async ({ page }) => {
+    const ok = await loginAndGoto(page, PAGE_URL, 'TC-DATA-UI-01');
+    expect(ok).toBeTruthy();
+
+    await page.waitForTimeout(1500);
+    await page.locator('#select-current-workspace').selectOption({ label: p.workspaceName as string ?? 'ws01' });
+    await page.waitForTimeout(1500);
+    await page.locator('#select-current-project').selectOption({ label: p.projectName as string ?? 'default' });
+    await page.waitForTimeout(3000);
+
+    const iframeEl = page.locator('#targetIframe iframe').first();
+    await iframeEl.waitFor({ state: 'attached', timeout: 15_000 });
+    const src = await iframeEl.getAttribute('src') || '';
+    console.log(`[TC-DATA-UI-01] iframe src: ${src}`);
+    expect(src).toMatch(/3300/);
+  });
+});
+
+test.describe('TC-DATA-UI-02: Nav 탭 Navigation', () => {
+
+  test('UI: Generate / Migration / Back up / Restore nav 링크 확인', async ({ page }) => {
+    const frame = await loadDataFrame(page, 'TC-DATA-UI-02');
+    if (!frame) { console.warn('[TC-DATA-UI-02] SKIP'); return; }
+
+    const navLinks = frame.locator('a.nav-link');
+    const count = await navLinks.count();
+    expect(count).toBeGreaterThan(0);
+
+    const texts: string[] = [];
+    for (let i = 0; i < count; i++) {
+      texts.push((await navLinks.nth(i).textContent())?.trim() ?? '');
+    }
+    console.log(`[TC-DATA-UI-02] nav links: ${texts.join(', ')}`);
+    expect(texts.some(t => /generate|migration|back|restore/i.test(t))).toBeTruthy();
+  });
+});
+
+test.describe('TC-DATA-UI-03: Service 탭 전환', () => {
+
+  test('UI: Object Storage / SQL Database / No-SQL 탭 전환', async ({ page }) => {
+    const frame = await loadDataFrame(page, 'TC-DATA-UI-03');
+    if (!frame) { console.warn('[TC-DATA-UI-03] SKIP'); return; }
+
+    for (const tab of ['Object Storage', 'SQL Database', 'No-SQL']) {
+      await clickServiceTab(frame, page, tab, 'TC-DATA-UI-03');
+    }
+    console.log('[TC-DATA-UI-03] service tab 전환 완료');
+  });
+});
+
+test.describe('TC-DATA-UI-04: Object Storage Migration 태스크 목록', () => {
+
+  test('UI: /migrate/objectstorage 페이지 로드', async ({ page }) => {
+    const frame = await loadDataFrame(page, 'TC-DATA-UI-04');
+    if (!frame) { console.warn('[TC-DATA-UI-04] SKIP'); return; }
+
+    await frame.goto(`${DATA_MANAGER}/migrate/objectstorage`, {
+      timeout: 10_000,
+      waitUntil: 'domcontentloaded',
+    }).catch(() => {});
+    await page.waitForTimeout(2000);
+    expect(frame.url()).toContain('/migrate/objectstorage');
+    console.log(`[TC-DATA-UI-04] URL: ${frame.url()}`);
+  });
+});
+
+test.describe('TC-DATA-UI-05: Generate 페이지', () => {
+
+  test('UI: /generate/objectstorage form 확인', async ({ page }) => {
+    const frame = await loadDataFrame(page, 'TC-DATA-UI-05');
+    if (!frame) { console.warn('[TC-DATA-UI-05] SKIP'); return; }
+
+    await frame.goto(`${DATA_MANAGER}/generate/objectstorage`, {
+      timeout: 10_000,
+      waitUntil: 'domcontentloaded',
+    }).catch(() => {});
+    await page.waitForTimeout(2000);
+    expect(frame.url()).toContain('/generate/objectstorage');
+
+    const submitBtn = frame.locator('button:visible').filter({ hasText: 'Submit' });
+    expect(await submitBtn.count()).toBeGreaterThan(0);
+    console.log('[TC-DATA-UI-05] Generate form 확인 완료');
+  });
+});
+
+test.describe('TC-DATA-UI-06: Back up / Restore 등록 페이지', () => {
+
+  test('UI: /backup/register 및 /restore/register 페이지 로드', async ({ page }) => {
+    const frame = await loadDataFrame(page, 'TC-DATA-UI-06');
+    if (!frame) { console.warn('[TC-DATA-UI-06] SKIP'); return; }
+
+    for (const path of ['/backup/register', '/restore/register']) {
+      await frame.goto(`${DATA_MANAGER}${path}`, {
+        timeout: 10_000,
+        waitUntil: 'domcontentloaded',
+      }).catch(() => {});
+      await page.waitForTimeout(1500);
+      expect(frame.url()).toContain(path);
+      console.log(`[TC-DATA-UI-06] ${path} 로드 확인`);
+    }
+  });
+});

--- a/e2e/tc/data/helpers/data-portal.helper.ts
+++ b/e2e/tc/data/helpers/data-portal.helper.ts
@@ -1,0 +1,76 @@
+/**
+ * mc-data-manager 포털(iframe) 로딩 헬퍼
+ *
+ * mc-web-console(https://15.164.139.37:3001) → Data Migration iframe → mc-data-manager-fe(:3300)
+ */
+import type { Frame } from '@playwright/test';
+
+export {
+  loadDataFrame,
+  clickServiceTab,
+  fillField,
+  submitAndCheckResult,
+} from '../../../shared/data-iframe.helper';
+
+/** iframe src에 mc-data-manager 포트가 포함됐는지 확인 */
+export async function assertDataManagerIframe(
+  page: import('@playwright/test').Page,
+  tag: string,
+): Promise<boolean> {
+  const iframeEl = page.locator('#targetIframe iframe').first();
+  const attached = await iframeEl.waitFor({ state: 'attached', timeout: 15_000 })
+    .then(() => true).catch(() => false);
+
+  if (!attached) {
+    console.warn(`[${tag}] iframe 미로드 — workspace/project 미선택 또는 mc-data-manager-fe URL 미설정`);
+    return false;
+  }
+
+  const src = await iframeEl.getAttribute('src') || '';
+  console.log(`[${tag}] iframe src: ${src}`);
+  return /3300/.test(src);
+}
+
+type CredOption = { value: string; text: string };
+
+/** credential 드롭다운 옵션 목록 */
+export async function listCredentialOptions(
+  frame: Frame,
+  selector = '#targetCredentialSelect',
+): Promise<CredOption[]> {
+  const credSelect = frame.locator(selector);
+  if (await credSelect.count() === 0) return [];
+  return credSelect.evaluate(
+    (e) => Array.from((e as HTMLSelectElement).options)
+      .filter(o => o.value !== 'none' && o.value !== '')
+      .map(o => ({ value: o.value, text: o.text })),
+  );
+}
+
+/**
+ * Tumblebug/등록 credential 선택
+ * @param filterKeywords — 옵션 text에 포함될 키워드 (소문자 비교)
+ */
+export async function selectRegisteredCredential(
+  frame: Frame,
+  page: import('@playwright/test').Page,
+  tag: string,
+  filterKeywords: string[],
+  selector = '#targetCredentialSelect',
+): Promise<CredOption | null> {
+  const opts = await listCredentialOptions(frame, selector);
+  if (opts.length === 0) {
+    console.warn(`[${tag}] credential 옵션 없음`);
+    return null;
+  }
+
+  const lowered = filterKeywords.map(k => k.toLowerCase());
+  const matched = opts.filter(o =>
+    lowered.some(kw => o.text.toLowerCase().includes(kw)),
+  );
+  const pick = matched[0] ?? opts[0];
+  await frame.locator(selector).selectOption(pick.value);
+  await page.waitForTimeout(1500);
+  console.log(`[${tag}] credential 선택: ${pick.text} (${pick.value})`);
+  return pick;
+}

--- a/e2e/tc/infra/TC-INFRA-DEPLOY-06.spec.ts
+++ b/e2e/tc/infra/TC-INFRA-DEPLOY-06.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * deploy/tc/infra/TC-INFRA-DEPLOY-06.spec.ts
+ * TC-INFRA-DEPLOY-06: MCI 생성 Expert 모드 — 오류 상태 확인
+ *
+ * Expert 모드는 현재 UI에서 오류를 반환한다.
+ * Add MCI → Deployment Algorithm → 'expert' 선택 시 오류 메시지가 표시되는지 확인한다.
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/infra/TC-INFRA-DEPLOY-06.spec.ts
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }         from '../../shared/pages';
+import { loginAndGoto }  from '../../shared/request-auth.helper';
+import { StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID = 'TC-INFRA-DEPLOY-06';
+const ctx   = new StandaloneContext(TC_ID);
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-INFRA-DEPLOY-06: MCI 생성 Expert 모드 오류 확인', () => {
+
+  test('UI: Expert 모드 선택 시 오류 표시 확인', async ({ page }) => {
+    test.setTimeout(3 * 60_000);
+
+    const tag = TC_ID;
+
+    const ok = await loginAndGoto(page, PAGES.operations.mciWorkloads, tag);
+    if (!ok) { console.warn(`[${tag}] 로그인 실패 — 건너뜀`); return; }
+
+    // 워크스페이스 경고 모달
+    try {
+      await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 3_000 });
+      await page.click('#commonDefaultModal-confirm-btn');
+      await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 5_000 });
+    } catch {}
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+    await page.waitForTimeout(1_000);
+
+    // Add MCI 버튼
+    const addBtn = page.locator('#page-header-btn-list a[href="#addmci"], #page-header-btn-list a', {
+      hasText: /Add.*MCI|Add.*VM/i,
+    }).first();
+    try {
+      await addBtn.waitFor({ state: 'visible', timeout: 10_000 });
+      await addBtn.click();
+      await page.locator('#addmci, [id*="mci-create"], [id*="createMci"]').first()
+        .waitFor({ state: 'visible', timeout: 5_000 });
+    } catch {
+      console.warn(`[${tag}] Add MCI 버튼 없음 — 건너뜀`);
+      return;
+    }
+
+    // Deployment Algorithm 드롭다운에서 'expert' 선택
+    try {
+      const algoSel = page.locator('#mci_deploy_algorithm');
+      await algoSel.waitFor({ state: 'visible', timeout: 5_000 });
+      await algoSel.selectOption('expert');
+      await page.waitForTimeout(1_500);
+    } catch (e) {
+      console.warn(`[${tag}] Deployment Algorithm 드롭다운 없음 — ${(e as Error).message?.slice(0, 60)}`);
+      return;
+    }
+
+    // Expert 모드 선택 후 오류 메시지 또는 오류 상태 확인
+    const errorLocator = page.locator(
+      '.alert-danger, .alert-warning, [class*="error"], [class*="Error"], ' +
+      '.toast-error, #expertModeError, [id*="expert-error"], ' +
+      'div:has-text("not supported"), div:has-text("미지원"), ' +
+      'div:has-text("준비 중"), div:has-text("개발 중")'
+    ).first();
+
+    const hasError = await errorLocator.isVisible({ timeout: 5_000 }).catch(() => false);
+    if (hasError) {
+      const errText = await errorLocator.textContent().catch(() => '');
+      console.log(`[${tag}] Expert 모드 오류 확인 완료: "${errText?.trim().slice(0, 100)}"`);
+    } else {
+      // 오류 메시지가 안 보여도 expert 폼 상태 확인
+      const expertForm = page.locator('#expert_server_configuration');
+      const formVisible = await expertForm.isVisible({ timeout: 2_000 }).catch(() => false);
+      if (formVisible) {
+        // Expert 폼이 나타났으면 Deploy 시도 후 오류 확인
+        console.log(`[${tag}] Expert 폼 표시됨 — Deploy 시도`);
+        const deployBtn = page.locator(
+          '#expert_server_configuration button[onclick*="deploy"], button[onclick*="deployMci"]',
+          { hasText: /deploy/i }
+        ).first();
+        if (await deployBtn.isVisible({ timeout: 2_000 }).catch(() => false)) {
+          await deployBtn.click();
+          await page.waitForTimeout(2_000);
+          // Deploy 후 오류 확인
+          const postError = await errorLocator.isVisible({ timeout: 3_000 }).catch(() => false);
+          console.log(`[${tag}] Deploy 후 오류 발생: ${postError}`);
+          expect(postError, 'Expert 모드 Deploy 시 오류가 발생해야 함').toBe(true);
+        }
+      } else {
+        console.log(`[${tag}] Expert 모드 선택 후 상태 변화 없음 (버그 또는 미구현 상태)`);
+      }
+    }
+  });
+});

--- a/e2e/tc/infra/TC-INFRA-DEPLOY-07.spec.ts
+++ b/e2e/tc/infra/TC-INFRA-DEPLOY-07.spec.ts
@@ -1,0 +1,272 @@
+/**
+ * deploy/tc/infra/TC-INFRA-DEPLOY-07.spec.ts
+ * TC-INFRA-DEPLOY-07: MCI 서버 추가 (Add Server — Expert 모드)
+ *
+ * 기존 MCI를 선택한 후 MCI Info Default Tab의 Add Server 버튼을 클릭하고
+ * Deployment Algorithm을 'expert'로 전환한 뒤 + VM 버튼으로 VM 정보를 입력한다.
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/infra/TC-INFRA-DEPLOY-07.spec.ts
+ *   TC_VARIANT=gcp npx playwright test deploy/tc/infra/TC-INFRA-DEPLOY-07.spec.ts
+ *
+ * ── 시나리오 실행 ─────────────────────────────────────────────────
+ *   SCENARIO_ID=C4-001 TC_VARIANT=aws \
+ *     npx playwright test deploy/tc/infra/TC-INFRA-DEPLOY-07.spec.ts
+ *
+ * ── 런타임 IN params (시나리오 모드) ─────────────────────────────
+ *   store.require('mciId')   — TC-INFRA-DEPLOY-05 OUT
+ *   store.require('mciName') — TC-INFRA-DEPLOY-05 OUT
+ *
+ * ── 런타임 OUT params ─────────────────────────────────────────────
+ *   store.set('subGroupId',   추가된 SubGroup ID)
+ *   store.set('subGroupName', subGroupName)
+ */
+import { test } from '@playwright/test';
+import { PAGES }         from '../../shared/pages';
+import { loginAndGoto }  from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-INFRA-DEPLOY-07';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+let createdSubGroupId = '';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-INFRA-DEPLOY-07: MCI 서버 추가 (Expert 모드)', () => {
+
+  test('UI: Add Server → Expert 모드 → +VM → Deploy', async ({ page }) => {
+    test.setTimeout(8 * 60_000);
+
+    const nsId         = (p.nsId         as string) ?? 'default';
+    const subGroupName = (p.subGroupName as string) ?? 'sg-exp1';
+    const provider     = (p.provider     as string) ?? 'aws';
+    const region       = (p.region       as string) ?? 'ap-northeast-2';
+    const connName     = (p.connectionName as string) ?? 'aws-ap-northeast-2';
+    const specId       = (p.commonSpec   as string) ?? '';
+    const subGroupSize = (p.subGroupSize as string) ?? '1';
+    const tag          = TC_ID;
+
+    // 시나리오 모드: 이전 MCI 생성 결과 참조
+    let targetMciName = (p.mciName as string) ?? 'mci11';
+    if (store) {
+      try {
+        targetMciName = store.require<string>('mciName');
+      } catch { /* 시나리오에 따라 없을 수 있음 */ }
+    }
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'}`);
+    console.log(`[${TC_ID}] mciName=${targetMciName}, provider=${provider}, conn=${connName}`);
+
+    const ok = await loginAndGoto(page, PAGES.operations.mciWorkloads, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+
+    // 워크스페이스 경고 모달
+    try {
+      await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 3_000 });
+      await page.click('#commonDefaultModal-confirm-btn');
+      await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 5_000 });
+    } catch {}
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    // MCI 목록 로드
+    await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+    await page.waitForTimeout(1_500);
+
+    // 대상 MCI 행 선택
+    const mciRow = page.locator('#mcilist-table .tabulator-row').filter({ hasText: targetMciName }).first();
+    if (await mciRow.count().catch(() => 0) === 0) {
+      throw new Error(`[${tag}] MCI ${targetMciName} 목록에 없음`);
+    }
+    await mciRow.click();
+    await page.waitForTimeout(1_000);
+
+    // MCI Info Default Tab에서 Add Server 버튼
+    try {
+      // Default Tab 활성화 (이미 활성화되어 있는 경우 생략)
+      const defaultTab = page.locator(
+        '[data-bs-target*="default"], .nav-link:has-text("Default"), .nav-link:first-child'
+      ).first();
+      if (await defaultTab.isVisible({ timeout: 3_000 }).catch(() => false)) {
+        await defaultTab.click();
+        await page.waitForTimeout(500);
+      }
+    } catch {}
+
+    const addServerBtn = page.locator(
+      'button[onclick*="addServer"], button[onclick*="addSubGroup"], ' +
+      'a[onclick*="addServer"], a[onclick*="addSubGroup"], ' +
+      'button:has-text("Add Server"), a:has-text("Add Server")'
+    ).first();
+    try {
+      await addServerBtn.waitFor({ state: 'visible', timeout: 10_000 });
+      await addServerBtn.click();
+      await page.waitForTimeout(800);
+    } catch {
+      throw new Error(`[${tag}] Add Server 버튼 없음`);
+    }
+
+    // Deployment Algorithm → Expert 선택
+    try {
+      const algoSel = page.locator('#mci_deploy_algorithm, [id*="deploy_algorithm"]').first();
+      await algoSel.waitFor({ state: 'visible', timeout: 5_000 });
+      await algoSel.selectOption('expert');
+      await page.waitForTimeout(800);
+      console.log(`[${tag}] Expert 모드 전환`);
+    } catch (e) {
+      throw new Error(`[${tag}] Deployment Algorithm 선택 실패 — ${(e as Error).message?.slice(0, 60)}`);
+    }
+
+    // + VM 버튼 클릭 (Expert 폼에서 VM 추가 행)
+    try {
+      const addVmBtn = page.locator(
+        'button[onclick*="addVm"], button[onclick*="addVM"], ' +
+        'button:has-text("+ VM"), button:has-text("+VM"), ' +
+        'a:has-text("+ VM"), a:has-text("Add VM")'
+      ).first();
+      await addVmBtn.waitFor({ state: 'visible', timeout: 5_000 });
+      await addVmBtn.click();
+      await page.waitForTimeout(800);
+      console.log(`[${tag}] + VM 버튼 클릭`);
+    } catch (e) {
+      throw new Error(`[${tag}] + VM 버튼 없음 — ${(e as Error).message?.slice(0, 60)}`);
+    }
+
+    // SubGroup 이름 입력
+    await page.fill('[id*="subgroup_name"], [id*="sg_name"], [name*="subGroupName"]', subGroupName)
+      .catch(() => {});
+
+    // Provider 선택
+    try {
+      const provSel = page.locator('[id*="vm_provider"], [id*="expert"][id*="provider"]').first();
+      if (await provSel.isVisible({ timeout: 3_000 }).catch(() => false)) {
+        const provOpt = await provSel.locator('option')
+          .filter({ hasText: new RegExp(provider, 'i') }).first().getAttribute('value');
+        await provSel.selectOption(provOpt ?? provider);
+        await page.waitForTimeout(800);
+      }
+    } catch { console.warn(`[${tag}] Provider 선택 실패`); }
+
+    // Region 선택
+    try {
+      const regionSel = page.locator('[id*="vm_region"], [id*="expert"][id*="region"]').first();
+      if (await regionSel.isVisible({ timeout: 5_000 }).catch(() => false)) {
+        await page.waitForFunction((reg: string) => {
+          const sel = document.querySelector('[id*="vm_region"], [id*="expert"][id*="region"]') as HTMLSelectElement;
+          return sel && Array.from(sel.options).some(o =>
+            o.value.toLowerCase().includes(reg.toLowerCase()) ||
+            o.text.toLowerCase().includes(reg.toLowerCase()));
+        }, region, { timeout: 8_000 }).catch(() => {});
+        const regionOpt = await regionSel.locator('option')
+          .filter({ hasText: new RegExp(region, 'i') }).first().getAttribute('value');
+        await regionSel.selectOption(regionOpt ?? region).catch(() => {});
+        await page.waitForTimeout(800);
+      }
+    } catch { console.warn(`[${tag}] Region 선택 실패`); }
+
+    // Connection 선택
+    if (connName) {
+      try {
+        const connSel = page.locator('[id*="vm_connection"], [id*="expert"][id*="connection"]').first();
+        if (await connSel.isVisible({ timeout: 5_000 }).catch(() => false)) {
+          await page.waitForFunction((conn: string) => {
+            const sel = document.querySelector('[id*="vm_connection"], [id*="expert"][id*="connection"]') as HTMLSelectElement;
+            return sel && Array.from(sel.options).some(o =>
+              o.value.toLowerCase().includes(conn.toLowerCase()) ||
+              o.text.toLowerCase().includes(conn.toLowerCase()));
+          }, connName, { timeout: 8_000 }).catch(() => {});
+          const connOpt = await connSel.locator('option')
+            .filter({ hasText: new RegExp(connName, 'i') }).first().getAttribute('value');
+          await connSel.selectOption(connOpt ?? connName).catch(() => {});
+          await page.waitForTimeout(800);
+        }
+      } catch { console.warn(`[${tag}] Connection 선택 실패`); }
+    }
+
+    // Spec 검색 모달 (Expert 폼 내부)
+    try {
+      const specBtn = page.locator('[data-bs-target*="spec-search"], [onclick*="spec-search"]').first();
+      if (await specBtn.isVisible({ timeout: 3_000 }).catch(() => false)) {
+        await specBtn.click();
+        const specModal = page.locator('[id*="spec-search"]').first();
+        await specModal.waitFor({ state: 'visible', timeout: 5_000 });
+        await page.locator('[id*="spec-search"] a[onclick*="getRecommend"]').first().click();
+        await page.locator('[id*="spec-search"] .tabulator-row:not(.tabulator-placeholder)').first()
+          .waitFor({ timeout: 30_000 });
+        const cspSpecName = specId.split('+').pop() ?? '';
+        await page.evaluate(
+          ({ specName }: { specName: string }) => {
+            const t = (window as unknown as {
+              recommendTable?: {
+                getData: () => Array<Record<string, unknown>>;
+                deselectRow: () => void;
+                getRows: () => Array<{ select: () => void }>;
+              };
+            }).recommendTable;
+            if (!t) return;
+            const rows = t.getData();
+            let idx = rows.findIndex(r =>
+              ((r['cspSpecName'] as string) ?? '').toLowerCase().includes(specName.toLowerCase())
+            );
+            if (idx < 0) idx = 0;
+            t.deselectRow();
+            t.getRows()[idx]?.select();
+          },
+          { specName: cspSpecName },
+        );
+        await page.waitForTimeout(400);
+        await page.locator('[id*="spec-search"] button[onclick*="applySpec"]').first().click();
+        await specModal.waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
+      }
+    } catch (e) {
+      console.warn(`[${tag}] Spec 선택 실패 — ${(e as Error).message?.slice(0, 60)}`);
+    }
+
+    // Subgroup 수량
+    await page.fill('[id*="subgroup_size"], [name*="subGroupSize"]', subGroupSize).catch(() => {});
+
+    // Deploy
+    page.on('dialog', async d => { await d.accept(); });
+    try {
+      const deployBtn = page.locator(
+        'button[onclick*="deployAddServer"], button[onclick*="addSubGroup"], ' +
+        'button[onclick*="deploySubGroup"], button',
+        { hasText: /deploy/i }
+      ).first();
+      await deployBtn.waitFor({ state: 'visible', timeout: 5_000 });
+      await deployBtn.click();
+    } catch {
+      throw new Error(`[${tag}] Deploy 버튼 없음`);
+    }
+
+    await page.waitForTimeout(3_000);
+    createdSubGroupId = subGroupName;
+    console.log(`[${tag}] Add Server Expert 완료: subGroup=${subGroupName}`);
+  });
+
+  test.afterAll(() => {
+    if (!store) return;
+    const subGroupName = (p.subGroupName as string) ?? 'sg-exp1';
+    store.set('subGroupId',   createdSubGroupId);
+    store.set('subGroupName', subGroupName);
+    console.log(`[${TC_ID}] store OUT: subGroupId=${createdSubGroupId}, subGroupName=${subGroupName}`);
+  });
+});

--- a/e2e/tc/infra/TC-INFRA-K8S-03.spec.ts
+++ b/e2e/tc/infra/TC-INFRA-K8S-03.spec.ts
@@ -1,0 +1,200 @@
+/**
+ * deploy/tc/infra/TC-INFRA-K8S-03.spec.ts
+ * TC-INFRA-K8S-03: K8s 클러스터(PMK) 생성 — 브라우저 UI 테스트
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/infra/TC-INFRA-K8S-03.spec.ts
+ *   TC_VARIANT=tencent npx playwright test deploy/tc/infra/TC-INFRA-K8S-03.spec.ts
+ *   TC_VARIANT=ncp     npx playwright test deploy/tc/infra/TC-INFRA-K8S-03.spec.ts
+ *
+ * ── 시나리오 실행 (런타임 store OUT param 저장) ────────────────────
+ *   SCENARIO_ID=C3-k8s-per-csp TC_VARIANT=tencent \
+ *     npx playwright test deploy/tc/infra/TC-INFRA-K8S-03.spec.ts
+ *
+ * ── 런타임 OUT params (시나리오 모드) ─────────────────────────────
+ *   store.set('k8sId',   생성된 K8s 클러스터 ID or clusterName)
+ *   store.set('k8sName', clusterName)
+ *   store.set('nsId',    nsId)
+ */
+import { test } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-INFRA-K8S-03';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+let createdK8sId = '';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-INFRA-K8S-03: K8s 클러스터 생성', () => {
+
+  test('UI: K8s 클러스터 생성 (PMK workloads → Add Cluster → Deploy)', async ({ page }) => {
+    test.setTimeout(10 * 60_000);
+
+    const nsId        = (p.nsId         as string) ?? 'default';
+    const clusterName = (p.clusterName  as string) ?? 'pmk1';
+    const ngName      = (p.nodeGroupName as string) ?? 'png1';
+    const connName    = (p.connectionName as string) ?? '';
+    const specId      = (p.commonSpec   as string) ?? (p.specId as string) ?? '';
+    const tag         = TC_ID;
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'}`);
+    console.log(`[${TC_ID}] clusterName=${clusterName}, conn=${connName}, spec=${specId}`);
+
+    const ok = await loginAndGoto(page, PAGES.operations.pmkWorkloads, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+
+    // 워크스페이스 경고 모달
+    try {
+      await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 3_000 });
+      await page.click('#commonDefaultModal-confirm-btn');
+      await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 5_000 });
+    } catch {}
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    // 목록 로드 대기
+    await page.locator('#pmklist-table, #k8slist-table, table').first().waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+    await page.waitForTimeout(1_500);
+
+    // 이미 존재 확인
+    const existRow = page.locator('#pmklist-table .tabulator-row, #k8slist-table .tabulator-row').filter({ hasText: clusterName });
+    if (await existRow.count().catch(() => 0) > 0) {
+      await existRow.first().click();
+      await page.waitForTimeout(500);
+      createdK8sId = await page.evaluate(() =>
+        (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentPmkId ??
+        (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentK8sId ?? ''
+      ) as string;
+      if (!createdK8sId) createdK8sId = clusterName;
+      console.log(`[${tag}] K8s 재사용: ${clusterName} (${createdK8sId})`);
+      return;
+    }
+
+    // Add Cluster 버튼
+    const addBtn = page.locator('#page-header-btn-list a[href="#createcluster"], #page-header-btn-list a', {
+      hasText: /Add.*Cluster|Add.*PMK/i,
+    }).first();
+    try {
+      await addBtn.waitFor({ state: 'visible', timeout: 10_000 });
+      await addBtn.click();
+      await page.locator('#createcluster').waitFor({ state: 'visible', timeout: 5_000 });
+    } catch {
+      console.warn(`[${tag}] Add Cluster 버튼 없음 — 건너뜀`);
+      return;
+    }
+
+    // 폼 입력
+    await page.fill('#cluster_name_dynamic', clusterName).catch(() => {});
+    await page.fill('#cluster_desc_dynamic', `${TC_ID} E2E 테스트 (variant: ${variant ?? 'base'})`).catch(() => {});
+    await page.fill('#nodegroup_name_dynamic', ngName).catch(() => {});
+
+    // Connection 선택
+    if (connName) {
+      try {
+        await page.waitForFunction((conn: string) => {
+          const sel = document.querySelector('#cluster_cloudconnection_dynamic') as HTMLSelectElement;
+          return sel && Array.from(sel.options).some(o =>
+            o.value.toLowerCase().includes(conn.toLowerCase()) ||
+            o.text.toLowerCase().includes(conn.toLowerCase()));
+        }, connName, { timeout: 10_000 });
+        const connOpt = await page.locator('#cluster_cloudconnection_dynamic option')
+          .filter({ hasText: new RegExp(connName, 'i') }).first().getAttribute('value');
+        await page.locator('#cluster_cloudconnection_dynamic').selectOption(connOpt ?? connName);
+        await page.waitForTimeout(1_000);
+      } catch { console.warn(`[${tag}] Connection ${connName} 선택 실패`); }
+    }
+
+    // Spec 검색 모달
+    try {
+      const specBtn = page.locator('[data-bs-target="#spec-search-pmk"], [onclick*="spec-search-pmk"]').first();
+      await specBtn.waitFor({ state: 'visible', timeout: 5_000 });
+      await specBtn.click();
+      await page.locator('#spec-search-pmk').waitFor({ state: 'visible', timeout: 5_000 });
+      await page.locator('#spec-search-pmk a[onclick*="getRecommendVmInfoPmk"], #spec-search-pmk a[onclick*="getRecommendVmInfo"]').first().click();
+      await page.locator('#spec-search-pmk .tabulator-row:not(.tabulator-placeholder)').first().waitFor({ timeout: 30_000 });
+      const cspSpecName = specId.split('+').pop() ?? '';
+      await page.evaluate(
+        ({ specName }: { specName: string }) => {
+          const t = (window as unknown as {
+            recommendTablePmk?: {
+              getData: () => Array<Record<string, unknown>>;
+              deselectRow: () => void;
+              getRows: () => Array<{ select: () => void }>;
+            };
+          }).recommendTablePmk;
+          if (!t) return;
+          const rows = t.getData();
+          let idx = rows.findIndex(r =>
+            ((r['cspSpecName'] as string) ?? '').toLowerCase().includes(specName.toLowerCase())
+          );
+          if (idx < 0) idx = 0;
+          t.deselectRow();
+          t.getRows()[idx]?.select();
+        },
+        { specName: cspSpecName },
+      );
+      await page.waitForTimeout(400);
+      await page.locator('#spec-search-pmk button[onclick*="applySpecInfo"]').click();
+      await page.locator('#spec-search-pmk').waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
+    } catch (e) {
+      console.warn(`[${tag}] PMK Spec 선택 실패 — ${(e as Error).message?.slice(0, 60)}`);
+    }
+
+    // Deploy
+    page.on('dialog', async d => { await d.accept(); });
+    try {
+      await page.locator('button[onclick*="deployPmkDynamic"], button', { hasText: /deploy/i }).first().click();
+    } catch {
+      console.warn(`[${tag}] PMK Deploy 버튼 없음 — 건너뜀`);
+      return;
+    }
+
+    await page.waitForNavigation({ waitUntil: 'networkidle', timeout: 60_000 }).catch(() => null);
+    await page.waitForTimeout(2_000);
+
+    // 목록에서 K8s 확인
+    const newRow = page.locator('#pmklist-table .tabulator-row, #k8slist-table .tabulator-row').filter({ hasText: clusterName });
+    if (await newRow.count().catch(() => 0) > 0) {
+      await newRow.first().click();
+      await page.waitForTimeout(500);
+      createdK8sId = await page.evaluate(() =>
+        (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentPmkId ??
+        (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentK8sId ?? ''
+      ) as string;
+      if (!createdK8sId) createdK8sId = clusterName;
+      console.log(`[${tag}] K8s 생성 완료: ${clusterName} (${createdK8sId})`);
+    } else {
+      console.warn(`[${tag}] ${clusterName} 목록 미표시`);
+    }
+  });
+
+  test.afterAll(() => {
+    if (!store) return;
+    const clusterName = (p.clusterName as string) ?? 'pmk1';
+    const nsId        = (p.nsId        as string) ?? 'default';
+    store.set('k8sId',   createdK8sId);
+    store.set('k8sName', clusterName);
+    store.set('nsId',    nsId);
+    console.log(`[${TC_ID}] store OUT: k8sId=${createdK8sId}, k8sName=${clusterName}, nsId=${nsId}`);
+  });
+});

--- a/e2e/tc/infra/TC-INFRA-K8S-04.spec.ts
+++ b/e2e/tc/infra/TC-INFRA-K8S-04.spec.ts
@@ -1,0 +1,254 @@
+/**
+ * deploy/tc/infra/TC-INFRA-K8S-04.spec.ts
+ * TC-INFRA-K8S-04: PMK 클러스터 생성 (Expert 모드) — 브라우저 UI 테스트
+ *
+ * Dynamic 모드(TC-INFRA-K8S-03)와 달리 toggleExpertCreation() 버튼으로
+ * #create_expert 폼으로 전환한 뒤 Provider / Region 드롭다운을 별도 지정한다.
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/infra/TC-INFRA-K8S-04.spec.ts
+ *   TC_VARIANT=tencent npx playwright test deploy/tc/infra/TC-INFRA-K8S-04.spec.ts
+ *   TC_VARIANT=ncp     npx playwright test deploy/tc/infra/TC-INFRA-K8S-04.spec.ts
+ *
+ * ── 시나리오 실행 ─────────────────────────────────────────────────
+ *   SCENARIO_ID=C3-k8s-per-csp TC_VARIANT=tencent \
+ *     npx playwright test deploy/tc/infra/TC-INFRA-K8S-04.spec.ts
+ *
+ * ── 런타임 OUT params ─────────────────────────────────────────────
+ *   store.set('k8sId',   생성된 K8s 클러스터 ID)
+ *   store.set('k8sName', clusterName)
+ *   store.set('nsId',    nsId)
+ */
+import { test } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-INFRA-K8S-04';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+let createdK8sId = '';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-INFRA-K8S-04: PMK 클러스터 생성 (Expert 모드)', () => {
+
+  test('UI: Expert 모드 PMK 생성 (toggleExpertCreation → Provider·Region·Connection 지정 → Deploy)', async ({ page }) => {
+    test.setTimeout(10 * 60_000);
+
+    const nsId        = (p.nsId         as string) ?? 'default';
+    const clusterName = (p.clusterName  as string) ?? 'pmk-exp1';
+    const ngName      = (p.nodeGroupName as string) ?? 'png-exp1';
+    const provider    = (p.provider     as string) ?? 'tencent';
+    const region      = (p.region       as string) ?? 'ap-tokyo';
+    const connName    = (p.connectionName as string) ?? 'tencent-ap-tokyo';
+    const specId      = (p.commonSpec   as string) ?? '';
+    const tag         = TC_ID;
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'}`);
+    console.log(`[${TC_ID}] clusterName=${clusterName}, provider=${provider}, region=${region}`);
+
+    const ok = await loginAndGoto(page, PAGES.operations.pmkWorkloads, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+
+    // 워크스페이스 경고 모달
+    try {
+      await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 3_000 });
+      await page.click('#commonDefaultModal-confirm-btn');
+      await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 5_000 });
+    } catch {}
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    // 목록 로드 대기
+    await page.locator('#pmklist-table, #k8slist-table, table').first().waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+    await page.waitForTimeout(1_500);
+
+    // 이미 존재 확인
+    const existRow = page.locator('#pmklist-table .tabulator-row, #k8slist-table .tabulator-row').filter({ hasText: clusterName });
+    if (await existRow.count().catch(() => 0) > 0) {
+      await existRow.first().click();
+      await page.waitForTimeout(500);
+      createdK8sId = await page.evaluate(() =>
+        (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentPmkId ??
+        (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentK8sId ?? ''
+      ) as string;
+      if (!createdK8sId) createdK8sId = clusterName;
+      console.log(`[${tag}] K8s 재사용: ${clusterName} (${createdK8sId})`);
+      return;
+    }
+
+    // Add Cluster 버튼 (Dynamic 폼 열기)
+    const addBtn = page.locator('#page-header-btn-list a[href="#createcluster"], #page-header-btn-list a', {
+      hasText: /Add.*Cluster|Add.*PMK/i,
+    }).first();
+    try {
+      await addBtn.waitFor({ state: 'visible', timeout: 10_000 });
+      await addBtn.click();
+      await page.locator('#createcluster').waitFor({ state: 'visible', timeout: 5_000 });
+    } catch {
+      throw new Error(`[${tag}] Add Cluster 버튼 없음`);
+    }
+
+    // ── Expert 모드 전환 ────────────────────────────────────────────
+    try {
+      // toggleExpertCreation() 을 호출하는 버튼 탐색
+      const expertBtn = page.locator(
+        'button[onclick*="toggleExpert"], a[onclick*="toggleExpert"], button:has-text("Expert"), a:has-text("Expert Creation")'
+      ).first();
+      await expertBtn.waitFor({ state: 'visible', timeout: 5_000 });
+      await expertBtn.click();
+      await page.locator('#create_expert').waitFor({ state: 'visible', timeout: 5_000 });
+      console.log(`[${tag}] Expert 모드 전환 완료`);
+    } catch (e) {
+      throw new Error(`[${tag}] Expert 모드 전환 실패 — ${(e as Error).message?.slice(0, 80)}`);
+    }
+
+    // ── Expert 폼 입력 ──────────────────────────────────────────────
+    // 클러스터 이름 / NodeGroup 이름
+    await page.fill('#cluster_name_expert, [id*="cluster"][id*="name"][id*="expert"]', clusterName).catch(() => {});
+    await page.fill('#nodegroup_name_expert, [id*="nodegroup"][id*="name"][id*="expert"]', ngName).catch(() => {});
+
+    // Provider 선택
+    try {
+      const provSel = page.locator('#cluster_provider_expert, [id*="expert"][id*="provider"]').first();
+      await provSel.waitFor({ state: 'visible', timeout: 5_000 });
+      const provOpt = await provSel.locator('option')
+        .filter({ hasText: new RegExp(provider, 'i') }).first().getAttribute('value');
+      await provSel.selectOption(provOpt ?? provider);
+      await page.waitForTimeout(800);
+    } catch { console.warn(`[${tag}] Provider 선택 실패`); }
+
+    // Region 선택 (Provider 선택 후 동적 로드)
+    try {
+      const regionSel = page.locator('#cluster_region_expert, [id*="expert"][id*="region"]').first();
+      await regionSel.waitFor({ state: 'visible', timeout: 8_000 });
+      await page.waitForFunction((reg: string) => {
+        const sel = document.querySelector('#cluster_region_expert, [id*="expert"][id*="region"]') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o =>
+          o.value.toLowerCase().includes(reg.toLowerCase()) ||
+          o.text.toLowerCase().includes(reg.toLowerCase()));
+      }, region, { timeout: 10_000 });
+      const regionOpt = await regionSel.locator('option')
+        .filter({ hasText: new RegExp(region, 'i') }).first().getAttribute('value');
+      await regionSel.selectOption(regionOpt ?? region);
+      await page.waitForTimeout(800);
+    } catch { console.warn(`[${tag}] Region 선택 실패`); }
+
+    // Connection 선택
+    if (connName) {
+      try {
+        await page.waitForFunction((conn: string) => {
+          const sel = document.querySelector('#cluster_cloudconnection_expert, [id*="expert"][id*="connection"]') as HTMLSelectElement;
+          return sel && Array.from(sel.options).some(o =>
+            o.value.toLowerCase().includes(conn.toLowerCase()) ||
+            o.text.toLowerCase().includes(conn.toLowerCase()));
+        }, connName, { timeout: 10_000 });
+        const connSel = page.locator('#cluster_cloudconnection_expert, [id*="expert"][id*="connection"]').first();
+        const connOpt = await connSel.locator('option')
+          .filter({ hasText: new RegExp(connName, 'i') }).first().getAttribute('value');
+        await connSel.selectOption(connOpt ?? connName);
+        await page.waitForTimeout(800);
+      } catch { console.warn(`[${tag}] Connection ${connName} 선택 실패`); }
+    }
+
+    // Spec 검색 모달 (Expert 폼 내부)
+    try {
+      const specBtn = page.locator('#create_expert [data-bs-target*="spec-search-pmk"], #create_expert [onclick*="spec-search-pmk"]').first();
+      await specBtn.waitFor({ state: 'visible', timeout: 5_000 });
+      await specBtn.click();
+      await page.locator('#spec-search-pmk').waitFor({ state: 'visible', timeout: 5_000 });
+      await page.locator('#spec-search-pmk a[onclick*="getRecommendVmInfoPmk"], #spec-search-pmk a[onclick*="getRecommendVmInfo"]').first().click();
+      await page.locator('#spec-search-pmk .tabulator-row:not(.tabulator-placeholder)').first().waitFor({ timeout: 30_000 });
+      const cspSpecName = specId.split('+').pop() ?? '';
+      await page.evaluate(
+        ({ specName }: { specName: string }) => {
+          const t = (window as unknown as {
+            recommendTablePmk?: {
+              getData: () => Array<Record<string, unknown>>;
+              deselectRow: () => void;
+              getRows: () => Array<{ select: () => void }>;
+            };
+          }).recommendTablePmk;
+          if (!t) return;
+          const rows = t.getData();
+          let idx = rows.findIndex(r =>
+            ((r['cspSpecName'] as string) ?? '').toLowerCase().includes(specName.toLowerCase())
+          );
+          if (idx < 0) idx = 0;
+          t.deselectRow();
+          t.getRows()[idx]?.select();
+        },
+        { specName: cspSpecName },
+      );
+      await page.waitForTimeout(400);
+      await page.locator('#spec-search-pmk button[onclick*="applySpecInfo"]').click();
+      await page.locator('#spec-search-pmk').waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
+    } catch (e) {
+      console.warn(`[${tag}] PMK Spec 선택 실패 (Expert) — ${(e as Error).message?.slice(0, 60)}`);
+    }
+
+    // Deploy (Expert 폼)
+    page.on('dialog', async d => { await d.accept(); });
+    try {
+      const deployBtn = page.locator(
+        '#create_expert button[onclick*="deployPmk"], #create_expert button',
+        { hasText: /deploy/i }
+      ).first();
+      await deployBtn.waitFor({ state: 'visible', timeout: 5_000 });
+      await deployBtn.click();
+    } catch {
+      // fallback
+      try {
+        await page.locator('button[onclick*="deployPmkExpert"], button[onclick*="deployPmk"]').first().click();
+      } catch {
+        throw new Error(`[${tag}] PMK Deploy 버튼 없음 (Expert)`);
+      }
+    }
+
+    await page.waitForNavigation({ waitUntil: 'networkidle', timeout: 60_000 }).catch(() => null);
+    await page.waitForTimeout(2_000);
+
+    // 목록 확인
+    const newRow = page.locator('#pmklist-table .tabulator-row, #k8slist-table .tabulator-row').filter({ hasText: clusterName });
+    if (await newRow.count().catch(() => 0) > 0) {
+      await newRow.first().click();
+      await page.waitForTimeout(500);
+      createdK8sId = await page.evaluate(() =>
+        (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentPmkId ??
+        (window as unknown as { currentPmkId?: string; currentK8sId?: string }).currentK8sId ?? ''
+      ) as string;
+      if (!createdK8sId) createdK8sId = clusterName;
+      console.log(`[${tag}] PMK Expert 생성 완료: ${clusterName} (${createdK8sId})`);
+    } else {
+      console.warn(`[${tag}] ${clusterName} 목록 미표시`);
+    }
+  });
+
+  test.afterAll(() => {
+    if (!store) return;
+    const clusterName = (p.clusterName as string) ?? 'pmk-exp1';
+    const nsId        = (p.nsId        as string) ?? 'default';
+    store.set('k8sId',   createdK8sId);
+    store.set('k8sName', clusterName);
+    store.set('nsId',    nsId);
+    console.log(`[${TC_ID}] store OUT: k8sId=${createdK8sId}, k8sName=${clusterName}, nsId=${nsId}`);
+  });
+});

--- a/e2e/tc/infra/TC-INFRA-K8S-05.spec.ts
+++ b/e2e/tc/infra/TC-INFRA-K8S-05.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * deploy/tc/infra/TC-INFRA-K8S-05.spec.ts
+ * TC-INFRA-K8S-05: PMK KubeConfig 획득 — 브라우저 UI 테스트
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/infra/TC-INFRA-K8S-05.spec.ts
+ *   TC_VARIANT=aws npx playwright test deploy/tc/infra/TC-INFRA-K8S-05.spec.ts
+ *   TC_VARIANT=ibm npx playwright test deploy/tc/infra/TC-INFRA-K8S-05.spec.ts
+ *
+ * ── 시나리오 실행 ─────────────────────────────────────────────────
+ *   SCENARIO_ID=C7-k8s-per-csp TC_VARIANT=aws \
+ *     npx playwright test deploy/tc/infra/TC-INFRA-K8S-05.spec.ts
+ *
+ * ── 런타임 IN params ──────────────────────────────────────────────
+ *   store.require('k8sId')   — TC-INFRA-K8S-03 OUT
+ *   store.require('k8sName') — TC-INFRA-K8S-03 OUT
+ *
+ * ── 런타임 OUT params ─────────────────────────────────────────────
+ *   store.set('kubeconfig', kubeconfig 내용)
+ */
+import { test } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-INFRA-K8S-05';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+let copiedKubeconfig = '';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-INFRA-K8S-05: PMK KubeConfig 획득', () => {
+
+  test('UI: KubeConfig 클립보드 복사 (클러스터 선택 → KubeConfig 탭 → 복사)', async ({ page }) => {
+    test.setTimeout(5 * 60_000);
+
+    const tag = TC_ID;
+    let targetK8sName = '';
+
+    if (store) {
+      targetK8sName = store.require<string>('k8sName');
+      console.log(`[${tag}] store IN: k8sName=${targetK8sName}`);
+    } else {
+      targetK8sName = (p.clusterName as string) ?? 'pmk1';
+      console.log(`[${tag}] 단독 실행 — clusterName=${targetK8sName} (variant: ${variant ?? 'base'})`);
+    }
+
+    const ok = await loginAndGoto(page, PAGES.operations.pmkWorkloads, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+
+    // 워크스페이스 경고 모달
+    try {
+      await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 3_000 });
+      await page.click('#commonDefaultModal-confirm-btn');
+      await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 5_000 });
+    } catch {}
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option')
+        .filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option')
+        .filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    // 클러스터 목록 로드
+    await page.locator('#pmklist-table, #k8slist-table, table').first()
+      .waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+    await page.waitForTimeout(1_500);
+
+    // 클러스터 행 선택
+    const clusterRow = page.locator('#pmklist-table .tabulator-row, #k8slist-table .tabulator-row')
+      .filter({ hasText: targetK8sName }).first();
+    if (await clusterRow.count().catch(() => 0) === 0) {
+      throw new Error(`[${tag}] 클러스터 ${targetK8sName} 목록에 없음`);
+    }
+    await clusterRow.click();
+    await page.waitForTimeout(800);
+
+    // KubeConfig 탭 이동
+    try {
+      const kubeconfigTab = page.locator(
+        'a[href*="kubeconfig"], a[data-bs-target*="kubeconfig"], .nav-link:has-text("KubeConfig"), .nav-link:has-text("kubeconfig")'
+      ).first();
+      await kubeconfigTab.waitFor({ state: 'visible', timeout: 8_000 });
+      await kubeconfigTab.click();
+      await page.waitForTimeout(1_000);
+    } catch {
+      throw new Error(`[${tag}] KubeConfig 탭 미발견`);
+    }
+
+    // KubeConfig 복사 버튼 클릭
+    try {
+      // 클립보드 권한 허용 (headless 모드)
+      await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+
+      const copyBtn = page.locator(
+        'button[onclick*="kubeconfig"], button[onclick*="KubeConfig"], button:has-text("Copy"), button:has-text("클립보드")'
+      ).first();
+      await copyBtn.waitFor({ state: 'visible', timeout: 5_000 });
+      await copyBtn.click();
+      await page.waitForTimeout(500);
+
+      // 클립보드에서 kubeconfig 읽기
+      copiedKubeconfig = await page.evaluate(() => navigator.clipboard.readText()).catch(() => '');
+      if (copiedKubeconfig) {
+        console.log(`[${tag}] KubeConfig 복사 완료 (${copiedKubeconfig.length} bytes)`);
+      } else {
+        // textarea에서 직접 읽기 시도
+        const textarea = page.locator('textarea').filter({ hasText: /apiVersion.*kubeconfig/i }).first();
+        if (await textarea.count().catch(() => 0) > 0) {
+          copiedKubeconfig = await textarea.inputValue().catch(() => '');
+          console.log(`[${tag}] KubeConfig textarea 읽기 (${copiedKubeconfig.length} bytes)`);
+        }
+      }
+    } catch (e) {
+      throw new Error(`[${tag}] KubeConfig 복사 실패 — ${(e as Error).message?.slice(0, 80)}`);
+    }
+  });
+
+  test.afterAll(() => {
+    if (!store) return;
+    store.set('kubeconfig', copiedKubeconfig);
+    console.log(`[${TC_ID}] store OUT: kubeconfig (${copiedKubeconfig.length} bytes)`);
+  });
+});

--- a/e2e/tc/infra/TC-INFRA-K8S-07.spec.ts
+++ b/e2e/tc/infra/TC-INFRA-K8S-07.spec.ts
@@ -1,0 +1,156 @@
+/**
+ * deploy/tc/infra/TC-INFRA-K8S-07.spec.ts
+ * TC-INFRA-K8S-07: PMK NodeGroup 삭제 — 브라우저 UI 테스트
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/infra/TC-INFRA-K8S-07.spec.ts
+ *   TC_VARIANT=tencent npx playwright test deploy/tc/infra/TC-INFRA-K8S-07.spec.ts
+ *
+ * ── 시나리오 실행 ─────────────────────────────────────────────────
+ *   SCENARIO_ID=C3-k8s-per-csp TC_VARIANT=tencent \
+ *     npx playwright test deploy/tc/infra/TC-INFRA-K8S-07.spec.ts
+ *
+ * ── 런타임 IN params ──────────────────────────────────────────────
+ *   store.require('k8sId')   — TC-INFRA-K8S-03 OUT
+ *   store.require('k8sName') — TC-INFRA-K8S-03 OUT
+ *   p.nodeGroupName          — 삭제할 NodeGroup 이름 (기본: 'png1')
+ *   p.minNodeGroupRequired   — true: CSP가 최소 1 NodeGroup 필요
+ *                              → 이 TC를 건너뛰고 PMK 삭제(K8S-08)로 일괄 처리
+ */
+import { test } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-INFRA-K8S-07';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-INFRA-K8S-07: PMK NodeGroup 삭제', () => {
+
+  test('UI: PMK NodeGroup 삭제 (클러스터 선택 → NodeGroup 탭 → 삭제)', async ({ page }) => {
+    test.setTimeout(5 * 60_000);
+
+    const tag     = TC_ID;
+    const ngName  = (p.nodeGroupName       as string)  ?? 'png1';
+    const minNgRequired = !!(p.minNodeGroupRequired);
+
+    let targetK8sId   = '';
+    let targetK8sName = '';
+
+    if (store) {
+      // CSP가 최소 1 NodeGroup을 요구하는 경우 FAIL
+      if (minNgRequired) {
+        throw new Error(`[${tag}] minNodeGroupRequired=true — NodeGroup 개별 삭제 불가`);
+      }
+      targetK8sId   = store.require<string>('k8sId');
+      targetK8sName = store.require<string>('k8sName');
+      console.log(`[${tag}] store IN: k8sId=${targetK8sId}, k8sName=${targetK8sName}, ngName=${ngName}`);
+    } else {
+      targetK8sName = (p.clusterName as string) ?? 'pmk1';
+      targetK8sId   = targetK8sName;
+      if (minNgRequired) {
+        console.log(`[${tag}] minNodeGroupRequired=true → 건너뜀`);
+        return;
+      }
+      console.log(`[${tag}] 단독 실행 — clusterName=${targetK8sName}, ngName=${ngName}`);
+    }
+
+    const ok = await loginAndGoto(page, PAGES.operations.pmkWorkloads, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+
+    // 워크스페이스 경고 모달
+    try {
+      await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 3_000 });
+      await page.click('#commonDefaultModal-confirm-btn');
+      await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 5_000 });
+    } catch {}
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option')
+        .filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option')
+        .filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    // 클러스터 목록 로드
+    await page.locator('#pmklist-table, #k8slist-table, table').first()
+      .waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+    await page.waitForTimeout(1_500);
+
+    // 페이지 크기 최대로 확장 (페이지네이션 우회)
+    await page.evaluate(() => {
+      const sel = document.querySelector('#pmklist-table .tabulator-page-size, #k8slist-table .tabulator-page-size') as HTMLSelectElement | null;
+      if (!sel) return;
+      const max = Math.max(...Array.from(sel.options).map(o => Number(o.value) || 0));
+      if (max > 0 && sel.value !== String(max)) { sel.value = String(max); sel.dispatchEvent(new Event('change')); }
+    }).catch(() => {});
+    await page.waitForTimeout(800);
+
+    // 클러스터 행 선택
+    const clusterRow = page.locator('#pmklist-table .tabulator-row, #k8slist-table .tabulator-row')
+      .filter({ hasText: targetK8sName }).first();
+    if (await clusterRow.count().catch(() => 0) === 0) {
+      throw new Error(`[${tag}] 클러스터 ${targetK8sName} 목록에 없음`);
+    }
+    await clusterRow.click();
+    await page.waitForTimeout(800);
+
+    // NodeGroup 탭 이동
+    try {
+      const ngTab = page.locator(
+        'a[href*="nodegroup"], a[data-bs-target*="nodegroup"], .nav-link:has-text("NodeGroup"), .nav-link:has-text("Node Group")'
+      ).first();
+      await ngTab.waitFor({ state: 'visible', timeout: 8_000 });
+      await ngTab.click();
+      await page.waitForTimeout(1_000);
+    } catch {
+      throw new Error(`[${tag}] NodeGroup 탭 미발견`);
+    }
+
+    // NodeGroup 행 찾기
+    const ngRow = page.locator('.tabulator-row, tr').filter({ hasText: ngName }).first();
+    if (await ngRow.count().catch(() => 0) === 0) {
+      throw new Error(`[${tag}] NodeGroup ${ngName} 없음`);
+    }
+    await ngRow.click();
+    await page.waitForTimeout(400);
+
+    // 삭제 액션
+    try {
+      // 드롭다운 액션 버튼 또는 개별 삭제 버튼
+      const dropdownBtn = page.locator('a.btn-action:has(svg.icon-tabler-chevron-down)').first();
+      const hasDropdown = await dropdownBtn.isVisible({ timeout: 2_000 }).catch(() => false);
+      if (hasDropdown) {
+        await dropdownBtn.click();
+        const deleteItem = page.locator('a.dropdown-item').filter({ hasText: /delete|삭제/i }).first();
+        await deleteItem.waitFor({ state: 'visible', timeout: 3_000 });
+        await deleteItem.click();
+      } else {
+        await page.locator('button, a').filter({ hasText: /delete.*nodegroup|nodegroup.*delete|노드그룹.*삭제/i })
+          .first().click();
+      }
+      await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 5_000 });
+      await page.click('#commonDefaultModal-confirm-btn');
+      await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 10_000 });
+      console.log(`[${tag}] NodeGroup 삭제 완료: ${ngName}`);
+    } catch (e) {
+      throw new Error(`[${tag}] NodeGroup 삭제 버튼 실패 — ${(e as Error).message?.slice(0, 80)}`);
+    }
+  });
+});

--- a/e2e/tc/infra/TC-INFRA-K8S-08.spec.ts
+++ b/e2e/tc/infra/TC-INFRA-K8S-08.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * deploy/tc/infra/TC-INFRA-K8S-08.spec.ts
+ * TC-INFRA-K8S-08: PMK(K8s 클러스터) 삭제 — 브라우저 UI 테스트
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/infra/TC-INFRA-K8S-08.spec.ts
+ *   TC_VARIANT=tencent npx playwright test deploy/tc/infra/TC-INFRA-K8S-08.spec.ts
+ *
+ * ── 시나리오 실행 ─────────────────────────────────────────────────
+ *   SCENARIO_ID=C3-k8s-per-csp TC_VARIANT=tencent \
+ *     npx playwright test deploy/tc/infra/TC-INFRA-K8S-08.spec.ts
+ *
+ * ── 런타임 IN params ──────────────────────────────────────────────
+ *   store.require('k8sId')   — TC-INFRA-K8S-03 OUT
+ *   store.require('k8sName') — TC-INFRA-K8S-03 OUT
+ *
+ * ── CSP 최소 NodeGroup 제약 처리 ─────────────────────────────────
+ *   일부 CSP는 클러스터에 NodeGroup 최소 1개를 요구한다.
+ *   이 경우 TC-INFRA-K8S-07 이 FAIL 처리되며, 이 TC에서 클러스터를
+ *   삭제하면 NodeGroup도 함께 제거된다.
+ */
+import { test } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-INFRA-K8S-08';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-INFRA-K8S-08: PMK 클러스터 삭제', () => {
+
+  test('UI: PMK 클러스터 삭제 (목록 → 선택 → 삭제)', async ({ page }) => {
+    test.setTimeout(5 * 60_000);
+
+    const tag = TC_ID;
+
+    let targetK8sId   = '';
+    let targetK8sName = '';
+
+    if (store) {
+      targetK8sId   = store.require<string>('k8sId');
+      targetK8sName = store.require<string>('k8sName');
+      console.log(`[${tag}] store IN: k8sId=${targetK8sId}, k8sName=${targetK8sName}`);
+    } else {
+      targetK8sName = (p.clusterName as string) ?? 'pmk1';
+      targetK8sId   = targetK8sName;
+      console.log(`[${tag}] 단독 실행 — clusterName=${targetK8sName}`);
+    }
+
+    const ok = await loginAndGoto(page, PAGES.operations.pmkWorkloads, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+
+    // 워크스페이스 경고 모달
+    try {
+      await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 3_000 });
+      await page.click('#commonDefaultModal-confirm-btn');
+      await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 5_000 });
+    } catch {}
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option')
+        .filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option')
+        .filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    // 클러스터 목록 로드
+    await page.locator('#pmklist-table, #k8slist-table, table').first()
+      .waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+    await page.waitForTimeout(1_500);
+
+    // 페이지 크기 최대로 확장 (페이지네이션 우회)
+    await page.evaluate(() => {
+      const sel = document.querySelector('#pmklist-table .tabulator-page-size, #k8slist-table .tabulator-page-size') as HTMLSelectElement | null;
+      if (!sel) return;
+      const max = Math.max(...Array.from(sel.options).map(o => Number(o.value) || 0));
+      if (max > 0 && sel.value !== String(max)) { sel.value = String(max); sel.dispatchEvent(new Event('change')); }
+    }).catch(() => {});
+    await page.waitForTimeout(800);
+
+    // 클러스터 행 찾기
+    const clusterRow = page.locator('#pmklist-table .tabulator-row, #k8slist-table .tabulator-row')
+      .filter({ hasText: targetK8sName }).first();
+    if (await clusterRow.count().catch(() => 0) === 0) {
+      throw new Error(`[${tag}] 클러스터 ${targetK8sName} 목록에 없음`);
+    }
+    await clusterRow.click();
+    await page.waitForTimeout(500);
+
+    // 삭제 액션 (드롭다운 또는 단독 버튼)
+    try {
+      const dropdownBtn = page.locator('a.btn-action:has(svg.icon-tabler-chevron-down)').first();
+      const hasDropdown = await dropdownBtn.isVisible({ timeout: 2_000 }).catch(() => false);
+      if (hasDropdown) {
+        await dropdownBtn.click();
+        // onclick 속성에 'PmkDelete' 포함 (텍스트는 'Delete')
+        const deleteItem = page.locator('a.dropdown-item[onclick*="PmkDelete"]').first();
+        await deleteItem.waitFor({ state: 'visible', timeout: 3_000 });
+        await deleteItem.click();
+      } else {
+        await page.locator('a[onclick*="PmkDelete"], button[onclick*="PmkDelete"]').first().click();
+      }
+      await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 5_000 });
+      await page.click('#commonDefaultModal-confirm-btn');
+      await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 10_000 });
+      console.log(`[${tag}] PMK 클러스터 삭제 완료: ${targetK8sName}`);
+    } catch (e) {
+      throw new Error(`[${tag}] 클러스터 삭제 버튼 실패 — ${(e as Error).message?.slice(0, 80)}`);
+    }
+  });
+});

--- a/e2e/tc/infra/TC-INFRA-LC-03.spec.ts
+++ b/e2e/tc/infra/TC-INFRA-LC-03.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * deploy/tc/infra/TC-INFRA-LC-03.spec.ts
+ * TC-INFRA-LC-03: mc* 로 시작하는 MCI 일괄 삭제 (case 분류 포함)
+ *
+ * ── case 정의 ─────────────────────────────────────────────────────
+ *   case1 : MCI만 존재, Total Servers = 0  (nodegroup 없음)
+ *   case2 : Total Servers = 1              (nodegroup 1개)
+ *   case3 : Total Servers ≥ 2             (nodegroup 2개 이상)
+ *   해당 case에 MCI가 없으면 SKIP 표시
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/infra/TC-INFRA-LC-03.spec.ts
+ *
+ * ── 시나리오 실행 ─────────────────────────────────────────────────
+ *   SCENARIO_ID=C3-mci-cleanup npx playwright test deploy/tc/infra/TC-INFRA-LC-03.spec.ts
+ */
+import { test, expect, type Page } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-INFRA-LC-03';
+const scenarioId = process.env.SCENARIO_ID;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID)
+  : new StandaloneContext(TC_ID);
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// ── 헬퍼: 워크스페이스 모달 닫기 ───────────────────────────────────────
+async function dismissModal(page: Page) {
+  try {
+    await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 3_000 });
+    await page.click('#commonDefaultModal-confirm-btn');
+    await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 5_000 });
+  } catch {}
+}
+
+// ── 헬퍼: ws01/default 선택 ────────────────────────────────────────
+async function selectWsProj(page: Page) {
+  try {
+    await page.waitForFunction(() => {
+      const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+      return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+    }, { timeout: 15_000 });
+    const wsVal = await page.locator('#select-current-workspace option')
+      .filter({ hasText: /ws01/i }).first().getAttribute('value');
+    await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+    const projVal = await page.locator('#select-current-project option')
+      .filter({ hasText: /default/i }).first().getAttribute('value');
+    await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+  } catch {}
+}
+
+// ── 헬퍼: 테이블 페이지 크기 최대 확장 ────────────────────────────────
+async function expandPageSize(page: Page) {
+  await page.evaluate(() => {
+    const sel = document.querySelector('#mcilist-table .tabulator-page-size') as HTMLSelectElement | null;
+    if (!sel) return;
+    const max = Math.max(...Array.from(sel.options).map(o => Number(o.value) || 0));
+    if (max > 0 && sel.value !== String(max)) { sel.value = String(max); sel.dispatchEvent(new Event('change')); }
+  }).catch(() => {});
+  await page.waitForTimeout(800);
+}
+
+// ── 헬퍼: MCI 목록 스캔 → mc* 필터 후 case 분류 ───────────────────────
+interface MciInfo { name: string; totalServers: number; }
+
+async function scanMcMcis(page: Page): Promise<MciInfo[]> {
+  await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+  await page.waitForTimeout(1_500);
+  await expandPageSize(page);
+
+  return (await page.evaluate(() => {
+    const headerEls = Array.from(document.querySelectorAll('#mcilist-table .tabulator-col'));
+    const colTitle  = (el: Element) =>
+      (el.querySelector('.tabulator-col-title') as HTMLElement)?.innerText?.trim() ?? '';
+    const nameIdx  = headerEls.findIndex(h => colTitle(h) === 'Name');
+    const totalIdx = headerEls.findIndex(h => colTitle(h) === 'Total Servers');
+
+    const rows = Array.from(
+      document.querySelectorAll('#mcilist-table .tabulator-row:not(.tabulator-placeholder)')
+    );
+    return rows.map(row => {
+      const cells = Array.from(row.querySelectorAll('.tabulator-cell'));
+      const name  = (cells[nameIdx]  as HTMLElement)?.innerText?.trim() || '';
+      const total = parseInt((cells[totalIdx] as HTMLElement)?.innerText?.trim() || '0', 10) || 0;
+      return { name, totalServers: total };
+    }).filter(r => r.name.startsWith('mc'));
+  })) as unknown as MciInfo[];
+}
+
+// ── 헬퍼: MCI 1개 삭제 ─────────────────────────────────────────────
+async function deleteMci(page: Page, mciName: string): Promise<boolean> {
+  await expandPageSize(page);
+
+  const row = page.locator('#mcilist-table .tabulator-row').filter({ hasText: mciName }).first();
+  if (await row.count().catch(() => 0) === 0) {
+    console.warn(`[${TC_ID}] ${mciName} 행 없음 — skip`);
+    return false;
+  }
+  await row.click();
+  await page.waitForTimeout(500);
+
+  try {
+    await page.locator('a.btn-action:has(svg.icon-tabler-chevron-down)').first().click();
+    await page.locator('a.dropdown-item[onclick*="MciDelete"]').first()
+      .waitFor({ state: 'visible', timeout: 3_000 });
+    await page.locator('a.dropdown-item[onclick*="MciDelete"]').first().click();
+    await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 5_000 });
+    await page.click('#commonDefaultModal-confirm-btn');
+    await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 10_000 });
+    console.log(`[${TC_ID}] 삭제 요청 완료: ${mciName}`);
+    await page.waitForTimeout(1_500);
+    return true;
+  } catch (e) {
+    console.warn(`[${TC_ID}] ${mciName} 삭제 실패 — ${(e as Error).message?.slice(0, 80)}`);
+    return false;
+  }
+}
+
+// ── 테스트 ─────────────────────────────────────────────────────────
+test.describe('TC-INFRA-LC-03: mc* MCI 일괄 삭제 (case 분류)', () => {
+
+  test('UI: mc*로 시작하는 MCI 스캔 → case1/2/3 분류 → 전체 삭제', async ({ page }) => {
+    test.setTimeout(20 * 60_000);
+
+    const ok = await loginAndGoto(page, PAGES.operations.mciWorkloads, TC_ID);
+    if (!ok) { throw new Error(`[${TC_ID}] 로그인 실패`); }
+
+    await dismissModal(page);
+    await selectWsProj(page);
+    // 워크스페이스 변경 후 추가 modal 대기·닫기
+    await page.waitForTimeout(1_500);
+    await dismissModal(page);
+
+    // ── 1단계: 스캔 ────────────────────────────────────────────────
+    const mcMcis = await scanMcMcis(page);
+
+    const case1 = mcMcis.filter(m => m.totalServers === 0);
+    const case2 = mcMcis.filter(m => m.totalServers === 1);
+    const case3 = mcMcis.filter(m => m.totalServers >= 2);
+
+    console.log(`[${TC_ID}] === mc* MCI 스캔 결과 ===`);
+    console.log(`[${TC_ID}] case1 (nodegroup 없음,  0개): ${case1.length === 0 ? 'SKIP' : case1.map(m => `${m.name}(${m.totalServers})`).join(', ')}`);
+    console.log(`[${TC_ID}] case2 (nodegroup 1개,  1 VM): ${case2.length === 0 ? 'SKIP' : case2.map(m => `${m.name}(${m.totalServers})`).join(', ')}`);
+    console.log(`[${TC_ID}] case3 (nodegroup 2개+, ≥2VM): ${case3.length === 0 ? 'SKIP' : case3.map(m => `${m.name}(${m.totalServers})`).join(', ')}`);
+    console.log(`[${TC_ID}] 총 삭제 대상: ${mcMcis.length}개`);
+
+    if (mcMcis.length === 0) {
+      console.log(`[${TC_ID}] mc*로 시작하는 MCI 없음 — 전체 SKIP`);
+      return;
+    }
+
+    // ── 2단계: 전체 삭제 ─────────────────────────────────────────
+    let deleted = 0;
+    for (const mci of mcMcis) {
+      const caseLabel = mci.totalServers === 0 ? 'case1' : mci.totalServers === 1 ? 'case2' : 'case3';
+      console.log(`[${TC_ID}] [${caseLabel}] 삭제 시작: ${mci.name} (Total Servers: ${mci.totalServers})`);
+      await dismissModal(page);
+      const success = await deleteMci(page, mci.name);
+      if (success) deleted++;
+    }
+
+    // ── 3단계: 잔류 확인 ─────────────────────────────────────────
+    await dismissModal(page);
+    await selectWsProj(page);
+    const remaining = await scanMcMcis(page);
+    console.log(`[${TC_ID}] 삭제 완료: ${deleted}/${mcMcis.length}, 잔류: ${remaining.length}개`);
+
+    if (remaining.length > 0) {
+      console.warn(`[${TC_ID}] 잔류 MCI: ${remaining.map(m => m.name).join(', ')}`);
+    }
+
+    // 잔류가 있어도 테스트는 통과 (비동기 삭제는 서버에서 진행 중)
+    expect(deleted).toBeGreaterThan(0);
+  });
+});

--- a/e2e/tc/infra/TC-INFRA-MCI-03.spec.ts
+++ b/e2e/tc/infra/TC-INFRA-MCI-03.spec.ts
@@ -1,0 +1,267 @@
+/**
+ * deploy/tc/infra/TC-INFRA-MCI-03.spec.ts
+ * TC-INFRA-MCI-03: MCI 생성 — 브라우저 UI 테스트
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/infra/TC-INFRA-MCI-03.spec.ts
+ *   TC_VARIANT=azure npx playwright test deploy/tc/infra/TC-INFRA-MCI-03.spec.ts
+ *
+ * ── 시나리오 실행 (런타임 store OUT param 저장) ────────────────────
+ *   SCENARIO_ID=C4-001 TC_VARIANT=aws \
+ *     npx playwright test deploy/tc/infra/TC-INFRA-MCI-03.spec.ts
+ *
+ * ── 런타임 OUT params (시나리오 모드) ─────────────────────────────
+ *   store.set('mciId',   생성된 MCI ID or mciName)
+ *   store.set('mciName', mciName)
+ *   store.set('nsId',    nsId)
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }         from '../../shared/pages';
+import { loginAndGoto }  from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-INFRA-DEPLOY-05';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+let createdMciId = '';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-INFRA-DEPLOY-05: MCI 생성', () => {
+
+  test('UI: MCI 생성 마법사 → Deploy → 목록 확인', async ({ page }) => {
+    test.setTimeout(8 * 60_000);
+
+    const nsId    = (p.nsId    as string) ?? 'default';
+    const mciName = (p.mciName as string) ?? 'tc-mci-temp';
+    const vmName  = (p.vmName  as string) ?? `${mciName}-vm-0`;
+    const specId  = (p.commonSpec as string) ?? '';
+    const connName = (p.connectionName as string) ?? 'aws-ap-northeast-2';
+    const tag     = TC_ID;
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'}`);
+    console.log(`[${TC_ID}] mciName=${mciName}, conn=${connName}, spec=${specId}`);
+
+    const ok = await loginAndGoto(page, PAGES.operations.mciWorkloads, tag);
+    if (!ok) { throw new Error(`[${tag}] 로그인 실패`); }
+
+    // 워크스페이스 경고 모달
+    try {
+      await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 3_000 });
+      await page.click('#commonDefaultModal-confirm-btn');
+      await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 5_000 });
+    } catch {}
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-project') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.toLowerCase().includes('default'));
+      }, { timeout: 15_000 });
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 15_000 });
+    await page.waitForTimeout(1_500);
+
+    // 이미 존재 확인
+    const existRow = page.locator('#mcilist-table .tabulator-row').filter({ hasText: mciName });
+    if (await existRow.count().catch(() => 0) > 0) {
+      await existRow.first().click();
+      await page.waitForTimeout(500);
+      createdMciId = await page.evaluate(() =>
+        (window as unknown as { currentMciId?: string }).currentMciId ?? '') as string;
+      if (!createdMciId) createdMciId = mciName;
+      console.log(`[${tag}] MCI 재사용: ${mciName} (${createdMciId})`);
+      return;
+    }
+
+    // Add Mci 버튼
+    const addBtn = page.locator('#page-header-btn-list a', { hasText: 'Add Mci' });
+    try {
+      await addBtn.waitFor({ state: 'visible', timeout: 10_000 });
+    } catch {
+      console.warn(`[${tag}] Add Mci 버튼 없음 — 건너뜀`);
+      return;
+    }
+    await page.evaluate(() => {
+      const modal = document.querySelector('#commonDefaultModal') as HTMLElement | null;
+      if (modal?.classList.contains('show')) {
+        modal.classList.remove('show');
+        modal.style.display = 'none';
+        document.querySelectorAll('.modal-backdrop').forEach(b => b.remove());
+        document.body.classList.remove('modal-open');
+        document.body.style.removeProperty('overflow');
+      }
+    });
+    await addBtn.click();
+    await page.locator('#mcicreate').waitFor({ state: 'visible', timeout: 5_000 });
+
+    await page.fill('#mci_name', mciName);
+    await page.fill('#mci_desc', `${TC_ID} E2E 테스트 (variant: ${variant ?? 'base'})`);
+    await page.click('#mci_plusVmIcon');
+    await page.locator('#server_configuration').waitFor({ state: 'visible', timeout: 5_000 });
+    await page.fill('#ep_name', vmName);
+
+    // Spec 검색 모달
+    await page.click('#server_configuration [data-bs-target="#spec-search"]');
+    await page.locator('#spec-search').first().waitFor({ state: 'visible', timeout: 5_000 });
+    await page.locator('#spec-search a[onclick*="getRecommendVmInfo"]').first().click();
+    try {
+      await page.locator('#spec-table .tabulator-row:not(.tabulator-placeholder)').first().waitFor({ timeout: 30_000 });
+      // specId 기반 행 선택 (없으면 첫 번째)
+      const cspSpecName = specId.split('+').pop() ?? '';
+      await page.evaluate(
+        ({ specName }: { specName: string }) => {
+          const t = (window as unknown as {
+            recommendTable?: {
+              getData: () => Array<Record<string, unknown>>;
+              deselectRow: () => void;
+              getRows: () => Array<{ select: () => void }>;
+            };
+          }).recommendTable;
+          if (!t) return;
+          const rows = t.getData();
+          let idx = rows.findIndex(r =>
+            ((r['cspSpecName'] as string) ?? '').toLowerCase().includes(specName.toLowerCase())
+          );
+          if (idx < 0) idx = 0;
+          t.deselectRow();
+          t.getRows()[idx]?.select();
+        },
+        { specName: cspSpecName },
+      );
+      await page.waitForTimeout(400);
+      await page.locator('#spec-search button[onclick*="applySpecInfo"]').first().click();
+      await page.locator('#spec-search').first().waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
+    } catch {
+      console.warn(`[${tag}] Spec 선택 실패 — 건너뜀`);
+      return;
+    }
+
+    // Image 검색 모달
+    try {
+      await page.click('#server_configuration [onclick*="validateAndOpenImageModal"]');
+      await page.locator('#image-search').first().waitFor({ state: 'visible', timeout: 5_000 });
+      try {
+        await page.locator('#image-search [onclick*="toggleOSDropdown"]').click();
+        await page.waitForTimeout(300);
+        await page.locator('#image-search a[onclick*="ubuntu 22.04"]').first().click();
+      } catch {}
+      await page.locator('#image-search a[onclick*="getRecommendImageInfo"]').first().click();
+      await page.locator('#image-table .tabulator-row:not(.tabulator-placeholder)').first().waitFor({ timeout: 30_000 });
+      await page.locator('#image-table .tabulator-row').first().click();
+      await page.waitForTimeout(400);
+      await page.locator('#image-search button[onclick*="applyImageInfo"]').first().click();
+      await page.locator('#image-search').first().waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
+    } catch { console.warn(`[${tag}] Image 선택 실패 — 진행 계속`); }
+
+    await page.click('button[onclick*="expressDone_btn"]');
+    await page.waitForTimeout(1_000);
+
+    await page.route('**/PostInfraDynamicReview', async route => {
+      await route.fulfill({
+        status: 200, contentType: 'application/json',
+        body: JSON.stringify({
+          responseData: { overallStatus: 'Ready', creationViable: true, infraName: mciName,
+            overallMessage: 'bypass review', nodeReviews: [], vmReviews: [], resourceSummary: {} },
+          status: { code: 200, message: 'OK' },
+        }),
+      });
+    });
+    page.on('dialog', async d => { await d.accept(); });
+
+    const navPromise = page.waitForNavigation({ waitUntil: 'networkidle', timeout: 60_000 }).catch(() => null);
+    try {
+      await page.click('button[onclick*="deployMci"]');
+    } catch {
+      console.warn(`[${tag}] Deploy 버튼 없음 — 건너뜀`);
+      return;
+    }
+    await navPromise;
+    await page.waitForTimeout(2_000);
+
+    // 배포 후 목록 확인 (creating / running / failed 모두 유효)
+    // 최대 6회 reload 재시도 (~60s). 미표시 시 배포 실패 처리한다.
+    let found = false;
+    for (let attempt = 0; attempt <= 5; attempt++) {
+      // 워크스페이스 모달 처리
+      try {
+        await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 2_000 });
+        await page.click('#commonDefaultModal-confirm-btn');
+        await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 5_000 });
+      } catch {}
+      // 워크스페이스/프로젝트 재선택
+      try {
+        await page.waitForFunction(() => {
+          const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+          return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+        }, { timeout: 10_000 });
+        const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+        await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+        await page.waitForFunction(() => {
+          const sel = document.querySelector('#select-current-project') as HTMLSelectElement;
+          return sel && Array.from(sel.options).some(o => o.text.toLowerCase().includes('default'));
+        }, { timeout: 10_000 });
+        const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+        await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+      } catch {}
+      await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 10_000 }).catch(() => {});
+      await page.waitForTimeout(2_000);
+
+      // 테이블 페이지 크기를 최대로 늘려 전체 행 검색 가능하게 함 (기본 5행 페이지네이션 우회)
+      await page.evaluate(() => {
+        const sel = document.querySelector('#mcilist-table .tabulator-page-size') as HTMLSelectElement | null;
+        if (!sel) return;
+        const max = Math.max(...Array.from(sel.options).map(o => Number(o.value) || 0));
+        if (max > 0 && sel.value !== String(max)) {
+          sel.value = String(max);
+          sel.dispatchEvent(new Event('change'));
+        }
+      }).catch(() => {});
+      await page.waitForTimeout(800);
+
+      const newRow = page.locator('#mcilist-table .tabulator-row').filter({ hasText: mciName });
+      if (await newRow.count().catch(() => 0) > 0) {
+        await newRow.first().click();
+        await page.waitForTimeout(500);
+        createdMciId = await page.evaluate(() =>
+          (window as unknown as { currentMciId?: string }).currentMciId ?? '') as string;
+        if (!createdMciId) createdMciId = mciName;
+        console.log(`[${tag}] MCI 생성 확인: ${mciName} (${createdMciId}) — attempt ${attempt + 1}`);
+        found = true;
+        break;
+      }
+      console.log(`[${tag}] MCI ${mciName} 미표시 (attempt ${attempt + 1}/6) — 재시도`);
+      if (attempt < 5) {
+        await page.reload({ waitUntil: 'networkidle', timeout: 30_000 }).catch(() => null);
+      }
+    }
+    expect(found, `MCI ${mciName} 배포 후 목록 미표시 — 배포 실패`).toBe(true);
+    expect(createdMciId, 'MCI ID 없음').toBeTruthy();
+  });
+
+  test.afterAll(() => {
+    if (!store) return;
+    const mciName = (p.mciName as string) ?? 'tc-mci-temp';
+    const nsId    = (p.nsId    as string) ?? 'default';
+    store.set('mciId',   createdMciId);
+    store.set('mciName', mciName);
+    store.set('nsId',    nsId);
+    console.log(`[${TC_ID}] store OUT: mciId=${createdMciId}, mciName=${mciName}, nsId=${nsId}`);
+  });
+});

--- a/e2e/tc/infra/TC-INFRA-MCI-05.spec.ts
+++ b/e2e/tc/infra/TC-INFRA-MCI-05.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * deploy/tc/infra/TC-INFRA-MCI-05.spec.ts
+ * TC-INFRA-MCI-05: MCI 삭제 — 브라우저 UI 테스트
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/infra/TC-INFRA-MCI-05.spec.ts
+ *
+ * ── 시나리오 실행 ─────────────────────────────────────────────────
+ *   SCENARIO_ID=C4-001 npx playwright test deploy/tc/infra/TC-INFRA-MCI-05.spec.ts
+ *
+ * ── 런타임 IN params ──────────────────────────────────────────────
+ *   store.require('mciId')  — TC-INFRA-DEPLOY-05 OUT
+ */
+import { test } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-INFRA-LC-02';
+const scenarioId = process.env.SCENARIO_ID;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID)
+  : new StandaloneContext(TC_ID);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-INFRA-LC-02: MCI 삭제', () => {
+
+  test('UI: MCI 삭제 (목록 → 선택 → 삭제)', async ({ page }) => {
+    test.setTimeout(3 * 60_000);
+
+    // IN param 읽기
+    let targetMciId = '';
+    const mciName   = (p.mciName as string) ?? 'tc-mci-temp';
+
+    if (store) {
+      targetMciId = store.require<string>('mciId');
+      console.log(`[${TC_ID}] store IN: mciId=${targetMciId}`);
+    } else {
+      // 단독 실행: mciName으로 찾음
+      targetMciId = mciName;
+      console.log(`[${TC_ID}] 단독 실행 — mciName: ${mciName}`);
+    }
+
+    const ok = await loginAndGoto(page, PAGES.operations.mciWorkloads, TC_ID);
+    if (!ok) { throw new Error(`[${TC_ID}] 로그인 실패`); }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    await page.locator('#mcilist-table').waitFor({ state: 'visible', timeout: 15_000 }).catch(() => {});
+    await page.waitForTimeout(1_500);
+
+    const mciRow = page.locator('#mcilist-table .tabulator-row').filter({ hasText: targetMciId }).first();
+    if (await mciRow.count().catch(() => 0) === 0) {
+      console.warn(`[${TC_ID}] MCI ${targetMciId} 목록에 없음 — 건너뜀`);
+      return;
+    }
+    await mciRow.click();
+    await page.waitForTimeout(500);
+
+    try {
+      await page.locator('a.btn-action:has(svg.icon-tabler-chevron-down)').click();
+      await page.locator('a.dropdown-item[onclick*="MciDelete"]').waitFor({ state: 'visible', timeout: 3_000 });
+      await page.locator('a.dropdown-item[onclick*="MciDelete"]').click();
+      await page.locator('#commonDefaultModal').waitFor({ state: 'visible', timeout: 5_000 });
+      await page.click('#commonDefaultModal-confirm-btn');
+      await page.locator('#commonDefaultModal').waitFor({ state: 'hidden', timeout: 10_000 });
+      console.log(`[${TC_ID}] MCI 삭제 완료: ${targetMciId}`);
+    } catch (e) {
+      console.warn(`[${TC_ID}] 삭제 버튼 클릭 실패 — ${(e as Error).message?.slice(0, 80)}`);
+    }
+  });
+});

--- a/e2e/tc/sw/TC-APP-APPS-01.spec.ts
+++ b/e2e/tc/sw/TC-APP-APPS-01.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * deploy/tc/sw/TC-APP-APPS-01.spec.ts
+ * TC-APP-APPS-01: 배포 상태 목록 갱신 (Refresh)
+ */
+import { test, expect } from '@playwright/test';
+import { API_ROUTES } from '../../shared/api-routes';
+import { PAGES } from '../../shared/pages';
+import { apiLoginBearer, loginAndGoto } from '../../shared/request-auth.helper';
+import { gotoSwIframeTab } from '../../shared/sw-iframe.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-APP-APPS-01';
+const scenarioId = process.env.SCENARIO_ID;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID)
+  : new StandaloneContext(TC_ID);
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-APPS-01: 배포 상태 목록 갱신 (Refresh)', () => {
+
+  test('API: Apps Status 목록 조회', async ({ request }) => {
+    const auth = await apiLoginBearer(request);
+    const res  = await request.get(API_ROUTES.sw.listAppsStatus, { headers: auth });
+    if (!res.ok()) {
+      console.warn(`[TC-APP-APPS-01] listAppsStatus ${res.status()} — TODO: Apps API 경로 discovery 필요`);
+      return;
+    }
+    const body = await res.json() as { code?: number; data?: unknown };
+    expect(body).toBeDefined();
+    console.log(`[TC-APP-APPS-01] Apps 목록: ${JSON.stringify(body).slice(0, 200)}`);
+  });
+
+  test('UI: Apps Status 탭 진입 → 목록 확인 → Refresh → 목록 갱신', async ({ page }) => {
+    const ok = await loginAndGoto(page, PAGES.sw.appsStatus, TC_ID);
+    if (!ok) return;
+
+    const frame = await gotoSwIframeTab(page, /apps?\s*status|appsStatus/i, TC_ID);
+    if (!frame) return;
+
+    // [1] 목록 표시 확인
+    const rows = frame.locator('table tbody tr, .tabulator-row, [class*="app-item"], [class*="status-item"]');
+    await page.waitForTimeout(1000);
+    const countBefore = await rows.count();
+    console.log(`[TC-APP-APPS-01][1] 초기 Apps 목록 수: ${countBefore}`);
+
+    if (countBefore === 0) {
+      const emptyEl = frame.locator('[class*="empty"], [class*="no-data"]').first();
+      console.log(`[TC-APP-APPS-01][1] 빈 목록: ${await emptyEl.isVisible().catch(() => false) ? '표시' : 'warn-TODO'}`);
+    }
+
+    // [2] Refresh 버튼 클릭
+    const refreshBtn = frame
+      .locator('button').filter({ hasText: /refresh|갱신|새로고침/i }).first()
+      .or(frame.locator('[class*="refresh"], button[aria-label*="refresh" i]').first());
+
+    if (await refreshBtn.count() === 0) {
+      console.warn('[TC-APP-APPS-01][2] Refresh 버튼 미발견 — discovery 필요');
+      return;
+    }
+
+    let refreshCalled = false;
+    page.on('response', res => {
+      if (res.url().includes('/apps') && res.request().method() === 'GET') refreshCalled = true;
+    });
+
+    await refreshBtn.click();
+    await page.waitForTimeout(1500);
+    console.log(`[TC-APP-APPS-01][2] Refresh 클릭 — API 재호출: ${refreshCalled ? '확인' : 'warn-TODO(미캡처)'}`);
+
+    const countAfter = await rows.count();
+    console.log(`[TC-APP-APPS-01][3] Refresh 후 목록 수: ${countAfter} (전: ${countBefore})`);
+
+    expect(page.url()).toMatch(/\/webconsole\//);
+  });
+});

--- a/e2e/tc/sw/TC-APP-APPS-02.spec.ts
+++ b/e2e/tc/sw/TC-APP-APPS-02.spec.ts
@@ -1,0 +1,85 @@
+/**
+ * deploy/tc/sw/TC-APP-APPS-02.spec.ts
+ * TC-APP-APPS-02: 배포 상세 조회
+ */
+import { test, expect } from '@playwright/test';
+import { API_ROUTES } from '../../shared/api-routes';
+import { PAGES } from '../../shared/pages';
+import { apiLoginBearer, loginAndGoto } from '../../shared/request-auth.helper';
+import { gotoSwIframeTab } from '../../shared/sw-iframe.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-APP-APPS-02';
+const scenarioId = process.env.SCENARIO_ID;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID)
+  : new StandaloneContext(TC_ID);
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-APPS-02: 배포 상세 조회', () => {
+
+  test('API: Apps 상세 조회 (목록 첫 번째 기준)', async ({ request }) => {
+    const auth = await apiLoginBearer(request);
+
+    const listRes = await request.get(API_ROUTES.sw.listAppsStatus, { headers: auth });
+    if (!listRes.ok()) {
+      console.warn(`[TC-APP-APPS-02] listAppsStatus ${listRes.status()} — discovery 필요`);
+      return;
+    }
+
+    const listBody = await listRes.json() as { code?: number; data?: Array<{ id?: string | number; name?: string }> };
+    const items = Array.isArray(listBody.data) ? listBody.data : [];
+    if (items.length === 0) {
+      console.warn('[TC-APP-APPS-02] 배포된 App 없음 — 사전 배포 필요');
+      return;
+    }
+
+    const firstId = items[0]?.id;
+    const detailRes = await request.get(`${API_ROUTES.sw.getAppsDetail}/${firstId}`, { headers: auth });
+    if (!detailRes.ok()) {
+      console.warn(`[TC-APP-APPS-02] getAppsDetail/${firstId} ${detailRes.status()} — discovery 필요`);
+      return;
+    }
+
+    const detail = await detailRes.json() as { code?: number; data?: unknown };
+    expect(detail.data).toBeDefined();
+    console.log(`[TC-APP-APPS-02] 상세 데이터: ${JSON.stringify(detail.data).slice(0, 200)}`);
+  });
+
+  test('UI: Apps Status 탭 → 항목 클릭 → 상세 화면 확인', async ({ page }) => {
+    const ok = await loginAndGoto(page, PAGES.sw.appsStatus, TC_ID);
+    if (!ok) return;
+
+    const frame = await gotoSwIframeTab(page, /apps?\s*status|appsStatus/i, TC_ID);
+    if (!frame) return;
+
+    // [1] 목록 첫 번째 항목 확인
+    const firstRow = frame.locator('table tbody tr, .tabulator-row, [class*="app-item"]').first();
+    if (await firstRow.count() === 0) {
+      console.warn('[TC-APP-APPS-02][1] 배포된 App 없음 — 사전 배포 필요');
+      return;
+    }
+
+    const itemName = ((await firstRow.textContent().catch(() => '')) ?? '').trim().slice(0, 40);
+    console.log(`[TC-APP-APPS-02][1] 선택할 App: '${itemName}'`);
+
+    // 상세 진입: Detail 버튼 → 행 클릭
+    const detailTrigger = firstRow.locator('a, button').filter({ hasText: /detail|상세|보기/i }).first();
+    if (await detailTrigger.count() > 0) {
+      await detailTrigger.click();
+    } else {
+      await firstRow.click().catch(() => null);
+    }
+
+    await page.waitForTimeout(1000);
+
+    // [2] 상세 화면 표시 확인
+    const detailContainer = frame.locator('[class*="detail"], [class*="modal"], [role="dialog"]').first();
+    const hasDetail = await detailContainer.count() > 0;
+    console.log(`[TC-APP-APPS-02][2] 상세 화면 표시: ${hasDetail ? '확인' : 'warn-TODO(미확인)'}`);
+
+    expect(page.url()).toMatch(/\/webconsole\//);
+  });
+});

--- a/e2e/tc/sw/TC-APP-APPS-03.spec.ts
+++ b/e2e/tc/sw/TC-APP-APPS-03.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-APPS-03.spec.ts
+ * TC-APP-APPS-03: 운영 액션 (Restart / Stop / Uninstall)
+ *
+ * status: wip — 구현 필요 (ISSUE-015)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-APPS-03: 운영 액션 (Restart / Stop / Uninstall)', () => {
+  test('TC-APP-APPS-03: 운영 액션 (Restart / Stop / Uninstall)', async () => {
+    throw new Error('[TC-APP-APPS-03] 미구현 (ISSUE-015) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-APPS-04.spec.ts
+++ b/e2e/tc/sw/TC-APP-APPS-04.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-APPS-04.spec.ts
+ * TC-APP-APPS-04: Rating 제출
+ *
+ * status: wip — 구현 필요 (ISSUE-015)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-APPS-04: Rating 제출', () => {
+  test('TC-APP-APPS-04: Rating 제출', async () => {
+    throw new Error('[TC-APP-APPS-04] 미구현 (ISSUE-015) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-CAT-01.spec.ts
+++ b/e2e/tc/sw/TC-APP-CAT-01.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-CAT-01.spec.ts
+ * TC-APP-CAT-01: 빌트인 Catalog 목록 표시
+ *
+ * status: wip — 구현 필요 (ISSUE-012)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-CAT-01: 빌트인 Catalog 목록 표시', () => {
+  test('TC-APP-CAT-01: 빌트인 Catalog 목록 표시', async () => {
+    throw new Error('[TC-APP-CAT-01] 미구현 (ISSUE-012) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-CAT-02.spec.ts
+++ b/e2e/tc/sw/TC-APP-CAT-02.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-CAT-02.spec.ts
+ * TC-APP-CAT-02: Catalog 상세 펼침/접힘
+ *
+ * status: wip — 구현 필요 (ISSUE-012)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-CAT-02: Catalog 상세 펼침/접힘', () => {
+  test('TC-APP-CAT-02: Catalog 상세 펼침/접힘', async () => {
+    throw new Error('[TC-APP-CAT-02] 미구현 (ISSUE-012) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-CAT-03.spec.ts
+++ b/e2e/tc/sw/TC-APP-CAT-03.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-CAT-03.spec.ts
+ * TC-APP-CAT-03: 외부 검색 결과 표시 (DockerHub/ArtifactHub)
+ *
+ * status: wip — 구현 필요 (ISSUE-012)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-CAT-03: 외부 검색 결과 표시 (DockerHub/ArtifactHub)', () => {
+  test('TC-APP-CAT-03: 외부 검색 결과 표시 (DockerHub/ArtifactHub)', async () => {
+    throw new Error('[TC-APP-CAT-03] 미구현 (ISSUE-012) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-CAT-04.spec.ts
+++ b/e2e/tc/sw/TC-APP-CAT-04.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-CAT-04.spec.ts
+ * TC-APP-CAT-04: 외부 검색 결과 업로드
+ *
+ * status: wip — 구현 필요 (ISSUE-012)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-CAT-04: 외부 검색 결과 업로드', () => {
+  test('TC-APP-CAT-04: 외부 검색 결과 업로드', async () => {
+    throw new Error('[TC-APP-CAT-04] 미구현 (ISSUE-012) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-CAT-05.spec.ts
+++ b/e2e/tc/sw/TC-APP-CAT-05.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-CAT-05.spec.ts
+ * TC-APP-CAT-05: App Catalog 신규 등록
+ *
+ * status: wip — 구현 필요 (ISSUE-012)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-CAT-05: App Catalog 신규 등록', () => {
+  test('TC-APP-CAT-05: App Catalog 신규 등록', async () => {
+    throw new Error('[TC-APP-CAT-05] 미구현 (ISSUE-012) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-CAT-06.spec.ts
+++ b/e2e/tc/sw/TC-APP-CAT-06.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-CAT-06.spec.ts
+ * TC-APP-CAT-06: Catalog 수정 (Edit)
+ *
+ * status: wip — 구현 필요 (ISSUE-012)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-CAT-06: Catalog 수정 (Edit)', () => {
+  test('TC-APP-CAT-06: Catalog 수정 (Edit)', async () => {
+    throw new Error('[TC-APP-CAT-06] 미구현 (ISSUE-012) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-CAT-07.spec.ts
+++ b/e2e/tc/sw/TC-APP-CAT-07.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-CAT-07.spec.ts
+ * TC-APP-CAT-07: Catalog 삭제 (Trash)
+ *
+ * status: wip — 구현 필요 (ISSUE-012)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-CAT-07: Catalog 삭제 (Trash)', () => {
+  test('TC-APP-CAT-07: Catalog 삭제 (Trash)', async () => {
+    throw new Error('[TC-APP-CAT-07] 미구현 (ISSUE-012) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-DEP-01.spec.ts
+++ b/e2e/tc/sw/TC-APP-DEP-01.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * deploy/tc/sw/TC-APP-DEP-01.spec.ts
+ * TC-APP-DEP-01: VM 단일 배포 (Standalone)
+ *
+ * API: mc-application-manager /deploy (TODO — discovery 필요)
+ * 화면: SW Catalogs iframe > Deploy 탭
+ */
+import { test, expect } from '@playwright/test';
+import { API_ROUTES } from '../../shared/api-routes';
+import { PAGES } from '../../shared/pages';
+import { apiLoginBearer, loginAndGoto } from '../../shared/request-auth.helper';
+import { gotoSwIframeTab } from '../../shared/sw-iframe.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-APP-DEP-01';
+const scenarioId = process.env.SCENARIO_ID;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID)
+  : new StandaloneContext(TC_ID);
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// ── TC-APP-DEP-01: VM 단일 배포 (Standalone) ─────────────────────────────────
+
+test.describe('TC-APP-DEP-01: VM 단일 배포 (Standalone)', () => {
+
+  test('API: Deploy API 엔드포인트 확인', async ({ request }) => {
+    const auth = await apiLoginBearer(request);
+    const res  = await request.get(API_ROUTES.sw.deploySw, { headers: auth });
+    if (!res.ok()) {
+      console.warn(`[TC-APP-DEP-01] deploySw GET ${res.status()} — TODO: Deploy API 경로 discovery 필요`);
+      return;
+    }
+    const body = await res.json() as { code?: number; data?: unknown };
+    expect(body).toBeDefined();
+    console.log(`[TC-APP-DEP-01] Deploy 엔드포인트 응답: ${JSON.stringify(body).slice(0, 200)}`);
+  });
+
+  test('UI: SW Deploy 탭 진입 → VM Standalone 배포 흐름', async ({ page }) => {
+    const ok = await loginAndGoto(page, PAGES.sw.deploy, TC_ID);
+    if (!ok) return;
+
+    const frame = await gotoSwIframeTab(page, /deploy/i, TC_ID);
+    if (!frame) return;
+
+    // [1] Deploy 화면 진입 확인
+    const deployContainer = frame.locator('[class*="deploy"], [class*="Deploy"], h1, h2').first();
+    const pageLoaded = await deployContainer.isVisible().catch(() => false);
+    console.log(`[TC-APP-DEP-01][1] Deploy 화면 진입: ${pageLoaded ? '확인' : 'warn-TODO(미확인)'}`);
+
+    // [2] 배포 타입 선택 — VM Standalone
+    const standaloneOpt = frame
+      .locator('input[type="radio"], [class*="type-card"], [class*="option"]')
+      .filter({ hasText: /standalone/i })
+      .first();
+
+    if (await standaloneOpt.count() > 0) {
+      await standaloneOpt.click().catch(() => null);
+      console.log('[TC-APP-DEP-01][2] Standalone 옵션 선택');
+    } else {
+      const deployTypeSelector = frame.locator('select[name*="type"], [class*="type"] select').first();
+      if (await deployTypeSelector.count() > 0) {
+        await deployTypeSelector.selectOption({ label: 'standalone' }).catch(async () => {
+          await deployTypeSelector.selectOption({ index: 0 }).catch(() => null);
+        });
+        console.log('[TC-APP-DEP-01][2] VM Standalone 배포 타입 선택');
+      } else {
+        console.warn('[TC-APP-DEP-01][2] 배포 타입 selector 미발견 — discovery 필요');
+      }
+    }
+    await page.waitForTimeout(500);
+
+    // [3] 대상 VM 선택 (목록 첫 번째 항목)
+    const vmSelector = frame.locator(
+      'select[name*="vm"], select[name*="target"], select[name*="mci"], [class*="vm"] select'
+    ).first();
+
+    if (await vmSelector.count() > 0) {
+      await vmSelector.selectOption({ index: 0 }).catch(() => null);
+      console.log('[TC-APP-DEP-01][3] 대상 VM 선택 (첫 번째 항목)');
+    } else {
+      const firstVm = frame.locator('[class*="vm-item"], [class*="vmItem"], [class*="target"] [class*="item"]').first();
+      if (await firstVm.count() > 0) {
+        await firstVm.click();
+        console.log('[TC-APP-DEP-01][3] VM 항목 클릭');
+      } else {
+        console.warn('[TC-APP-DEP-01][3] 대상 VM 선택 UI 미발견 — discovery 필요');
+      }
+    }
+    await page.waitForTimeout(300);
+
+    // [4] Catalog 선택
+    const catalogSelector = frame.locator('select[name*="catalog"], select[name*="app"]').first();
+    if (await catalogSelector.count() > 0) {
+      await catalogSelector.selectOption({ index: 0 }).catch(() => null);
+      console.log('[TC-APP-DEP-01][4] Catalog 선택 (첫 번째 항목)');
+    } else {
+      console.warn('[TC-APP-DEP-01][4] Catalog 선택 UI 미발견 — discovery 필요');
+    }
+
+    // [5] 배포 실행 버튼 클릭
+    const deployBtn = frame.locator('button').filter({ hasText: /deploy|배포|실행|install/i }).first();
+    if (await deployBtn.count() === 0) {
+      console.warn('[TC-APP-DEP-01][5] 배포 버튼 미발견 — discovery 필요');
+      return;
+    }
+
+    let deployStatus = 0;
+    page.on('response', res => {
+      if (res.request().method() === 'POST' && res.url().includes('/deploy')) {
+        deployStatus = res.status();
+      }
+    });
+
+    const clicked = await deployBtn.click({ timeout: 5_000 }).then(() => true).catch(() => false);
+    if (!clicked) {
+      console.warn('[TC-APP-DEP-01][5] 배포 버튼 클릭 실패 — 비활성 또는 오버레이 (discovery 필요)');
+      return;
+    }
+    await page.waitForTimeout(2000);
+    console.log(`[TC-APP-DEP-01][5] 배포 실행 클릭 — API 응답: ${deployStatus || 'warn-TODO(미캡처)'}`);
+
+    expect(page.url()).toMatch(/\/webconsole\//);
+  });
+});

--- a/e2e/tc/sw/TC-APP-DEP-02.spec.ts
+++ b/e2e/tc/sw/TC-APP-DEP-02.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-DEP-02.spec.ts
+ * TC-APP-DEP-02: VM 다중 배포 (Clustering)
+ *
+ * status: wip — 구현 필요 (ISSUE-014)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-DEP-02: VM 다중 배포 (Clustering)', () => {
+  test('TC-APP-DEP-02: VM 다중 배포 (Clustering)', async () => {
+    throw new Error('[TC-APP-DEP-02] 미구현 (ISSUE-014) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-DEP-03.spec.ts
+++ b/e2e/tc/sw/TC-APP-DEP-03.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-DEP-03.spec.ts
+ * TC-APP-DEP-03: K8S 배포 (Helm chart 기반)
+ *
+ * status: wip — 구현 필요 (ISSUE-014)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-DEP-03: K8S 배포 (Helm chart 기반)', () => {
+  test('TC-APP-DEP-03: K8S 배포 (Helm chart 기반)', async () => {
+    throw new Error('[TC-APP-DEP-03] 미구현 (ISSUE-014) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-REP-01.spec.ts
+++ b/e2e/tc/sw/TC-APP-REP-01.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-REP-01.spec.ts
+ * TC-APP-REP-01: Repository 목록 조회
+ *
+ * status: wip — 구현 필요 (ISSUE-013)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-REP-01: Repository 목록 조회', () => {
+  test('TC-APP-REP-01: Repository 목록 조회', async () => {
+    throw new Error('[TC-APP-REP-01] 미구현 (ISSUE-013) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-REP-02.spec.ts
+++ b/e2e/tc/sw/TC-APP-REP-02.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-REP-02.spec.ts
+ * TC-APP-REP-02: Repository 신규 생성
+ *
+ * status: wip — 구현 필요 (ISSUE-013)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-REP-02: Repository 신규 생성', () => {
+  test('TC-APP-REP-02: Repository 신규 생성', async () => {
+    throw new Error('[TC-APP-REP-02] 미구현 (ISSUE-013) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-REP-03.spec.ts
+++ b/e2e/tc/sw/TC-APP-REP-03.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-REP-03.spec.ts
+ * TC-APP-REP-03: Repository 상세 진입
+ *
+ * status: wip — 구현 필요 (ISSUE-013)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-REP-03: Repository 상세 진입', () => {
+  test('TC-APP-REP-03: Repository 상세 진입', async () => {
+    throw new Error('[TC-APP-REP-03] 미구현 (ISSUE-013) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-REP-04.spec.ts
+++ b/e2e/tc/sw/TC-APP-REP-04.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-REP-04.spec.ts
+ * TC-APP-REP-04: Repository 컴포넌트 삭제
+ *
+ * status: wip — 구현 필요 (ISSUE-013)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-REP-04: Repository 컴포넌트 삭제', () => {
+  test('TC-APP-REP-04: Repository 컴포넌트 삭제', async () => {
+    throw new Error('[TC-APP-REP-04] 미구현 (ISSUE-013) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/sw/TC-APP-REP-05.spec.ts
+++ b/e2e/tc/sw/TC-APP-REP-05.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * deploy/tc/sw/TC-APP-REP-05.spec.ts
+ * TC-APP-REP-05: Repository 삭제
+ *
+ * status: wip — 구현 필요 (ISSUE-013)
+ */
+import { test } from '@playwright/test';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-APP-REP-05: Repository 삭제', () => {
+  test('TC-APP-REP-05: Repository 삭제', async () => {
+    throw new Error('[TC-APP-REP-05] 미구현 (ISSUE-013) — 구현 후 이 throw를 제거하고 실제 테스트 코드를 작성');
+  });
+});

--- a/e2e/tc/workflow/TC-WF-EL-01.spec.ts
+++ b/e2e/tc/workflow/TC-WF-EL-01.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * deploy/tc/workflow/TC-WF-EL-01.spec.ts
+ * TC-WF-EL-01: Event Listener 목록 조회
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workflow/TC-WF-EL-01.spec.ts
+ *   TC_VARIANT=default npx playwright test deploy/tc/workflow/TC-WF-EL-01.spec.ts
+ *
+ * ── 시나리오 실행 ────────────────────────────────────────────────
+ *   SCENARIO_ID=WF-001 npx playwright test deploy/tc/workflow/TC-WF-EL-01.spec.ts
+ *
+ * ── OUT params ──────────────────────────────────────────────────
+ *   (없음) — EL 목록 조회만 수행, store에 저장하는 값 없음
+ */
+import { test } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-WF-EL-01';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// ── 헬퍼 ─────────────────────────────────────────────────────────
+
+const getWfFrame = async (page: import('@playwright/test').Page) => {
+  await page.waitForTimeout(3000);
+  return page.frames().find(f => f.url().includes('workflow') && !f.url().includes('webconsole'));
+};
+
+const enterElTab = async (frame: import('@playwright/test').Frame) => {
+  const tab = frame.locator('a, button, [role="tab"], .nav-link, li')
+    .filter({ hasText: /event.?listener|이벤트.?리스너/i }).first();
+  const ok = await tab.waitFor({ state: 'visible', timeout: 10_000 }).then(() => true).catch(() => false);
+  if (ok) { await tab.click(); await frame.page().waitForTimeout(1000); }
+  return ok;
+};
+
+// ─────────────────────────────────────────────────────────────────
+
+test.describe('TC-WF-EL-01: Event Listener 목록 조회', () => {
+
+  test('워크플로우 페이지 접속 → EL 탭 진입 → 목록 영역 확인', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'}`);
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, TC_ID);
+    if (!ok) {
+      throw new Error(`[${TC_ID}] 로그인 실패`);
+    }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 10_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    // iframe 취득
+    const frame = await getWfFrame(page);
+    if (!frame) {
+      throw new Error(`[${TC_ID}] 워크플로우 iframe 없음`);
+    }
+
+    // EL 탭 진입
+    const tabOk = await enterElTab(frame);
+    if (!tabOk) {
+      throw new Error(`[${TC_ID}] Event Listener 탭을 찾지 못함`);
+    }
+
+    // 목록 영역 확인 (없어도 pass)
+    const listLocator = frame.locator('table, .tabulator, [class*="list"]').first();
+    const listVisible = await listLocator.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false);
+    if (listVisible) {
+      // 행 개수 집계
+      const rowCount = await frame.locator('table tr, .tabulator-row').count();
+      console.log(`[${TC_ID}] Event Listener 목록 확인 — 행 수: ${rowCount}`);
+    } else {
+      console.log(`[${TC_ID}] 목록 영역 미발견 (데이터 없음 또는 구조 상이) — 테스트 통과 처리`);
+    }
+  });
+});

--- a/e2e/tc/workflow/TC-WF-EL-02.spec.ts
+++ b/e2e/tc/workflow/TC-WF-EL-02.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * deploy/tc/workflow/TC-WF-EL-02.spec.ts
+ * TC-WF-EL-02: 신규 Event Listener 생성
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workflow/TC-WF-EL-02.spec.ts
+ *   EL_NAME=my-el WORKFLOW_NAME=my-wf npx playwright test deploy/tc/workflow/TC-WF-EL-02.spec.ts
+ *
+ * ── 시나리오 실행 ────────────────────────────────────────────────
+ *   SCENARIO_ID=WF-001 npx playwright test deploy/tc/workflow/TC-WF-EL-02.spec.ts
+ *
+ * ── IN params ───────────────────────────────────────────────────
+ *   eventListenerName : 생성할 EL 이름 (기본 'infra-create-el')
+ *   workflowName      : 연결할 워크플로우 이름 (기본 '')
+ *
+ * ── OUT params ──────────────────────────────────────────────────
+ *   elName : 생성/확인된 EL 이름 → store에 저장
+ */
+import { test } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-WF-EL-02';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// ── 헬퍼 ─────────────────────────────────────────────────────────
+
+const getWfFrame = async (page: import('@playwright/test').Page) => {
+  await page.waitForTimeout(3000);
+  return page.frames().find(f => f.url().includes('workflow') && !f.url().includes('webconsole'));
+};
+
+const enterElTab = async (frame: import('@playwright/test').Frame) => {
+  const tab = frame.locator('a, button, [role="tab"], .nav-link, li')
+    .filter({ hasText: /event.?listener|이벤트.?리스너/i }).first();
+  const ok = await tab.waitFor({ state: 'visible', timeout: 10_000 }).then(() => true).catch(() => false);
+  if (ok) { await tab.click(); await frame.page().waitForTimeout(1000); }
+  return ok;
+};
+
+// ─────────────────────────────────────────────────────────────────
+
+test.describe('TC-WF-EL-02: 신규 Event Listener 생성', () => {
+
+  test('EL 생성 — 이미 있으면 store 저장 후 스킵, 없으면 생성 후 저장', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    const elName       = (p.eventListenerName as string) || 'infra-create-el';
+    const workflowName = (p.workflowName as string)      || '';
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'} | elName: ${elName} | workflowName: ${workflowName}`);
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, TC_ID);
+    if (!ok) {
+      throw new Error(`[${TC_ID}] 로그인 실패`);
+    }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 10_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    // iframe 취득
+    const frame = await getWfFrame(page);
+    if (!frame) {
+      throw new Error(`[${TC_ID}] 워크플로우 iframe 없음`);
+    }
+
+    // EL 탭 진입
+    const tabOk = await enterElTab(frame);
+    if (!tabOk) {
+      throw new Error(`[${TC_ID}] Event Listener 탭을 찾지 못함`);
+    }
+
+    // 이미 존재 여부 확인
+    const existingRow = frame.locator('tr, .tabulator-row').filter({ hasText: elName }).first();
+    const alreadyExists = await existingRow.isVisible().catch(() => false);
+    if (alreadyExists) {
+      console.log(`[${TC_ID}] '${elName}' 이미 존재 — 생성 스킵, store 저장`);
+      store?.set('elName', elName);
+      return;
+    }
+
+    // POST /eventlistener 응답 인터셉트
+    let postStatus = 0;
+    page.on('response', async (resp) => {
+      if (resp.url().includes('eventlistener') && resp.request().method() === 'POST') {
+        postStatus = resp.status();
+        console.log(`[${TC_ID}] POST /eventlistener → status: ${postStatus}`);
+      }
+    });
+
+    // create 버튼 클릭
+    const createBtn = frame.locator('button, a').filter({ hasText: /create|추가|생성|new/i }).first();
+    const createOk = await createBtn.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false);
+    if (!createOk) {
+      throw new Error(`[${TC_ID}] create 버튼을 찾지 못함`);
+    }
+    await createBtn.click();
+    await frame.page().waitForTimeout(1000);
+
+    // 이름 입력
+    const nameInput = frame.locator('input[name*="name"], input[placeholder*="name"], input[id*="name"]').first();
+    const nameOk = await nameInput.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false);
+    if (!nameOk) {
+      throw new Error(`[${TC_ID}] name input을 찾지 못함`);
+    }
+    await nameInput.fill(elName);
+
+    // 워크플로우 select (첫 번째 select)
+    if (workflowName) {
+      try {
+        const wfSelect = frame.locator('select').first();
+        await wfSelect.selectOption({ label: workflowName });
+      } catch {
+        console.warn(`[${TC_ID}] 워크플로우 선택 실패 (무시)`);
+      }
+    }
+
+    // submit 버튼 클릭
+    const submitBtn = frame.locator('button[type="submit"], button').filter({ hasText: /save|submit|저장|확인|ok/i }).first();
+    const submitOk = await submitBtn.waitFor({ state: 'visible', timeout: 5_000 }).then(() => true).catch(() => false);
+    if (!submitOk) {
+      throw new Error(`[${TC_ID}] submit 버튼을 찾지 못함`);
+    }
+    await submitBtn.click();
+    await frame.page().waitForTimeout(2000);
+
+    console.log(`[${TC_ID}] EL 생성 완료 — postStatus: ${postStatus}`);
+    store?.set('elName', elName);
+  });
+
+  test.afterAll(async () => {
+    const elName = (p.eventListenerName as string) || 'infra-create-el';
+    store?.set('elName', elName);
+  });
+});

--- a/e2e/tc/workflow/TC-WF-EL-03.spec.ts
+++ b/e2e/tc/workflow/TC-WF-EL-03.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * deploy/tc/workflow/TC-WF-EL-03.spec.ts
+ * TC-WF-EL-03: Event Listener 이름 중복 검사
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workflow/TC-WF-EL-03.spec.ts
+ *   EL_NAME=infra-create-el npx playwright test deploy/tc/workflow/TC-WF-EL-03.spec.ts
+ *
+ * ── 시나리오 실행 ────────────────────────────────────────────────
+ *   SCENARIO_ID=WF-001 npx playwright test deploy/tc/workflow/TC-WF-EL-03.spec.ts
+ *
+ * ── IN params ───────────────────────────────────────────────────
+ *   eventListenerName : 중복 검사할 EL 이름
+ *                       (기본값: store의 elName → EL_NAME 환경변수 → 'infra-create-el')
+ *
+ * ── OUT params ──────────────────────────────────────────────────
+ *   (없음)
+ */
+import { test } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-WF-EL-03';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// ── 헬퍼 ─────────────────────────────────────────────────────────
+
+const getWfFrame = async (page: import('@playwright/test').Page) => {
+  await page.waitForTimeout(3000);
+  return page.frames().find(f => f.url().includes('workflow') && !f.url().includes('webconsole'));
+};
+
+const enterElTab = async (frame: import('@playwright/test').Frame) => {
+  const tab = frame.locator('a, button, [role="tab"], .nav-link, li')
+    .filter({ hasText: /event.?listener|이벤트.?리스너/i }).first();
+  const ok = await tab.waitFor({ state: 'visible', timeout: 10_000 }).then(() => true).catch(() => false);
+  if (ok) { await tab.click(); await frame.page().waitForTimeout(1000); }
+  return ok;
+};
+
+// ─────────────────────────────────────────────────────────────────
+
+test.describe('TC-WF-EL-03: Event Listener 이름 중복 검사', () => {
+
+  test('이미 존재하는 이름 입력 → 중복 오류 메시지 확인 → 폼 닫기', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    // store의 elName → 환경변수 → params → fallback 순으로 이름 결정
+    const elName: string = (p.eventListenerName as string)
+      || (store?.get('elName') as string | undefined)
+      || process.env.EL_NAME
+      || 'infra-create-el';
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'} | elName: ${elName}`);
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, TC_ID);
+    if (!ok) {
+      throw new Error(`[${TC_ID}] 로그인 실패`);
+    }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 10_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    // iframe 취득
+    const frame = await getWfFrame(page);
+    if (!frame) {
+      throw new Error(`[${TC_ID}] 워크플로우 iframe 없음`);
+    }
+
+    // EL 탭 진입
+    const tabOk = await enterElTab(frame);
+    if (!tabOk) {
+      throw new Error(`[${TC_ID}] Event Listener 탭을 찾지 못함`);
+    }
+
+    // create 버튼 클릭
+    const createBtn = frame.locator('button, a').filter({ hasText: /create|추가|생성|new/i }).first();
+    const createOk = await createBtn.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false);
+    if (!createOk) {
+      throw new Error(`[${TC_ID}] create 버튼을 찾지 못함`);
+    }
+    await createBtn.click();
+    await frame.page().waitForTimeout(1000);
+
+    // 이미 존재하는 이름 입력
+    const nameInput = frame.locator('input[name*="name"], input[placeholder*="name"], input[id*="name"]').first();
+    const nameOk = await nameInput.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false);
+    if (!nameOk) {
+      throw new Error(`[${TC_ID}] name input을 찾지 못함`);
+    }
+    await nameInput.fill(elName);
+    // blur 처리로 유효성 검사 트리거
+    await nameInput.press('Tab');
+    await frame.page().waitForTimeout(1000);
+
+    // 중복 오류 메시지 확인
+    const errorLocator = frame.locator('[class*="error"], [class*="invalid"], .alert, .text-danger');
+    const hasError = await errorLocator.filter({ hasText: /중복|duplicate|already/i }).first()
+      .isVisible().catch(() => false);
+
+    if (hasError) {
+      const errText = await errorLocator.filter({ hasText: /중복|duplicate|already/i }).first().textContent().catch(() => '');
+      console.log(`[${TC_ID}] 중복 오류 메시지 확인: "${errText?.trim()}"`);
+    } else {
+      console.warn(`[${TC_ID}] 중복 오류 메시지를 찾지 못함 (UI 미지원 또는 서버 측 검사)`);
+    }
+
+    // 폼 닫기 — cancel 버튼 또는 Escape
+    const cancelBtn = frame.locator('button').filter({ hasText: /cancel|취소|닫기|close/i }).first();
+    const cancelOk = await cancelBtn.isVisible().catch(() => false);
+    if (cancelOk) {
+      await cancelBtn.click();
+    } else {
+      await frame.page().keyboard.press('Escape');
+    }
+    await frame.page().waitForTimeout(500);
+  });
+});

--- a/e2e/tc/workflow/TC-WF-EL-04.spec.ts
+++ b/e2e/tc/workflow/TC-WF-EL-04.spec.ts
@@ -1,0 +1,143 @@
+/**
+ * deploy/tc/workflow/TC-WF-EL-04.spec.ts
+ * TC-WF-EL-04: Event Listener 상세 수정
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workflow/TC-WF-EL-04.spec.ts
+ *   EL_NAME=infra-create-el npx playwright test deploy/tc/workflow/TC-WF-EL-04.spec.ts
+ *
+ * ── 시나리오 실행 ────────────────────────────────────────────────
+ *   SCENARIO_ID=WF-001 npx playwright test deploy/tc/workflow/TC-WF-EL-04.spec.ts
+ *
+ * ── IN params ───────────────────────────────────────────────────
+ *   eventListenerName : 수정할 EL 이름 (없으면 FAIL)
+ *
+ * ── OUT params ──────────────────────────────────────────────────
+ *   (없음)
+ */
+import { test } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-WF-EL-04';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// ── 헬퍼 ─────────────────────────────────────────────────────────
+
+const getWfFrame = async (page: import('@playwright/test').Page) => {
+  await page.waitForTimeout(3000);
+  return page.frames().find(f => f.url().includes('workflow') && !f.url().includes('webconsole'));
+};
+
+const enterElTab = async (frame: import('@playwright/test').Frame) => {
+  const tab = frame.locator('a, button, [role="tab"], .nav-link, li')
+    .filter({ hasText: /event.?listener|이벤트.?리스너/i }).first();
+  const ok = await tab.waitFor({ state: 'visible', timeout: 10_000 }).then(() => true).catch(() => false);
+  if (ok) { await tab.click(); await frame.page().waitForTimeout(1000); }
+  return ok;
+};
+
+// ─────────────────────────────────────────────────────────────────
+
+test.describe('TC-WF-EL-04: Event Listener 상세 수정', () => {
+
+  test('EL 행 클릭 → edit 버튼 → description 수정 → 저장', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    // params에서 이름 취득 (없으면 FAIL)
+    const elName = (p.eventListenerName as string) || '';
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'} | elName: ${elName || '(없음)'}`);
+
+    if (!elName) {
+      throw new Error(`[${TC_ID}] eventListenerName 파라미터 없음`);
+    }
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, TC_ID);
+    if (!ok) {
+      throw new Error(`[${TC_ID}] 로그인 실패`);
+    }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 10_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    // iframe 취득
+    const frame = await getWfFrame(page);
+    if (!frame) {
+      throw new Error(`[${TC_ID}] 워크플로우 iframe 없음`);
+    }
+
+    // EL 탭 진입
+    const tabOk = await enterElTab(frame);
+    if (!tabOk) {
+      throw new Error(`[${TC_ID}] Event Listener 탭을 찾지 못함`);
+    }
+
+    // EL 행 찾기
+    const row = frame.locator('tr, .tabulator-row').filter({ hasText: elName }).first();
+    const rowOk = await row.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false);
+    if (!rowOk) {
+      throw new Error(`[${TC_ID}] '${elName}' 행을 찾지 못함`);
+    }
+
+    // edit/수정 버튼 클릭
+    const editBtn = row.locator('button, a').filter({ hasText: /edit|수정|편집/i }).first();
+    const editOk = await editBtn.waitFor({ state: 'visible', timeout: 5_000 }).then(() => true).catch(() => false);
+    if (!editOk) {
+      // 행 자체를 클릭해 상세 패널 열기 시도
+      await row.click();
+      await frame.page().waitForTimeout(1000);
+    } else {
+      await editBtn.click();
+      await frame.page().waitForTimeout(1000);
+    }
+
+    // description input 수정
+    const descInput = frame.locator('input[name*="desc"], textarea[name*="desc"], input[id*="desc"], textarea[id*="desc"]').first();
+    const descOk = await descInput.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false);
+    if (!descOk) {
+      throw new Error(`[${TC_ID}] description input을 찾지 못함`);
+    }
+    const currentDesc = await descInput.inputValue().catch(() => '');
+    await descInput.fill(`${currentDesc} (수정)`);
+
+    // PATCH /eventlistener 응답 인터셉트
+    let patchStatus = 0;
+    page.on('response', async (resp) => {
+      if (resp.url().includes('eventlistener') && resp.request().method() === 'PATCH') {
+        patchStatus = resp.status();
+        console.log(`[${TC_ID}] PATCH /eventlistener → status: ${patchStatus}`);
+      }
+    });
+
+    // save 버튼 클릭
+    const saveBtn = frame.locator('button[type="submit"], button').filter({ hasText: /save|저장|확인|ok|update/i }).first();
+    const saveOk = await saveBtn.waitFor({ state: 'visible', timeout: 5_000 }).then(() => true).catch(() => false);
+    if (!saveOk) {
+      throw new Error(`[${TC_ID}] save 버튼을 찾지 못함`);
+    }
+    await saveBtn.click();
+    await frame.page().waitForTimeout(2000);
+
+    console.log(`[${TC_ID}] 수정 완료 — patchStatus: ${patchStatus}`);
+  });
+});

--- a/e2e/tc/workflow/TC-WF-EL-05.spec.ts
+++ b/e2e/tc/workflow/TC-WF-EL-05.spec.ts
@@ -1,0 +1,138 @@
+/**
+ * deploy/tc/workflow/TC-WF-EL-05.spec.ts
+ * TC-WF-EL-05: Event Listener 삭제
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workflow/TC-WF-EL-05.spec.ts
+ *   EL_NAME=infra-create-el npx playwright test deploy/tc/workflow/TC-WF-EL-05.spec.ts
+ *
+ * ── 시나리오 실행 ────────────────────────────────────────────────
+ *   SCENARIO_ID=WF-001 npx playwright test deploy/tc/workflow/TC-WF-EL-05.spec.ts
+ *
+ * ── IN params ───────────────────────────────────────────────────
+ *   eventListenerName : 삭제할 EL 이름 (없으면 FAIL)
+ *
+ * ── OUT params ──────────────────────────────────────────────────
+ *   (없음)
+ */
+import { test } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-WF-EL-05';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// ── 헬퍼 ─────────────────────────────────────────────────────────
+
+const getWfFrame = async (page: import('@playwright/test').Page) => {
+  await page.waitForTimeout(3000);
+  return page.frames().find(f => f.url().includes('workflow') && !f.url().includes('webconsole'));
+};
+
+const enterElTab = async (frame: import('@playwright/test').Frame) => {
+  const tab = frame.locator('a, button, [role="tab"], .nav-link, li')
+    .filter({ hasText: /event.?listener|이벤트.?리스너/i }).first();
+  const ok = await tab.waitFor({ state: 'visible', timeout: 10_000 }).then(() => true).catch(() => false);
+  if (ok) { await tab.click(); await frame.page().waitForTimeout(1000); }
+  return ok;
+};
+
+// ─────────────────────────────────────────────────────────────────
+
+test.describe('TC-WF-EL-05: Event Listener 삭제', () => {
+
+  test('EL 행 클릭 → 삭제 버튼 → 확인 다이얼로그 → 행 사라짐 확인', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    const elName = (p.eventListenerName as string) || '';
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'} | elName: ${elName || '(없음)'}`);
+
+    if (!elName) {
+      throw new Error(`[${TC_ID}] eventListenerName 파라미터 없음`);
+    }
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, TC_ID);
+    if (!ok) {
+      throw new Error(`[${TC_ID}] 로그인 실패`);
+    }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 10_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    // iframe 취득
+    const frame = await getWfFrame(page);
+    if (!frame) {
+      throw new Error(`[${TC_ID}] 워크플로우 iframe 없음`);
+    }
+
+    // EL 탭 진입
+    const tabOk = await enterElTab(frame);
+    if (!tabOk) {
+      throw new Error(`[${TC_ID}] Event Listener 탭을 찾지 못함`);
+    }
+
+    // EL 행 찾기
+    const row = frame.locator('tr, .tabulator-row').filter({ hasText: elName }).first();
+    const rowOk = await row.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false);
+    if (!rowOk) {
+      throw new Error(`[${TC_ID}] '${elName}' 행을 찾지 못함`);
+    }
+
+    // 삭제 버튼 클릭
+    const delBtn = row.locator('button, a').filter({ hasText: /del|delete|삭제|remove/i }).first();
+    const delOk = await delBtn.waitFor({ state: 'visible', timeout: 5_000 }).then(() => true).catch(() => false);
+    if (!delOk) {
+      throw new Error(`[${TC_ID}] 삭제 버튼을 찾지 못함`);
+    }
+    await delBtn.click();
+    await frame.page().waitForTimeout(1000);
+
+    // 확인 다이얼로그 처리 (SweetAlert2 또는 Bootstrap modal)
+    const confirmBtn = page.locator('.swal2-confirm, .modal.show button')
+      .filter({ hasText: /확인|ok|yes|삭제/i }).first();
+    const confirmOk = await confirmBtn.waitFor({ state: 'visible', timeout: 5_000 }).then(() => true).catch(() => false);
+    if (confirmOk) {
+      await confirmBtn.click();
+    } else {
+      // iframe 내부 confirm 버튼 시도
+      const frameConfirmBtn = frame.locator('.swal2-confirm, .modal.show button, button')
+        .filter({ hasText: /확인|ok|yes|삭제/i }).first();
+      const frameConfirmOk = await frameConfirmBtn.isVisible().catch(() => false);
+      if (frameConfirmOk) {
+        await frameConfirmBtn.click();
+      } else {
+        console.warn(`[${TC_ID}] 확인 다이얼로그를 찾지 못함 — 계속 진행`);
+      }
+    }
+
+    await frame.page().waitForTimeout(1500);
+
+    // 행 사라짐 확인
+    const rowGone = await row.isVisible().then(v => !v).catch(() => true);
+    if (rowGone) {
+      console.log(`[${TC_ID}] '${elName}' 삭제 확인 — 행이 목록에서 사라짐`);
+    } else {
+      console.warn(`[${TC_ID}] '${elName}' 행이 아직 보임 — 삭제가 반영되지 않았거나 비동기 처리 중`);
+    }
+  });
+});

--- a/e2e/tc/workflow/TC-WF-EL-06.spec.ts
+++ b/e2e/tc/workflow/TC-WF-EL-06.spec.ts
@@ -1,0 +1,166 @@
+/**
+ * deploy/tc/workflow/TC-WF-EL-06.spec.ts
+ * TC-WF-EL-06: Event Listener를 통한 Workflow 실행 (GET)
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workflow/TC-WF-EL-06.spec.ts
+ *   EL_NAME=infra-create-el npx playwright test deploy/tc/workflow/TC-WF-EL-06.spec.ts
+ *
+ * ── 시나리오 실행 ────────────────────────────────────────────────
+ *   SCENARIO_ID=WF-001 npx playwright test deploy/tc/workflow/TC-WF-EL-06.spec.ts
+ *
+ * ── IN params ───────────────────────────────────────────────────
+ *   eventListenerName : callUrl을 조회할 EL 이름 (없으면 FAIL)
+ *
+ * ── OUT params ──────────────────────────────────────────────────
+ *   (없음)
+ */
+import { test } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-WF-EL-06';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// ── 헬퍼 ─────────────────────────────────────────────────────────
+
+const getWfFrame = async (page: import('@playwright/test').Page) => {
+  await page.waitForTimeout(3000);
+  return page.frames().find(f => f.url().includes('workflow') && !f.url().includes('webconsole'));
+};
+
+const enterElTab = async (frame: import('@playwright/test').Frame) => {
+  const tab = frame.locator('a, button, [role="tab"], .nav-link, li')
+    .filter({ hasText: /event.?listener|이벤트.?리스너/i }).first();
+  const ok = await tab.waitFor({ state: 'visible', timeout: 10_000 }).then(() => true).catch(() => false);
+  if (ok) { await tab.click(); await frame.page().waitForTimeout(1000); }
+  return ok;
+};
+
+/**
+ * EL 행에서 callUrl을 취득한다.
+ * 1순위: td 내 http로 시작하는 텍스트
+ * 2순위: detail/상세 버튼 클릭 후 readonly input의 value
+ */
+const getCallUrl = async (
+  frame: import('@playwright/test').Frame,
+  elName: string,
+): Promise<string | null> => {
+  const row = frame.locator('tr, .tabulator-row').filter({ hasText: elName }).first();
+  const rowOk = await row.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false);
+  if (!rowOk) return null;
+
+  // 1순위: td 중 http 텍스트 포함 셀
+  const urlCell = row.locator('td').filter({ hasText: /https?:\/\//i }).first();
+  const urlCellOk = await urlCell.isVisible().catch(() => false);
+  if (urlCellOk) {
+    const text = await urlCell.textContent().catch(() => '');
+    const match = text?.match(/https?:\/\/\S+/);
+    if (match) return match[0].trim();
+  }
+
+  // 2순위: detail/상세 버튼 클릭
+  const detailBtn = row.locator('button, a').filter({ hasText: /detail|상세|view|보기/i }).first();
+  const detailOk = await detailBtn.isVisible().catch(() => false);
+  if (detailOk) {
+    await detailBtn.click();
+    await frame.page().waitForTimeout(1000);
+    const urlInput = frame.locator('input[readonly]').filter({ hasText: /https?/i }).first();
+    const urlInputOk = await urlInput.isVisible().catch(() => false);
+    if (urlInputOk) {
+      return await urlInput.inputValue().catch(() => null);
+    }
+    // placeholder 또는 value attribute 시도
+    const allReadonlyInputs = frame.locator('input[readonly]');
+    const count = await allReadonlyInputs.count();
+    for (let i = 0; i < count; i++) {
+      const val = await allReadonlyInputs.nth(i).inputValue().catch(() => '');
+      if (val.startsWith('http')) return val;
+    }
+  }
+
+  return null;
+};
+
+// ─────────────────────────────────────────────────────────────────
+
+test.describe('TC-WF-EL-06: Event Listener를 통한 Workflow 실행 (GET)', () => {
+
+  test('EL callUrl 취득 → GET 요청 → 응답 상태 확인', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    const elName = (p.eventListenerName as string) || '';
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'} | elName: ${elName || '(없음)'}`);
+
+    if (!elName) {
+      throw new Error(`[${TC_ID}] eventListenerName 파라미터 없음`);
+    }
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, TC_ID);
+    if (!ok) {
+      throw new Error(`[${TC_ID}] 로그인 실패`);
+    }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 10_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    // iframe 취득
+    const frame = await getWfFrame(page);
+    if (!frame) {
+      throw new Error(`[${TC_ID}] 워크플로우 iframe 없음`);
+    }
+
+    // EL 탭 진입
+    const tabOk = await enterElTab(frame);
+    if (!tabOk) {
+      throw new Error(`[${TC_ID}] Event Listener 탭을 찾지 못함`);
+    }
+
+    // callUrl 취득
+    const callUrl = await getCallUrl(frame, elName);
+    if (!callUrl) {
+      throw new Error(`[${TC_ID}] '${elName}'의 callUrl을 취득하지 못함`);
+    }
+
+    console.log(`[${TC_ID}] callUrl: ${callUrl}`);
+
+    // GET 요청
+    const response = await page.request.get(callUrl, { ignoreHTTPSErrors: true }).catch((e) => {
+      console.warn(`[${TC_ID}] GET 요청 실패: ${e}`);
+      return null;
+    });
+
+    if (!response) {
+      throw new Error(`[${TC_ID}] GET 요청 실패 — callUrl: ${callUrl}`);
+    }
+
+    const status = response.status();
+    console.log(`[${TC_ID}] GET ${callUrl} → status: ${status}`);
+
+    if (status >= 200 && status < 300) {
+      console.log(`[${TC_ID}] PASS — 2xx 응답 수신`);
+    } else {
+      console.warn(`[${TC_ID}] 비정상 응답 status: ${status} (워크플로우 미연결 또는 인증 필요일 수 있음)`);
+    }
+  });
+});

--- a/e2e/tc/workflow/TC-WF-EL-07.spec.ts
+++ b/e2e/tc/workflow/TC-WF-EL-07.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * deploy/tc/workflow/TC-WF-EL-07.spec.ts
+ * TC-WF-EL-07: Event Listener를 통한 Workflow 실행 (POST)
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workflow/TC-WF-EL-07.spec.ts
+ *   EL_NAME=infra-create-el npx playwright test deploy/tc/workflow/TC-WF-EL-07.spec.ts
+ *
+ * ── 시나리오 실행 ────────────────────────────────────────────────
+ *   SCENARIO_ID=WF-001 npx playwright test deploy/tc/workflow/TC-WF-EL-07.spec.ts
+ *
+ * ── IN params ───────────────────────────────────────────────────
+ *   eventListenerName : callUrl을 조회할 EL 이름 (없으면 FAIL)
+ *   triggerBody       : POST body (기본 {})
+ *
+ * ── OUT params ──────────────────────────────────────────────────
+ *   (없음)
+ */
+import { test } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-WF-EL-07';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// ── 헬퍼 ─────────────────────────────────────────────────────────
+
+const getWfFrame = async (page: import('@playwright/test').Page) => {
+  await page.waitForTimeout(3000);
+  return page.frames().find(f => f.url().includes('workflow') && !f.url().includes('webconsole'));
+};
+
+const enterElTab = async (frame: import('@playwright/test').Frame) => {
+  const tab = frame.locator('a, button, [role="tab"], .nav-link, li')
+    .filter({ hasText: /event.?listener|이벤트.?리스너/i }).first();
+  const ok = await tab.waitFor({ state: 'visible', timeout: 10_000 }).then(() => true).catch(() => false);
+  if (ok) { await tab.click(); await frame.page().waitForTimeout(1000); }
+  return ok;
+};
+
+/**
+ * EL 행에서 callUrl을 취득한다.
+ * 1순위: td 내 http로 시작하는 텍스트
+ * 2순위: detail/상세 버튼 클릭 후 readonly input의 value
+ */
+const getCallUrl = async (
+  frame: import('@playwright/test').Frame,
+  elName: string,
+): Promise<string | null> => {
+  const row = frame.locator('tr, .tabulator-row').filter({ hasText: elName }).first();
+  const rowOk = await row.waitFor({ state: 'visible', timeout: 8_000 }).then(() => true).catch(() => false);
+  if (!rowOk) return null;
+
+  // 1순위: td 중 http 텍스트 포함 셀
+  const urlCell = row.locator('td').filter({ hasText: /https?:\/\//i }).first();
+  const urlCellOk = await urlCell.isVisible().catch(() => false);
+  if (urlCellOk) {
+    const text = await urlCell.textContent().catch(() => '');
+    const match = text?.match(/https?:\/\/\S+/);
+    if (match) return match[0].trim();
+  }
+
+  // 2순위: detail/상세 버튼 클릭
+  const detailBtn = row.locator('button, a').filter({ hasText: /detail|상세|view|보기/i }).first();
+  const detailOk = await detailBtn.isVisible().catch(() => false);
+  if (detailOk) {
+    await detailBtn.click();
+    await frame.page().waitForTimeout(1000);
+    const urlInput = frame.locator('input[readonly]').filter({ hasText: /https?/i }).first();
+    const urlInputOk = await urlInput.isVisible().catch(() => false);
+    if (urlInputOk) {
+      return await urlInput.inputValue().catch(() => null);
+    }
+    // 모든 readonly input의 value 순회
+    const allReadonlyInputs = frame.locator('input[readonly]');
+    const count = await allReadonlyInputs.count();
+    for (let i = 0; i < count; i++) {
+      const val = await allReadonlyInputs.nth(i).inputValue().catch(() => '');
+      if (val.startsWith('http')) return val;
+    }
+  }
+
+  return null;
+};
+
+// ─────────────────────────────────────────────────────────────────
+
+test.describe('TC-WF-EL-07: Event Listener를 통한 Workflow 실행 (POST)', () => {
+
+  test('EL callUrl 취득 → POST 요청 → 응답 상태 확인', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    const elName      = (p.eventListenerName as string) || '';
+    const triggerBody = (p.triggerBody as Record<string, unknown>) || {};
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'} | elName: ${elName || '(없음)'}`);
+
+    if (!elName) {
+      throw new Error(`[${TC_ID}] eventListenerName 파라미터 없음`);
+    }
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, TC_ID);
+    if (!ok) {
+      throw new Error(`[${TC_ID}] 로그인 실패`);
+    }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 10_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {}
+
+    // iframe 취득
+    const frame = await getWfFrame(page);
+    if (!frame) {
+      throw new Error(`[${TC_ID}] 워크플로우 iframe 없음`);
+    }
+
+    // EL 탭 진입
+    const tabOk = await enterElTab(frame);
+    if (!tabOk) {
+      throw new Error(`[${TC_ID}] Event Listener 탭을 찾지 못함`);
+    }
+
+    // callUrl 취득
+    const callUrl = await getCallUrl(frame, elName);
+    if (!callUrl) {
+      throw new Error(`[${TC_ID}] '${elName}'의 callUrl을 취득하지 못함`);
+    }
+
+    console.log(`[${TC_ID}] callUrl: ${callUrl}`);
+    console.log(`[${TC_ID}] triggerBody: ${JSON.stringify(triggerBody)}`);
+
+    // POST 요청
+    const response = await page.request.post(callUrl, {
+      data: triggerBody,
+      ignoreHTTPSErrors: true,
+    }).catch((e) => {
+      console.warn(`[${TC_ID}] POST 요청 실패: ${e}`);
+      return null;
+    });
+
+    if (!response) {
+      throw new Error(`[${TC_ID}] POST 요청 실패 — callUrl: ${callUrl}`);
+    }
+
+    const status = response.status();
+    console.log(`[${TC_ID}] POST ${callUrl} → status: ${status}`);
+
+    if (status >= 200 && status < 300) {
+      console.log(`[${TC_ID}] PASS — 2xx 응답 수신`);
+    } else {
+      console.warn(`[${TC_ID}] 비정상 응답 status: ${status} (워크플로우 미연결 또는 인증 필요일 수 있음)`);
+    }
+  });
+});

--- a/e2e/tc/workflow/TC-WF-FLOW-01.spec.ts
+++ b/e2e/tc/workflow/TC-WF-FLOW-01.spec.ts
@@ -1,0 +1,103 @@
+/**
+ * deploy/tc/workflow/TC-WF-FLOW-01.spec.ts
+ * TC-WF-FLOW-01: Workflow Engine(Jenkins) 등록 및 연동 확인
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workflow/TC-WF-FLOW-01.spec.ts
+ *   TC_VARIANT=default npx playwright test deploy/tc/workflow/TC-WF-FLOW-01.spec.ts
+ *
+ * ── 시나리오 실행 ────────────────────────────────────────────────
+ *   SCENARIO_ID=WF-001 npx playwright test deploy/tc/workflow/TC-WF-FLOW-01.spec.ts
+ *
+ * ── OUT params ──────────────────────────────────────────────────
+ *   (없음) — OSS 목록 조회만 수행, store에 저장하는 값 없음
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-WF-FLOW-01';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-WF-FLOW-01: Workflow Engine(Jenkins) 등록 및 연동 확인', () => {
+
+  test('워크플로우 페이지 접속 → OSS/Engine 탭 확인 → OSS 목록 조회', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'}`);
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, TC_ID);
+    if (!ok) {
+      throw new Error(`[${TC_ID}] 로그인 실패`);
+    }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-project') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.toLowerCase().includes('default'));
+      }, { timeout: 15_000 });
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {
+      console.warn(`[${TC_ID}] 워크스페이스/프로젝트 선택 실패 — 진행 계속`);
+    }
+
+    await page.waitForLoadState('networkidle', { timeout: 20_000 }).catch(() => {});
+    await page.waitForTimeout(2_000);
+
+    // OSS/Engine 탭 찾아 클릭 (없으면 pass)
+    const ossTab = page.locator('a, button, [role="tab"]').filter({ hasText: /oss|engine|jenkins/i }).first();
+    const ossTabVisible = await ossTab.isVisible().catch(() => false);
+    if (ossTabVisible) {
+      await ossTab.click();
+      await page.waitForTimeout(1_500);
+      console.log(`[${TC_ID}] OSS/Engine 탭 클릭 완료`);
+    } else {
+      console.warn(`[${TC_ID}] OSS/Engine 탭 없음 — 목록 조회만 진행`);
+    }
+
+    // GET /api/mc-workflow-manager/oss/list 호출 → 응답 status 로그
+    let ossCount = 0;
+    try {
+      const response = await page.request.get('/api/mc-workflow-manager/oss/list');
+      console.log(`[${TC_ID}] GET /api/mc-workflow-manager/oss/list → status: ${response.status()}`);
+      if (response.ok()) {
+        const body = await response.json().catch(() => null);
+        if (body && Array.isArray(body)) {
+          ossCount = body.length;
+        } else if (body && typeof body === 'object') {
+          const arr = body.data ?? body.items ?? body.list ?? body.result ?? [];
+          ossCount = Array.isArray(arr) ? arr.length : 0;
+        }
+      }
+    } catch (e) {
+      console.warn(`[${TC_ID}] OSS 목록 API 호출 실패: ${e instanceof Error ? e.message : String(e)}`);
+    }
+
+    console.log(`[${TC_ID}] 등록된 OSS(Engine) count: ${ossCount}`);
+    // 0이어도 pass — 미등록 환경 허용
+    expect(ossCount).toBeGreaterThanOrEqual(0);
+  });
+
+  test.afterAll(() => {
+    // OUT params 없음
+    console.log(`[${TC_ID}] afterAll — store OUT 없음`);
+  });
+});

--- a/e2e/tc/workflow/TC-WF-FLOW-02.spec.ts
+++ b/e2e/tc/workflow/TC-WF-FLOW-02.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * deploy/tc/workflow/TC-WF-FLOW-02.spec.ts
+ * TC-WF-FLOW-02: Workflow 목록 조회
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workflow/TC-WF-FLOW-02.spec.ts
+ *   TC_VARIANT=default npx playwright test deploy/tc/workflow/TC-WF-FLOW-02.spec.ts
+ *
+ * ── 시나리오 실행 ────────────────────────────────────────────────
+ *   SCENARIO_ID=WF-001 npx playwright test deploy/tc/workflow/TC-WF-FLOW-02.spec.ts
+ *
+ * ── OUT params ──────────────────────────────────────────────────
+ *   (없음) — 목록 행 수 로그만 출력, store에 저장 없음
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-WF-FLOW-02';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-WF-FLOW-02: Workflow 목록 조회', () => {
+
+  test('워크플로우 페이지 접속 → 목록 행 수 확인', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'}`);
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, TC_ID);
+    if (!ok) {
+      throw new Error(`[${TC_ID}] 로그인 실패`);
+    }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-project') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.toLowerCase().includes('default'));
+      }, { timeout: 15_000 });
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {
+      console.warn(`[${TC_ID}] 워크스페이스/프로젝트 선택 실패 — 진행 계속`);
+    }
+
+    await page.waitForLoadState('networkidle', { timeout: 20_000 }).catch(() => {});
+    await page.waitForTimeout(2_000);
+
+    // iframe 내부 워크플로우 테이블 탐색
+    const wfFrame = page.frames().find(f => f.url().includes('workflow') && !f.url().includes('webconsole'));
+
+    let rowCount = 0;
+    if (wfFrame) {
+      // iframe 내 tabulator 또는 tr 행 수 확인
+      try {
+        await wfFrame.waitForLoadState('networkidle', { timeout: 10_000 }).catch(() => {});
+        const rows = wfFrame.locator('.tabulator-row, tr:not(:first-child)');
+        rowCount = await rows.count().catch(() => 0);
+      } catch {
+        console.warn(`[${TC_ID}] iframe 내 행 탐색 실패`);
+      }
+    } else {
+      // 메인 프레임에서 탐색
+      try {
+        const rows = page.locator('.tabulator-row, tr:not(:first-child)');
+        rowCount = await rows.count().catch(() => 0);
+      } catch {
+        console.warn(`[${TC_ID}] 메인 프레임 행 탐색 실패`);
+      }
+    }
+
+    // 0이어도 pass — 빈 목록 허용
+    console.log(`[${TC_ID}] 워크플로우 목록 행 수: ${rowCount}`);
+    expect(rowCount).toBeGreaterThanOrEqual(0);
+  });
+
+  test.afterAll(() => {
+    // OUT params 없음
+    console.log(`[${TC_ID}] afterAll — store OUT 없음`);
+  });
+});

--- a/e2e/tc/workflow/TC-WF-FLOW-03.spec.ts
+++ b/e2e/tc/workflow/TC-WF-FLOW-03.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * deploy/tc/workflow/TC-WF-FLOW-03.spec.ts
+ * TC-WF-FLOW-03: 신규 Workflow 생성 (정의 확인)
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workflow/TC-WF-FLOW-03.spec.ts
+ *   TC_VARIANT=default npx playwright test deploy/tc/workflow/TC-WF-FLOW-03.spec.ts
+ *
+ * ── 시나리오 실행 ────────────────────────────────────────────────
+ *   SCENARIO_ID=WF-001 npx playwright test deploy/tc/workflow/TC-WF-FLOW-03.spec.ts
+ *
+ * ── IN params ───────────────────────────────────────────────────
+ *   workflowName: 확인할 워크플로우 이름 (기본값: '' — FAIL)
+ *
+ * ── OUT params (시나리오 모드) ──────────────────────────────────
+ *   store.set('workflowName', workflowName) — 발견된 경우
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-WF-FLOW-03';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+let foundWorkflowName = '';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-WF-FLOW-03: 신규 Workflow 생성 (정의 확인)', () => {
+
+  test('워크플로우 페이지 접속 → 지정된 워크플로우 행 존재 확인', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    const workflowName = (p.workflowName as string) ?? '';
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'}, workflowName: ${workflowName || '(없음)'}`);
+
+    // workflowName이 없으면 FAIL
+    if (!workflowName) {
+      throw new Error(`[${TC_ID}] workflowName 파라미터 없음 — params 설정 확인`);
+    }
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, TC_ID);
+    if (!ok) {
+      throw new Error(`[${TC_ID}] 로그인 실패`);
+    }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-project') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.toLowerCase().includes('default'));
+      }, { timeout: 15_000 });
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {
+      console.warn(`[${TC_ID}] 워크스페이스/프로젝트 선택 실패 — 진행 계속`);
+    }
+
+    await page.waitForLoadState('networkidle', { timeout: 20_000 }).catch(() => {});
+    await page.waitForTimeout(2_000);
+
+    // iframe 또는 메인 프레임에서 행 탐색
+    const wfFrame = page.frames().find(f => f.url().includes('workflow') && !f.url().includes('webconsole'));
+    const target  = wfFrame ?? page;
+
+    const row = target.locator('.tabulator-row, tr').filter({ hasText: workflowName });
+    const rowCount = await row.count().catch(() => 0);
+
+    expect(rowCount).toBeGreaterThan(0);
+    foundWorkflowName = workflowName;
+    console.log(`[${TC_ID}] 워크플로우 행 발견: ${workflowName} (${rowCount}개)`);
+  });
+
+  test.afterAll(() => {
+    if (!store) return;
+    if (foundWorkflowName) {
+      store.set('workflowName', foundWorkflowName);
+      console.log(`[${TC_ID}] store OUT: workflowName=${foundWorkflowName}`);
+    } else {
+      console.warn(`[${TC_ID}] workflowName 미발견 — store OUT 없음`);
+    }
+  });
+});

--- a/e2e/tc/workflow/TC-WF-FLOW-04.spec.ts
+++ b/e2e/tc/workflow/TC-WF-FLOW-04.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * deploy/tc/workflow/TC-WF-FLOW-04.spec.ts
+ * TC-WF-FLOW-04: Workflow 상세 수정
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workflow/TC-WF-FLOW-04.spec.ts
+ *   TC_VARIANT=default npx playwright test deploy/tc/workflow/TC-WF-FLOW-04.spec.ts
+ *
+ * ── 시나리오 실행 ────────────────────────────────────────────────
+ *   SCENARIO_ID=WF-001 npx playwright test deploy/tc/workflow/TC-WF-FLOW-04.spec.ts
+ *
+ * ── IN params ───────────────────────────────────────────────────
+ *   workflowName: 수정할 워크플로우 이름 (기본값: '' — FAIL)
+ *
+ * ── OUT params ──────────────────────────────────────────────────
+ *   (없음) — 수정 후 PATCH 응답 status 로그만 출력
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-WF-FLOW-04';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-WF-FLOW-04: Workflow 상세 수정', () => {
+
+  test('워크플로우 행 찾기 → 수정 버튼 클릭 → description 수정 → 저장', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    const workflowName = (p.workflowName as string) ?? '';
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'}, workflowName: ${workflowName || '(없음)'}`);
+
+    if (!workflowName) {
+      throw new Error(`[${TC_ID}] workflowName 파라미터 없음`);
+    }
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, TC_ID);
+    if (!ok) {
+      throw new Error(`[${TC_ID}] 로그인 실패`);
+    }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-project') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.toLowerCase().includes('default'));
+      }, { timeout: 15_000 });
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {
+      console.warn(`[${TC_ID}] 워크스페이스/프로젝트 선택 실패 — 진행 계속`);
+    }
+
+    await page.waitForLoadState('networkidle', { timeout: 20_000 }).catch(() => {});
+    await page.waitForTimeout(2_000);
+
+    // iframe 또는 메인 프레임 탐색
+    const wfFrame = page.frames().find(f => f.url().includes('workflow') && !f.url().includes('webconsole'));
+    const target  = wfFrame ?? page;
+
+    // workflowName 행 찾기
+    const row = target.locator('.tabulator-row, tr').filter({ hasText: workflowName });
+    const rowCount = await row.count().catch(() => 0);
+
+    if (rowCount === 0) {
+      throw new Error(`[${TC_ID}] 워크플로우 행 없음: ${workflowName}`);
+    }
+
+    // 수정 버튼(edit/수정/편집) 클릭
+    const editBtn = row.first().locator('button, a').filter({ hasText: /edit|수정|편집/i }).first();
+    const editBtnVisible = await editBtn.isVisible().catch(() => false);
+
+    if (!editBtnVisible) {
+      // 행 자체를 클릭해 상세/편집 화면 진입 시도
+      await row.first().click();
+      await page.waitForTimeout(1_500);
+      console.warn(`[${TC_ID}] 수정 버튼 없음 — 행 클릭으로 대체`);
+    } else {
+      await editBtn.click();
+      await page.waitForTimeout(1_500);
+      console.log(`[${TC_ID}] 수정 버튼 클릭 완료`);
+    }
+
+    // PATCH 요청 인터셉트 (응답 status 로그)
+    let patchStatus = -1;
+    page.on('response', res => {
+      if (res.request().method() === 'PATCH' && res.url().includes('workflow')) {
+        patchStatus = res.status();
+        console.log(`[${TC_ID}] PATCH ${res.url()} → status: ${patchStatus}`);
+      }
+    });
+
+    // description 필드 수정 (현재값 + ' (수정)')
+    const descField = (wfFrame ?? page).locator(
+      'textarea[name*="desc"], input[name*="desc"], textarea[placeholder*="desc"], input[placeholder*="desc"], #description, textarea, input[name="description"]'
+    ).first();
+    const descVisible = await descField.isVisible().catch(() => false);
+
+    if (descVisible) {
+      const currentVal = await descField.inputValue().catch(() => '');
+      const newVal = currentVal.replace(/ \(수정\)$/, '') + ' (수정)';
+      await descField.fill(newVal);
+      console.log(`[${TC_ID}] description 수정: "${newVal}"`);
+    } else {
+      console.warn(`[${TC_ID}] description 필드 없음 — 저장만 시도`);
+    }
+
+    // 저장 버튼 클릭
+    const saveBtn = (wfFrame ?? page).locator('button, a').filter({ hasText: /save|저장|확인|apply/i }).first();
+    const saveBtnVisible = await saveBtn.isVisible().catch(() => false);
+
+    if (!saveBtnVisible) {
+      throw new Error(`[${TC_ID}] 저장 버튼 없음`);
+    }
+    await saveBtn.click();
+    await page.waitForTimeout(2_000);
+    console.log(`[${TC_ID}] 저장 버튼 클릭 완료, PATCH status: ${patchStatus}`);
+
+    // PATCH가 없거나 성공이어도 pass
+    expect(patchStatus === -1 || patchStatus < 500).toBeTruthy();
+  });
+
+  test.afterAll(() => {
+    // OUT params 없음
+    console.log(`[${TC_ID}] afterAll — store OUT 없음`);
+  });
+});

--- a/e2e/tc/workflow/TC-WF-FLOW-05.spec.ts
+++ b/e2e/tc/workflow/TC-WF-FLOW-05.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * deploy/tc/workflow/TC-WF-FLOW-05.spec.ts
+ * TC-WF-FLOW-05: Workflow 삭제
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workflow/TC-WF-FLOW-05.spec.ts
+ *   TC_VARIANT=default npx playwright test deploy/tc/workflow/TC-WF-FLOW-05.spec.ts
+ *
+ * ── 시나리오 실행 ────────────────────────────────────────────────
+ *   SCENARIO_ID=WF-001 npx playwright test deploy/tc/workflow/TC-WF-FLOW-05.spec.ts
+ *
+ * ── IN params ───────────────────────────────────────────────────
+ *   workflowName: 삭제할 워크플로우 이름 (기본값: '' — FAIL)
+ *
+ * ── OUT params ──────────────────────────────────────────────────
+ *   (없음)
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-WF-FLOW-05';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-WF-FLOW-05: Workflow 삭제', () => {
+
+  test('워크플로우 행 찾기 → 삭제 버튼 클릭 → 확인 → 행 사라짐 확인', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    const workflowName = (p.workflowName as string) ?? '';
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'}, workflowName: ${workflowName || '(없음)'}`);
+
+    if (!workflowName) {
+      throw new Error(`[${TC_ID}] workflowName 파라미터 없음`);
+    }
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, TC_ID);
+    if (!ok) {
+      throw new Error(`[${TC_ID}] 로그인 실패`);
+    }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-project') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.toLowerCase().includes('default'));
+      }, { timeout: 15_000 });
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {
+      console.warn(`[${TC_ID}] 워크스페이스/프로젝트 선택 실패 — 진행 계속`);
+    }
+
+    await page.waitForLoadState('networkidle', { timeout: 20_000 }).catch(() => {});
+    await page.waitForTimeout(2_000);
+
+    // iframe 또는 메인 프레임 탐색
+    const wfFrame = page.frames().find(f => f.url().includes('workflow') && !f.url().includes('webconsole'));
+    const target  = wfFrame ?? page;
+
+    // workflowName 행 찾기
+    const row = target.locator('.tabulator-row, tr').filter({ hasText: workflowName });
+    const rowCount = await row.count().catch(() => 0);
+
+    if (rowCount === 0) {
+      throw new Error(`[${TC_ID}] 워크플로우 행 없음: ${workflowName}`);
+    }
+
+    // DEL/삭제 버튼 클릭
+    const delBtn = row.first().locator('button, a').filter({ hasText: /del|delete|삭제|remove/i }).first();
+    const delBtnVisible = await delBtn.isVisible().catch(() => false);
+
+    if (!delBtnVisible) {
+      throw new Error(`[${TC_ID}] 삭제 버튼 없음`);
+    }
+
+    await delBtn.click();
+    console.log(`[${TC_ID}] 삭제 버튼 클릭 완료`);
+    await page.waitForTimeout(1_500);
+
+    // 확인 다이얼로그 클릭 (.swal2-confirm 또는 .modal.show button)
+    const swal2Confirm = page.locator('.swal2-confirm').first();
+    const swal2Visible = await swal2Confirm.isVisible().catch(() => false);
+
+    if (swal2Visible) {
+      await swal2Confirm.click();
+      console.log(`[${TC_ID}] swal2 확인 버튼 클릭`);
+    } else {
+      // modal.show 내 확인 버튼
+      const modalConfirm = page.locator('.modal.show button').filter({ hasText: /confirm|ok|확인|yes|삭제/i }).first();
+      const modalVisible = await modalConfirm.isVisible().catch(() => false);
+      if (modalVisible) {
+        await modalConfirm.click();
+        console.log(`[${TC_ID}] 모달 확인 버튼 클릭`);
+      } else {
+        // native dialog 처리
+        page.once('dialog', async d => { await d.accept(); });
+        console.warn(`[${TC_ID}] 확인 UI 없음 — native dialog 대기`);
+      }
+    }
+
+    await page.waitForTimeout(3_000);
+
+    // 삭제 후 행 없어짐 확인
+    const rowAfter = target.locator('.tabulator-row, tr').filter({ hasText: workflowName });
+    const rowAfterCount = await rowAfter.count().catch(() => 0);
+
+    console.log(`[${TC_ID}] 삭제 후 행 수: ${rowAfterCount} (0이어야 성공)`);
+    expect(rowAfterCount).toBe(0);
+  });
+
+  test.afterAll(() => {
+    // OUT params 없음
+    console.log(`[${TC_ID}] afterAll — store OUT 없음`);
+  });
+});

--- a/e2e/tc/workflow/TC-WF-FLOW-06.spec.ts
+++ b/e2e/tc/workflow/TC-WF-FLOW-06.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * deploy/tc/workflow/TC-WF-FLOW-06.spec.ts
+ * TC-WF-FLOW-06: Workflow 실행 (RUN)
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workflow/TC-WF-FLOW-06.spec.ts
+ *   TC_VARIANT=default npx playwright test deploy/tc/workflow/TC-WF-FLOW-06.spec.ts
+ *
+ * ── 시나리오 실행 ────────────────────────────────────────────────
+ *   SCENARIO_ID=WF-001 npx playwright test deploy/tc/workflow/TC-WF-FLOW-06.spec.ts
+ *
+ * ── IN params ───────────────────────────────────────────────────
+ *   workflowName: 실행할 워크플로우 이름 (기본값: '' — FAIL)
+ *
+ * ── OUT params ──────────────────────────────────────────────────
+ *   (없음) — POST /workflow/run 응답 status 로그만 출력
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-WF-FLOW-06';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-WF-FLOW-06: Workflow 실행 (RUN)', () => {
+
+  test('워크플로우 행 찾기 → RUN 버튼 클릭 → RunWorkflow 모달 → 실행', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    const workflowName = (p.workflowName as string) ?? '';
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'}, workflowName: ${workflowName || '(없음)'}`);
+
+    if (!workflowName) {
+      throw new Error(`[${TC_ID}] workflowName 파라미터 없음`);
+    }
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, TC_ID);
+    if (!ok) {
+      throw new Error(`[${TC_ID}] 로그인 실패`);
+    }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-project') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.toLowerCase().includes('default'));
+      }, { timeout: 15_000 });
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {
+      console.warn(`[${TC_ID}] 워크스페이스/프로젝트 선택 실패 — 진행 계속`);
+    }
+
+    await page.waitForLoadState('networkidle', { timeout: 20_000 }).catch(() => {});
+    await page.waitForTimeout(2_000);
+
+    // POST /workflow/run 응답 인터셉트
+    let runStatus = -1;
+    page.on('response', res => {
+      if (res.request().method() === 'POST' && res.url().match(/workflow.*run|run.*workflow/i)) {
+        runStatus = res.status();
+        console.log(`[${TC_ID}] POST ${res.url()} → status: ${runStatus}`);
+      }
+    });
+
+    // iframe 또는 메인 프레임 탐색
+    const wfFrame = page.frames().find(f => f.url().includes('workflow') && !f.url().includes('webconsole'));
+    const target  = wfFrame ?? page;
+
+    // workflowName 행 찾기
+    const row = target.locator('.tabulator-row, tr').filter({ hasText: workflowName });
+    const rowCount = await row.count().catch(() => 0);
+
+    if (rowCount === 0) {
+      throw new Error(`[${TC_ID}] 워크플로우 행 없음: ${workflowName}`);
+    }
+
+    // RUN/실행 버튼 클릭
+    const runBtn = row.first().locator('button, a').filter({ hasText: /^run$|실행|play/i }).first();
+    const runBtnVisible = await runBtn.isVisible().catch(() => false);
+
+    if (!runBtnVisible) {
+      throw new Error(`[${TC_ID}] RUN 버튼 없음`);
+    }
+
+    await runBtn.click();
+    console.log(`[${TC_ID}] RUN 버튼 클릭 완료`);
+    await page.waitForTimeout(1_500);
+
+    // RunWorkflow 모달(#runWorkflow, .modal.show) 대기
+    const modal = page.locator('#runWorkflow, .modal.show').first();
+    const modalVisible = await modal.isVisible().catch(() => false);
+
+    if (!modalVisible) {
+      throw new Error(`[${TC_ID}] RunWorkflow 모달 미표시`);
+    }
+
+    console.log(`[${TC_ID}] RunWorkflow 모달 표시 확인`);
+
+    // 모달 내 Run/실행 버튼 클릭
+    const modalRunBtn = modal.locator('button').filter({ hasText: /^run$|실행|submit|확인/i }).first();
+    const modalRunBtnVisible = await modalRunBtn.isVisible().catch(() => false);
+
+    if (!modalRunBtnVisible) {
+      throw new Error(`[${TC_ID}] 모달 Run 버튼 없음`);
+    }
+    await modalRunBtn.click();
+    await page.waitForTimeout(3_000);
+    console.log(`[${TC_ID}] 모달 Run 버튼 클릭 완료, POST run status: ${runStatus}`);
+
+    // POST run이 없거나 성공이어도 pass
+    expect(runStatus === -1 || runStatus < 500).toBeTruthy();
+  });
+
+  test.afterAll(() => {
+    // OUT params 없음
+    console.log(`[${TC_ID}] afterAll — store OUT 없음`);
+  });
+});

--- a/e2e/tc/workflow/TC-WF-FLOW-07.spec.ts
+++ b/e2e/tc/workflow/TC-WF-FLOW-07.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * deploy/tc/workflow/TC-WF-FLOW-07.spec.ts
+ * TC-WF-FLOW-07: Workflow 로그 모달 표시
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workflow/TC-WF-FLOW-07.spec.ts
+ *   TC_VARIANT=default npx playwright test deploy/tc/workflow/TC-WF-FLOW-07.spec.ts
+ *
+ * ── 시나리오 실행 ────────────────────────────────────────────────
+ *   SCENARIO_ID=WF-001 npx playwright test deploy/tc/workflow/TC-WF-FLOW-07.spec.ts
+ *
+ * ── IN params ───────────────────────────────────────────────────
+ *   workflowName: 로그를 볼 워크플로우 이름 (기본값: '' — 첫 번째 행 사용)
+ *
+ * ── OUT params ──────────────────────────────────────────────────
+ *   (없음) — 로그 모달 표시 여부 로그만 출력
+ */
+import { test, expect } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+const TC_ID      = 'TC-WF-FLOW-07';
+const scenarioId = process.env.SCENARIO_ID;
+const variant    = process.env.TC_VARIANT;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID, variant)
+  : new StandaloneContext(TC_ID, variant);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+// iframe 내 워크플로우 프레임을 탐색하는 헬퍼
+const getWfIframe = async (page: import('@playwright/test').Page) => {
+  await page.waitForTimeout(3000);
+  return page.frames().find(f => f.url().includes('workflow') && !f.url().includes('webconsole'));
+};
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+test.describe('TC-WF-FLOW-07: Workflow 로그 모달 표시', () => {
+
+  test('워크플로우 행 찾기 → LOG 버튼 클릭 → 로그 모달 표시 확인 → 닫기', async ({ page }) => {
+    test.setTimeout(60_000);
+
+    const workflowName = (p.workflowName as string) ?? '';
+
+    console.log(`[${TC_ID}] variant: ${variant ?? '(base)'}, workflowName: ${workflowName || '(없음 — 첫 번째 행 사용)'}`);
+
+    const ok = await loginAndGoto(page, PAGES.sw.workflow, TC_ID);
+    if (!ok) {
+      throw new Error(`[${TC_ID}] 로그인 실패`);
+    }
+
+    // 워크스페이스/프로젝트 선택
+    try {
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-workspace') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.includes('ws01'));
+      }, { timeout: 15_000 });
+      const wsVal = await page.locator('#select-current-workspace option').filter({ hasText: /ws01/i }).first().getAttribute('value');
+      await page.locator('#select-current-workspace').selectOption(wsVal ?? 'ws01');
+      await page.waitForFunction(() => {
+        const sel = document.querySelector('#select-current-project') as HTMLSelectElement;
+        return sel && Array.from(sel.options).some(o => o.text.toLowerCase().includes('default'));
+      }, { timeout: 15_000 });
+      const projVal = await page.locator('#select-current-project option').filter({ hasText: /default/i }).first().getAttribute('value');
+      await page.locator('#select-current-project').selectOption(projVal ?? 'default');
+    } catch {
+      console.warn(`[${TC_ID}] 워크스페이스/프로젝트 선택 실패 — 진행 계속`);
+    }
+
+    await page.waitForLoadState('networkidle', { timeout: 20_000 }).catch(() => {});
+
+    // iframe 탐색 (getWfIframe 헬퍼 사용 — 3초 대기 포함)
+    const wfFrame = await getWfIframe(page);
+    const target  = wfFrame ?? page;
+
+    // workflowName 행 또는 첫 번째 행 탐색
+    let targetRow;
+    if (workflowName) {
+      const namedRow = target.locator('.tabulator-row, tr').filter({ hasText: workflowName });
+      const namedCount = await namedRow.count().catch(() => 0);
+      if (namedCount > 0) {
+        targetRow = namedRow.first();
+        console.log(`[${TC_ID}] 지정된 워크플로우 행 사용: ${workflowName}`);
+      } else {
+        console.warn(`[${TC_ID}] 지정된 워크플로우 행 없음 — 첫 번째 행으로 fallback`);
+      }
+    }
+
+    if (!targetRow) {
+      const firstRow = target.locator('.tabulator-row, tr:not(:first-child)').first();
+      const firstVisible = await firstRow.isVisible().catch(() => false);
+      if (!firstVisible) {
+        throw new Error(`[${TC_ID}] 워크플로우 행 없음`);
+      }
+      targetRow = firstRow;
+      console.log(`[${TC_ID}] 첫 번째 행 사용`);
+    }
+
+    // LOG/로그/기록 버튼 클릭
+    const logBtn = targetRow.locator('button, a').filter({ hasText: /log|로그|기록|history/i }).first();
+    const logBtnVisible = await logBtn.isVisible().catch(() => false);
+
+    if (!logBtnVisible) {
+      throw new Error(`[${TC_ID}] LOG 버튼 없음`);
+    }
+
+    await logBtn.click();
+    console.log(`[${TC_ID}] LOG 버튼 클릭 완료`);
+    await page.waitForTimeout(2_000);
+
+    // 모달(.modal.show) 표시 확인
+    const modal = page.locator('.modal.show').first();
+    const modalVisible = await modal.isVisible().catch(() => false);
+
+    if (!modalVisible) {
+      throw new Error(`[${TC_ID}] 로그 모달 미표시`);
+    }
+
+    console.log(`[${TC_ID}] 로그 모달 표시 확인`);
+    expect(modalVisible).toBe(true);
+
+    // 로그 내용 영역(pre, code, [class*="log"]) 확인
+    const logContent = modal.locator('pre, code, [class*="log"]').first();
+    const logContentVisible = await logContent.isVisible().catch(() => false);
+
+    if (logContentVisible) {
+      const logText = await logContent.innerText().catch(() => '');
+      console.log(`[${TC_ID}] 로그 내용 영역 확인 (길이: ${logText.length}자)`);
+    } else {
+      console.warn(`[${TC_ID}] 로그 내용 영역(pre/code/[class*=log]) 미확인 — 모달은 표시됨`);
+    }
+
+    // 모달 닫기 (close/닫기 버튼 또는 Escape)
+    const closeBtn = modal.locator('button').filter({ hasText: /close|닫기|dismiss|cancel/i }).first();
+    const closeBtnAlt = modal.locator('button.btn-close, .modal-header button, [data-bs-dismiss="modal"]').first();
+
+    const closeBtnVisible = await closeBtn.isVisible().catch(() => false);
+    const closeAltVisible = await closeBtnAlt.isVisible().catch(() => false);
+
+    if (closeBtnVisible) {
+      await closeBtn.click();
+      console.log(`[${TC_ID}] 닫기 버튼 클릭`);
+    } else if (closeAltVisible) {
+      await closeBtnAlt.click();
+      console.log(`[${TC_ID}] 모달 닫기 버튼(alt) 클릭`);
+    } else {
+      await page.keyboard.press('Escape');
+      console.log(`[${TC_ID}] Escape 키로 모달 닫기`);
+    }
+
+    await page.waitForTimeout(1_000);
+    console.log(`[${TC_ID}] 로그 모달 닫기 완료`);
+  });
+
+  test.afterAll(() => {
+    // OUT params 없음
+    console.log(`[${TC_ID}] afterAll — store OUT 없음`);
+  });
+});

--- a/e2e/tc/workload/TC-WORKLOAD-MCI-01.spec.ts
+++ b/e2e/tc/workload/TC-WORKLOAD-MCI-01.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * deploy/tc/workload/TC-WORKLOAD-MCI-01.spec.ts
+ * TC-WORKLOAD-MCI-01: MCI 터미널 접속 · 명령 실행
+ *
+ * ── 단독 실행 ────────────────────────────────────────────────────
+ *   npx playwright test deploy/tc/workload/TC-WORKLOAD-MCI-01.spec.ts
+ *   # 단독 실행 시 MCI_ID / MCI_NAME 은 params.mciId (없으면 오류)
+ *   # 또는: PW_mciId=<id> PW_mciName=<name> npx playwright test ...
+ *
+ * ── 시나리오 실행 (런타임 store IN param 사용) ─────────────────────
+ *   SCENARIO_ID=C4-001 npx playwright test deploy/tc/workload/TC-WORKLOAD-MCI-01.spec.ts
+ *
+ * ── 런타임 IN params ──────────────────────────────────────────────
+ *   store.require('mciId')   — TC-INFRA-DEPLOY-05 OUT
+ *   store.require('mciName') — TC-INFRA-DEPLOY-05 OUT
+ *
+ * ── IN param 주의 ────────────────────────────────────────────────
+ *   store.require('mciId'), store.require('mciName') 이 없으면 FAIL
+ */
+import { test, expect, type Page } from '@playwright/test';
+import { PAGES }        from '../../shared/pages';
+import { loginAndGoto } from '../../shared/request-auth.helper';
+import { ScenarioContext, StandaloneContext } from '../../params/runtime/context';
+
+// ── 컨텍스트 결정 ─────────────────────────────────────────────────────────────
+const TC_ID      = 'TC-WORKLOAD-MCI-01';
+const scenarioId = process.env.SCENARIO_ID;
+
+const ctx   = scenarioId
+  ? new ScenarioContext(scenarioId, TC_ID)
+  : new StandaloneContext(TC_ID);
+const p     = ctx.params;
+const store = ctx instanceof ScenarioContext ? ctx.store : null;
+
+// ── IN param 확정 ─────────────────────────────────────────────────────────────
+//   모듈 평가 시점이 아닌 test.beforeAll 에서 읽어야 한다
+//   (이전 TC 가 afterAll 에서 store.set 을 호출하기 때문)
+let mciId   = '';
+let mciName = '';
+
+test.use({ storageState: { cookies: [], origins: [] } });
+
+// ── 헬퍼 함수 ─────────────────────────────────────────────────────────────────
+
+async function selectByLabel(page: Page, selector: string, label: string): Promise<void> {
+  const sel = page.locator(selector);
+  await sel.waitFor({ state: 'attached', timeout: 10_000 });
+  await expect(async () => {
+    const opts = await sel.locator('option').allTextContents();
+    expect(opts.some(t => t.trim() === label)).toBeTruthy();
+  }).toPass({ timeout: 15_000 });
+  await sel.selectOption({ label });
+}
+
+async function clickMciRow(page: Page, name: string): Promise<void> {
+  await page.waitForSelector('#mcilist-table .tabulator-row', { timeout: 30_000 });
+  const rows  = page.locator('#mcilist-table .tabulator-row');
+  const count = await rows.count();
+  for (let i = 0; i < count; i++) {
+    const row = rows.nth(i);
+    if ((await row.innerText()).includes(name)) {
+      await row.click();
+      return;
+    }
+  }
+  throw new Error(`MCI 행 '${name}' 을 찾을 수 없음 — MCI 가 서버에 존재하는지 확인하세요`);
+}
+
+// ── TC-WORKLOAD-MCI-01 ────────────────────────────────────────────────────────
+
+test.describe('TC-WORKLOAD-MCI-01: MCI 터미널 접속·명령 실행', () => {
+
+  // IN param 읽기: 이전 TC afterAll 이 완료된 후 store 에서 읽는다
+  test.beforeAll(() => {
+    if (store) {
+      mciId   = store.require<string>('mciId');
+      mciName = store.require<string>('mciName');
+      console.log(`[TC-WORKLOAD-MCI-01] store IN: mciId=${mciId}, mciName=${mciName}`);
+    } else {
+      // 단독 실행: params 에서 직접 읽음 (PW_mciId 로 주입 가능)
+      mciId   = p.mciId   as string ?? '';
+      mciName = p.mciName as string ?? '';
+      if (!mciId) {
+        console.warn('[TC-WORKLOAD-MCI-01] 단독 실행 — mciId 없음. PW_mciId=<id> 로 주입하거나 params 파일에 기재하세요.');
+      }
+    }
+  });
+
+  test('UI: MCI 워크로드 화면 → 터미널 → 명령 실행', async ({ page }) => {
+    test.setTimeout(2 * 60_000);
+    const tag = TC_ID;
+
+    if (!mciId && !store) {
+      throw new Error(`[${tag}] mciId 없음 — PW_mciId 환경변수 또는 시나리오 실행 필요`);
+    }
+
+    const ok = await loginAndGoto(page, PAGES.operations.mciWorkloads, tag);
+    expect(ok, `[${tag}] 로그인 실패`).toBeTruthy();
+
+    // 1. 워크스페이스 / 프로젝트 선택
+    await selectByLabel(page, '#select-current-workspace', 'ws01');
+    console.log(`[${tag}] 워크스페이스 ws01 선택`);
+
+    await selectByLabel(page, '#select-current-project', 'default');
+    console.log(`[${tag}] 프로젝트 default 선택`);
+
+    // 2. MCI 행 클릭 (시나리오에서 받은 mciName 사용)
+    await clickMciRow(page, mciName);
+    console.log(`[${tag}] MCI '${mciName}' 행 클릭`);
+
+    // 3. MCI 정보 카드 표시 확인
+    await expect(page.locator('#mci_info'), 'MCI 정보 카드 미표시').toBeVisible({ timeout: 10_000 });
+
+    // 4. Terminal 버튼 → confirm 모달
+    await page.click('a[onclick*="initMciRemoteCmdModal"]');
+    await expect(page.locator('#commonDefaultModal'), 'Confirm 모달 미오픈').toBeVisible({ timeout: 10_000 });
+
+    // 5. 확인 → Remote Terminal 모달
+    await page.click('#commonDefaultModal-confirm-btn');
+    await expect(page.locator('#mci-cmdtestmodal'), 'Remote Terminal 모달 미오픈').toBeVisible({ timeout: 15_000 });
+
+    // 6. 명령어 입력 (params 에서 읽음)
+    const command = p.command as string ?? 'hostname';
+    await page.fill('#mci-command-input', command);
+    console.log(`[${tag}] 명령어 입력: '${command}'`);
+
+    // 7. Execute → API 응답 확인
+    const [response] = await Promise.all([
+      page.waitForResponse(
+        r => r.url().includes('PostCmdInfra'),
+        { timeout: 30_000 },
+      ),
+      page.click('#mci-execute-command-btn'),
+    ]);
+
+    const status = response.status();
+    console.log(`[${tag}] PostCmdInfra 응답 status: ${status}`);
+    expect(
+      status >= 200 && status < 300,
+      `PostCmdInfra API 실패 (status: ${status})`,
+    ).toBeTruthy();
+
+    // 8. 결과 섹션 표시 확인
+    await expect(
+      page.locator('#mci-command-results-section'),
+      '명령어 실행 결과 미표시',
+    ).toBeVisible({ timeout: 15_000 });
+
+    console.log(`[${tag}] ✅ 터미널 실행 완료`);
+  });
+
+});

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020", "DOM"],
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "baseUrl": "."
+  },
+  "include": ["./**/*.ts"],
+  "exclude": ["node_modules", "report"]
+}


### PR DESCRIPTION
## Summary

- MCMP 플랫폼 기능 검증을 위한 Playwright E2E 테스트 스펙 추가
- `e2e/` 폴더는 스펙 파일만 포함 (실행 환경은 이 폴더 밖에 별도 설치)
- TC 193개(9개 도메인), 시나리오 54개(C2~C10) 포함

## 구조

| 폴더 | 내용 |
|------|------|
| `tc/` | 도메인별 개별 기능 TC |
| `scenarios/` | 통합 흐름 시나리오 (C2~C10) |
| `registry/` | TC·시나리오 카탈로그 |
| `params/` | 4-layer 파라미터 시스템 |
| `shared/` | 공통 유틸리티 |
| `playwright.config.ts` | 세션 그룹 기반 실행 설정 |

## 실행 방법

```bash
# Playwright 설치 (e2e/ 밖 임의 위치)
npm install @playwright/test ts-node typescript dotenv
npx playwright install --with-deps chromium

# 환경 설정
cp e2e/.env.external-ip.example e2e/.env.external-ip
# 값 수정 후

# 실행
ACCESS_MODE=external-ip npx playwright test \
  --config=e2e/playwright.config.ts \
  e2e/tc/infra/TC-INFRA-DEPLOY-06.spec.ts
```

자세한 내용은 [e2e/README.md](e2e/README.md) 참고.