### PR TITLE
[feat]: align admin-cli IAM setup with permission.yaml seed

### DIFF
--- a/conf/docker/conf/mc-iam-manager/.env
+++ b/conf/docker/conf/mc-iam-manager/.env
@@ -18,7 +18,12 @@ MC_IAM_MANAGER_USE_TICKET_VALID=true # [true|false]
 
 MC_ADMIN_CLI_APIYAML=https://raw.githubusercontent.com/m-cmp/mc-admin-cli/refs/heads/main/conf/api.yaml
 MC_WEB_CONSOLE_MENUYAML=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_resources.yaml
+# Legacy CSV role-menu seed (deprecated; YAML resolver ignores non-.yaml URLs)
 MC_WEB_CONSOLE_MENU_PERMISSIONS=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_permissions.csv
+# YAML role-menu seed (prefer this over CSV for new installs)
+# Leave empty to use container asset/menu/permission.yaml (compose mount)
+# MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML=https://...
+MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML=
 
 
 MC_IAM_MANAGER_PLATFORMADMIN_ID=mcmp

--- a/conf/docker/conf/mc-iam-manager/.env.setup
+++ b/conf/docker/conf/mc-iam-manager/.env.setup
@@ -1,6 +1,8 @@
 ## MC-IAM-Manager Service Environment Variables
 ## Injected into container runtime via env_file (supplements docker compose environment: block)
 ## Generated from .env.setup — be sure to change passwords and secrets in production
+## permission.yaml: conf bundle + compose mount to /app/asset/menu/permission.yaml,
+## or set MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML to a remote YAML URL
 
 # Basic service configuration
 # MC_IAM_MANAGER_DOMAIN: Internal Docker container name — differs from PUBLIC_DOMAIN, do not change
@@ -16,7 +18,12 @@ MC_IAM_MANAGER_USE_TICKET_VALID=true
 
 MC_ADMIN_CLI_APIYAML=https://raw.githubusercontent.com/m-cmp/mc-admin-cli/refs/heads/main/conf/api.yaml
 MC_WEB_CONSOLE_MENUYAML=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_resources.yaml
+# Legacy CSV role-menu seed (deprecated; YAML resolver ignores non-.yaml URLs)
 MC_WEB_CONSOLE_MENU_PERMISSIONS=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_permissions.csv
+# YAML role-menu seed (prefer this over CSV for new installs)
+# Leave empty to use container asset/menu/permission.yaml (compose mount)
+# MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML=https://...
+MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML=
 
 # Platform administrator
 MC_IAM_MANAGER_PLATFORMADMIN_ID=mcmp
@@ -48,6 +55,8 @@ MC_IAM_MANAGER_DATABASE_URL=postgres://mciamdbadmin:mciamdbpassword@mc-iam-manag
 
 # Keycloak server
 MC_IAM_MANAGER_KEYCLOAK_DOMAIN=mc-iam-manager-kc
+# Access token TTL (seconds). mc-web-console proactive refresh is 5 minutes — keep this above 300.
+MC_IAM_MANAGER_ACCESS_TOKEN_LIFESPAN=1800
 MC_IAM_MANAGER_KEYCLOAK_PORT=8080
 MC_IAM_MANAGER_KEYCLOAK_HOST=http://mc-iam-manager-kc:8080/auth
 

--- a/conf/docker/conf/mc-iam-manager/1_setup_auto.sh
+++ b/conf/docker/conf/mc-iam-manager/1_setup_auto.sh
@@ -42,6 +42,15 @@ auto_setup() {
         return 1
     fi
     echo "✓ Menu data initialized successfully"
+
+    # 4-1. Role-menu permissions from YAML (after menus; fail-fast if IAM lacks YAML API)
+    echo "Step 4-1: Initializing role-menu permissions from YAML..."
+    init_menu_permissions
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Role-menu permission (YAML) initialization failed"
+        return 1
+    fi
+    echo "✓ Role-menu permissions initialized successfully"
     
     # 5. API resource data initialization
     echo "Step 5: Initializing API resources..."
@@ -309,6 +318,46 @@ init_menu() {
     fi
     
     echo "Menu data initialized"
+    return 0
+}
+
+# Seed role-menu mappings via YAML API.
+# Always call without filePath: IAM resolvePermissionSeedPath uses
+# MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML (if set) or mounted
+# /app/asset/menu/permission.yaml. Do not pass post-init ./permission.yaml
+# as filePath — that path is not visible inside the IAM container.
+init_menu_permissions() {
+    echo "Initializing role-menu permissions from YAML..."
+
+    url="$MC_IAM_MANAGER_HOST/api/setup/initial-role-menu-permission-yaml"
+    echo "Calling YAML permission seed without filePath (server resolvePermissionSeedPath)"
+    http_and_body=$(curl -s -w "\n%{http_code}" -X GET \
+        --header "Authorization: Bearer $MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN" \
+        --header 'Content-Type: application/json' \
+        "$url")
+
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Failed to call initial-role-menu-permission-yaml"
+        return 1
+    fi
+
+    http_code=$(printf '%s\n' "$http_and_body" | tail -n1)
+    response=$(printf '%s\n' "$http_and_body" | sed '$d')
+
+    echo "Menu permission (YAML) initialization response (HTTP $http_code): $response"
+
+    if [ "$http_code" != "200" ]; then
+        echo "ERROR: Menu permission (YAML) initialization failed (HTTP $http_code)"
+        echo "Ensure IAM image includes YAML seed API and permission.yaml is mounted."
+        return 1
+    fi
+
+    if echo "$response" | jq -e '.error' > /dev/null 2>&1; then
+        echo "ERROR: Menu permission (YAML) initialization failed"
+        return 1
+    fi
+
+    echo "Role-menu permissions initialized from YAML"
     return 0
 }
 

--- a/conf/docker/conf/mc-iam-manager/1_setup_manual.sh
+++ b/conf/docker/conf/mc-iam-manager/1_setup_manual.sh
@@ -92,6 +92,42 @@ init_menu() {
     echo "Menu data initialized"
 }
 
+# Seed role-menu mappings via YAML API (no filePath — IAM uses mounted asset or YAML env URL).
+init_menu_permissions() {
+    echo "Initializing role-menu permissions from YAML..."
+
+    url="$MC_IAM_MANAGER_HOST/api/setup/initial-role-menu-permission-yaml"
+    echo "Calling YAML permission seed without filePath (server resolvePermissionSeedPath)"
+    http_and_body=$(curl -s -w "\n%{http_code}" -X GET \
+        --header "Authorization: Bearer $MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN" \
+        --header 'Content-Type: application/json' \
+        "$url")
+
+    if [ $? -ne 0 ]; then
+        echo "ERROR: Failed to call initial-role-menu-permission-yaml"
+        return 1
+    fi
+
+    http_code=$(printf '%s\n' "$http_and_body" | tail -n1)
+    response=$(printf '%s\n' "$http_and_body" | sed '$d')
+
+    echo "Menu permission (YAML) initialization response (HTTP $http_code): $response"
+
+    if [ "$http_code" != "200" ]; then
+        echo "ERROR: Menu permission (YAML) initialization failed (HTTP $http_code)"
+        echo "Ensure IAM image includes YAML seed API and permission.yaml is mounted."
+        return 1
+    fi
+
+    if echo "$response" | jq -e '.error' > /dev/null 2>&1; then
+        echo "ERROR: Menu permission (YAML) initialization failed"
+        return 1
+    fi
+
+    echo "Role-menu permissions initialized from YAML"
+    return 0
+}
+
 init_api_resources() {
     echo "Initializing API resources..."
     wget -q -O ./api.yaml "$MC_ADMIN_CLI_APIYAML"
@@ -223,7 +259,8 @@ while true; do
     echo "1. Init Platform And PlatformAdmin"
     echo "2. PlatformAdmin Login"
     echo "3. Init Role Data"
-    echo "4. Init Menu Data"
+    echo "4. Init Menu Data (+ role-menu YAML permissions)"
+    echo "4a. Init Menu Role Permissions (YAML) (re-seed only)"
     echo "5. Init API Resource Data"
     echo "6. Init Cloud Resource Data"
     echo "7. Map API-Cloud Resources"
@@ -259,6 +296,15 @@ while true; do
                 echo "Current token value: '$MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN'"
             else
                 init_menu
+                init_menu_permissions
+            fi
+            ;;
+        4a)
+            if [ -z "$MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN" ]; then
+                echo "Please login first (option 2)"
+                echo "Current token value: '$MC_IAM_MANAGER_PLATFORMADMIN_ACCESSTOKEN'"
+            else
+                init_menu_permissions
             fi
             ;;
         5)

--- a/conf/docker/conf/mc-iam-manager/permission.yaml
+++ b/conf/docker/conf/mc-iam-manager/permission.yaml
@@ -1,0 +1,130 @@
+# asset/menu/permission.yaml
+# Role-centric permissions: permissions → role → menus | operations | csps
+# - menus: mcmp_menus.id 목록 (역할별 접근 가능 메뉴)
+# - operations: (reserved) framework/API operation 권한 ID — 향후 시드
+# - csps: (reserved) CSP 관련 권한/역할 키 — 향후 시드
+# Source: permission.csv invert + remote menu ID remaps (2026-07-15)
+# Bundled for admin-cli: compose mounts to /app/asset/menu/permission.yaml
+permissions:
+  - role: admin
+    menus:
+      - operations
+      - manage
+      - workspaces
+      - projects
+      - projectboard
+      - members
+      - roles
+      - csproles
+      - workloads
+      - mciworkloads
+      - pmkworkloads
+      - workflows
+      - swcatalogs
+      - mcdatamanager
+      - datamigrations
+      - generateobjectstorage
+      - generaterdb
+      - analytics
+      - costanalysis
+      - observability
+      - settings
+      - accountnaccess
+      - organizations
+      - companyinfo
+      - users
+      - groups
+      - approvals
+      - accesscontrols
+      - menus
+      - environment
+      - cloudsps
+      - cloudoverview
+      - regions
+      - connections
+      - clouddrivers
+      - credentials
+      - cspaccounts
+      - cloudresources
+      - serverspecs
+      - specs
+      - images
+      - serverimages
+      - networks
+      - securitygroups
+      - securitys
+      - myimages
+      - disks
+      - sshkeys
+      - csp
+      - cspschedule
+      - resourcesync
+      - cloudrescatalogs
+      - workspacessettings
+      - allocatedprojects
+      - sharemembers
+      - allocaterolesws
+    operations: []
+    csps: []
+
+  - role: billadmin
+    menus:
+      - operations
+      - manage
+      - workloads
+      - mciworkloads
+      - analytics
+      - costanalysis
+    operations: []
+    csps: []
+
+  - role: billviewer
+    menus:
+      - operations
+      - analytics
+      - costanalysis
+    operations: []
+    csps: []
+
+  - role: operator
+    menus:
+      - operations
+      - manage
+      - workloads
+      - mciworkloads
+      - pmkworkloads
+      - workflows
+      - swcatalogs
+      - mcdatamanager
+      - datamigrations
+      - generateobjectstorage
+      - generaterdb
+      - analytics
+      - observability
+      - settings
+      - environment
+      - cloudsps
+      - cloudoverview
+      - regions
+      - cloudresources
+      - specs
+      - images
+      - networks
+      - securitys
+      - myimages
+      - disks
+      - sshkeys
+      - cloudrescatalogs
+    operations: []
+    csps: []
+
+  - role: viewer
+    menus:
+      - operations
+      - analytics
+      - observability
+      - settings
+      - environment
+      - cloudrescatalogs
+    operations: []
+    csps: []

--- a/conf/docker/docker-compose.yaml
+++ b/conf/docker/docker-compose.yaml
@@ -268,6 +268,8 @@ services:
       - ./conf/mc-iam-manager/.env
     volumes:
       - ./tool/mcc:/app/tool/mcc
+      # Role-menu seed overlay (SSOT bundle; post-init calls YAML API without filePath)
+      - ./conf/mc-iam-manager/permission.yaml:/app/asset/menu/permission.yaml:ro
     healthcheck:
       test: [ "CMD", "/app/tool/mcc", "rest", "get", "http://${MC_IAM_MANAGER_DOMAIN}:${MC_IAM_MANAGER_PORT}/readyz" ]
       <<: *default-health-check


### PR DESCRIPTION
## Summary
- Bundle `conf/docker/conf/mc-iam-manager/permission.yaml` as the role-menu seed SSOT and mount it into the IAM container at `/app/asset/menu/permission.yaml:ro`.
- Add `MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML` to `.env` / `.env.setup` (empty = use mounted asset; optional remote YAML URL override).
- Update `1_setup_auto.sh` / `1_setup_manual.sh` with Step 4-1 / menu 4+4a calling `GET .../initial-role-menu-permission-yaml` **without** `filePath` so IAM resolves via env or mounted asset.

## Prerequisite
- IAM image must include the YAML seed API (`initial-role-menu-permission-yaml`) and permission.yaml mount support.

## Out of scope
- nginx changes
- bulk `api.yaml` copy behavior

## Test plan
- [ ] Compose brings up IAM with `permission.yaml` mounted read-only
- [ ] Run auto setup: Step 4-1 succeeds (YAML seed, no filePath)
- [ ] Run manual setup menu 4 / 4a for role-menu YAML re-seed
- [ ] Confirm optional `MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML` URL still overrides when set