### PR TITLE
[refactor]: point MENU_PERMISSIONS env to permission.yaml

### DIFF
--- a/conf/docker/.env.setup
+++ b/conf/docker/.env.setup
@@ -79,7 +79,8 @@ MC_IAM_MANAGER_USE_TICKET_VALID=true # [true|false]
 
 MC_ADMIN_CLI_APIYAML=https://raw.githubusercontent.com/m-cmp/mc-admin-cli/refs/heads/main/conf/api.yaml
 MC_WEB_CONSOLE_MENUYAML=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_resources.yaml
-MC_WEB_CONSOLE_MENU_PERMISSIONS=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_permissions.csv
+# YAML role-menu permission seed (path or remote URL); IAM env_file prefers conf/mc-iam-manager/.env
+MC_WEB_CONSOLE_MENU_PERMISSIONS=asset/menu/permission.yaml
 
 
 MC_IAM_MANAGER_PLATFORMADMIN_ID=mcmp

--- a/conf/docker/conf/mc-iam-manager/.env
+++ b/conf/docker/conf/mc-iam-manager/.env
@@ -18,12 +18,9 @@ MC_IAM_MANAGER_USE_TICKET_VALID=true # [true|false]
 
 MC_ADMIN_CLI_APIYAML=https://raw.githubusercontent.com/m-cmp/mc-admin-cli/refs/heads/main/conf/api.yaml
 MC_WEB_CONSOLE_MENUYAML=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_resources.yaml
-# Legacy CSV role-menu seed (deprecated; YAML resolver ignores non-.yaml URLs)
-MC_WEB_CONSOLE_MENU_PERMISSIONS=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_permissions.csv
-# YAML role-menu seed (prefer this over CSV for new installs)
-# Leave empty to use container asset/menu/permission.yaml (compose mount)
-# MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML=https://...
-MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML=
+# YAML role-menu permission seed (path or remote URL).
+# Default: conf bundle + compose mount at /app/asset/menu/permission.yaml
+MC_WEB_CONSOLE_MENU_PERMISSIONS=asset/menu/permission.yaml
 
 
 MC_IAM_MANAGER_PLATFORMADMIN_ID=mcmp

--- a/conf/docker/conf/mc-iam-manager/.env.setup
+++ b/conf/docker/conf/mc-iam-manager/.env.setup
@@ -2,7 +2,7 @@
 ## Injected into container runtime via env_file (supplements docker compose environment: block)
 ## Generated from .env.setup — be sure to change passwords and secrets in production
 ## permission.yaml: conf bundle + compose mount to /app/asset/menu/permission.yaml,
-## or set MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML to a remote YAML URL
+## or set MC_WEB_CONSOLE_MENU_PERMISSIONS to a path or remote YAML URL
 
 # Basic service configuration
 # MC_IAM_MANAGER_DOMAIN: Internal Docker container name — differs from PUBLIC_DOMAIN, do not change
@@ -18,12 +18,9 @@ MC_IAM_MANAGER_USE_TICKET_VALID=true
 
 MC_ADMIN_CLI_APIYAML=https://raw.githubusercontent.com/m-cmp/mc-admin-cli/refs/heads/main/conf/api.yaml
 MC_WEB_CONSOLE_MENUYAML=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_resources.yaml
-# Legacy CSV role-menu seed (deprecated; YAML resolver ignores non-.yaml URLs)
-MC_WEB_CONSOLE_MENU_PERMISSIONS=https://raw.githubusercontent.com/m-cmp/mc-web-console/refs/heads/main/conf/webconsole_menu_permissions.csv
-# YAML role-menu seed (prefer this over CSV for new installs)
-# Leave empty to use container asset/menu/permission.yaml (compose mount)
-# MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML=https://...
-MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML=
+# YAML role-menu permission seed (path or remote URL).
+# Default: conf bundle + compose mount at /app/asset/menu/permission.yaml
+MC_WEB_CONSOLE_MENU_PERMISSIONS=asset/menu/permission.yaml
 
 # Platform administrator
 MC_IAM_MANAGER_PLATFORMADMIN_ID=mcmp

--- a/conf/docker/conf/mc-iam-manager/1_setup_auto.sh
+++ b/conf/docker/conf/mc-iam-manager/1_setup_auto.sh
@@ -323,7 +323,7 @@ init_menu() {
 
 # Seed role-menu mappings via YAML API.
 # Always call without filePath: IAM resolvePermissionSeedPath uses
-# MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML (if set) or mounted
+# MC_WEB_CONSOLE_MENU_PERMISSIONS (if set and .yaml/.yml) or mounted
 # /app/asset/menu/permission.yaml. Do not pass post-init ./permission.yaml
 # as filePath — that path is not visible inside the IAM container.
 init_menu_permissions() {

--- a/conf/docker/conf/mc-iam-manager/1_setup_manual.sh
+++ b/conf/docker/conf/mc-iam-manager/1_setup_manual.sh
@@ -92,7 +92,8 @@ init_menu() {
     echo "Menu data initialized"
 }
 
-# Seed role-menu mappings via YAML API (no filePath — IAM uses mounted asset or YAML env URL).
+# Seed role-menu mappings via YAML API (no filePath — IAM uses
+# MC_WEB_CONSOLE_MENU_PERMISSIONS or mounted asset/menu/permission.yaml).
 init_menu_permissions() {
     echo "Initializing role-menu permissions from YAML..."
 


### PR DESCRIPTION
## Summary
- Set `MC_WEB_CONSOLE_MENU_PERMISSIONS=asset/menu/permission.yaml` in IAM docker env samples
- Remove `MC_WEB_CONSOLE_MENU_PERMISSIONS_YAML` entirely
- Align `conf/docker/.env.setup` and setup script comments with the shared env key
