### PR TITLE
fix: handle influx init-exit-restart so docker compose up does not abort

### DIFF
--- a/conf/docker/conf/mc-observability/influxdb/influxdb_init/init.sh
+++ b/conf/docker/conf/mc-observability/influxdb/influxdb_init/init.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-influx -execute "CREATE DATABASE insight"
-influx -execute "CREATE DATABASE downsampling"

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -1189,10 +1189,10 @@ services:
         condition: service_healthy
       mc-observability-infra:
         condition: service_healthy
-      mc-observability-influx:
-        condition: service_healthy
-      mc-observability-influx-2:
-        condition: service_healthy
+      mc-observability-influx-ready:
+        condition: service_completed_successfully
+      mc-observability-influx-2-ready:
+        condition: service_completed_successfully
       mc-observability-loki:
         condition: service_healthy
       mc-observability-maria:
@@ -1423,6 +1423,39 @@ services:
       retries: 30
       start_period: 120s
 
+  # Wait containers: poll until each influx instance is healthy, then exit 0.
+  # Dependent services use service_completed_successfully on these instead of
+  # service_healthy on influx directly, so they survive influx's init-exit-restart cycle.
+  mc-observability-influx-ready:
+    image: busybox:stable
+    container_name: mc-observability-influx-ready
+    restart: "no"
+    command:
+      - sh
+      - -c
+      - "until wget -qO /dev/null http://mc-observability-influx:8086/health 2>/dev/null; do sleep 3; done"
+    init: true
+    networks:
+      - mc-observability-network
+    depends_on:
+      mc-observability-influx:
+        condition: service_started
+
+  mc-observability-influx-2-ready:
+    image: busybox:stable
+    container_name: mc-observability-influx-2-ready
+    restart: "no"
+    command:
+      - sh
+      - -c
+      - "until wget -qO /dev/null http://mc-observability-influx-2:8086/health 2>/dev/null; do sleep 3; done"
+    init: true
+    networks:
+      - mc-observability-network
+    depends_on:
+      mc-observability-influx-2:
+        condition: service_started
+
 ##### Remove annotations if data inquiry is required with chronograf during development phase #####
 #  mc-observability-chronograf:
 #    image: chronograf:1.9.4
@@ -1589,8 +1622,8 @@ services:
     depends_on:
       mc-observability-maria:
         condition: service_healthy
-      mc-observability-influx:
-        condition: service_healthy
+      mc-observability-influx-ready:
+        condition: service_completed_successfully
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:9001/readyz" ]
       interval: 1m
@@ -1710,8 +1743,8 @@ services:
         published: ${MC_OBSERVABILITY_MCP_INFLUX_PORT}
         protocol: tcp
     depends_on:
-      mc-observability-influx:
-        condition: service_healthy
+      mc-observability-influx-ready:
+        condition: service_completed_successfully
     environment:
       - TZ=Asia/Seoul
       - INFLUXDB_URL=http://mc-observability-influx:8086


### PR DESCRIPTION
## Summary

커스텀 `mc-observability-influx` 이미지가 첫 번째 DB init 직후 프로세스를 종료하고 Docker가 재시작하는 구조입니다. Docker Compose는 `service_healthy` 의존 컨테이너가 재시작/종료하는 순간을 실패로 보고 `up` 전체를 중단합니다.

### 변경 사항

- **`init.sh` 삭제**: auth 없이 `CREATE DATABASE`를 실행해 `INFLUXDB_HTTP_AUTH_ENABLED=true` 환경에서 인증 오류를 유발, 컨테이너 종료의 원인이 됨. `init-database.sh`가 동일 DB(`insight`, `downsampling`)를 auth 포함으로 이미 생성하므로 완전히 중복
- **`mc-observability-influx-ready` / `mc-observability-influx-2-ready` 추가**: busybox 컨테이너가 influx `/health` 엔드포인트를 폴링, 재시작 구간을 통과해 healthy 확인 후 exit 0
- **의존성 변경** (3곳): `mc-observability-manager`, `mc-observability-insight`, `mc-observability-mcp-influx`의 influx 의존성을 `service_healthy` → ready 컨테이너 `service_completed_successfully`로 교체

## Changed Files

- `conf/docker/docker-compose.yaml`
- `conf/docker/conf/mc-observability/influxdb/influxdb_init/init.sh` (삭제)