### PR TITLE
chore: rename mci/pmk workload menu id and label

### DIFF
--- a/conf/docker/conf/mc-iam-manager/permission.yaml
+++ b/conf/docker/conf/mc-iam-manager/permission.yaml
@@ -17,8 +17,8 @@ permissions:
       - roles
       - csproles
       - workloads
-      - mciworkloads
-      - pmkworkloads
+      - infraworkloads
+      - k8sworkloads
       - workflows
       - swcatalogs
       - mcdatamanager
@@ -72,7 +72,7 @@ permissions:
       - operations
       - manage
       - workloads
-      - mciworkloads
+      - infraworkloads
       - analytics
       - costanalysis
     operations: []
@@ -91,8 +91,8 @@ permissions:
       - operations
       - manage
       - workloads
-      - mciworkloads
-      - pmkworkloads
+      - infraworkloads
+      - k8sworkloads
       - workflows
       - swcatalogs
       - mcdatamanager

--- a/conf/docker/menu.yaml
+++ b/conf/docker/menu.yaml
@@ -280,17 +280,17 @@ menus:
     priority: 2
     menunumber: 1750
 
-  - id: mciworkloads
+  - id: infraworkloads
     parentid: workloads
-    displayname: MCI Workloads
+    displayname: Infra Workloads
     restype: menu
     isaction: true
     priority: 2
     menunumber: 1760
 
-  - id: pmkworkloads
+  - id: k8sworkloads
     parentid: workloads
-    displayname: PMK Workloads
+    displayname: K8s Workloads
     restype: menu
     isaction: true
     priority: 2


### PR DESCRIPTION
## Summary
- mciworkloads -> infraworkloads (MCI Workloads -> Infra Workloads)
- pmkworkloads -> k8sworkloads (PMK Workloads -> K8s Workloads)
- Applied to conf/docker/menu.yaml, conf/docker/conf/mc-iam-manager/permission.yaml
- Note: conf/docker/conf/mc-iam-manager/menu.yaml is gitignored (downloaded from remote at setup time) and is not part of this PR; it was updated directly on the running local instance.
