### PR TITLE
Bump cb-spider to 0.12.34 and cb-tumblebug to 0.12.24

### DIFF
--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
 ##### MC-INFRA-CONNECTOR #########################################################################################################################
 
   mc-infra-connector:
-    image: cloudbaristaorg/cb-spider:0.12.33
+    image: cloudbaristaorg/cb-spider:0.12.34
     pull_policy: missing
     container_name: mc-infra-connector
     restart: unless-stopped
@@ -56,7 +56,7 @@ services:
 ##### MC-INFRA-MANAGER #########################################################################################################################
 
   mc-infra-manager:
-    image: cloudbaristaorg/cb-tumblebug:0.12.23
+    image: cloudbaristaorg/cb-tumblebug:0.12.24
     container_name: mc-infra-manager
     restart: unless-stopped
     pull_policy: missing


### PR DESCRIPTION
## Summary
- mc-infra-connector: cloudbaristaorg/cb-spider 0.12.33 → 0.12.34
- mc-infra-manager: cloudbaristaorg/cb-tumblebug 0.12.23 → 0.12.24

## Test plan
- [ ] `./mcc infra update -s mc-infra-connector` confirmed healthy
- [ ] `./mcc infra update -s mc-infra-manager` confirmed healthy